### PR TITLE
docs: fix documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An enterprise-ready knowledge graph as a service platform.
 
 Images are [built on Konflux](https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/kartograph-tenant/applications/kartograph) and [published to Quay](https://quay.io/repository/redhat-user-workloads/kartograph-tenant/kartograph-api?tab=tags&tag=latest).
 
-[Documentation](https://openshift-hyperfleet.github.io/kartograph/guides/extraction-mutations/)
+[Documentation](https://openshift-hyperfleet.github.io/kartograph)
 
 ## Contributing
 


### PR DESCRIPTION
Updated documentation link to the main Kartograph page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed documentation link in README to point to the correct base path.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->