### PR TITLE
fix(deploy): attempt to correct argocd managed-by label target

### DIFF
--- a/deploy/apps/kartograph/overlays/stage/namespace.yaml
+++ b/deploy/apps/kartograph/overlays/stage/namespace.yaml
@@ -4,4 +4,4 @@ kind: Namespace
 metadata:
   name: kartograph-stage
   labels:
-    argocd.argoproj.io/managed-by: argocd-tenant-hcm-ai-catalyst
+    argocd.argoproj.io/managed-by: kartograph-tenant


### PR DESCRIPTION
The current configuration results in the error: 
```
Failed to load live state: namespace "kartograph-stage" for Service "kartograph-api" is not managed
```

Using the `ns` found in the tenants config ArgoCD instance, in conjunction with the [Red Hat ArgoCD docs](https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/1.13/html/argo_cd_instance/setting-up-argocd-instance#gitops-deploy-resources-different-namespaces_setting-up-argocd-instance), attempt to resolve error by change ns from `argocd-tenant-kartograph` to `kartograph-tenant`. 

It's quite possible this is incorrect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration namespace label to reflect current tenant management identity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->