### PR TITLE
fix: dont have kustomize handle namespace creation

### DIFF
--- a/deploy/apps/kartograph/overlays/stage/kustomization.yaml
+++ b/deploy/apps/kartograph/overlays/stage/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 namespace: kartograph-stage
 resources:
   - ../../base
-  - namespace.yaml
   - route.yaml
   - secret-provider-class.yaml
 patches:

--- a/deploy/apps/kartograph/overlays/stage/namespace.yaml
+++ b/deploy/apps/kartograph/overlays/stage/namespace.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kartograph-stage


### PR DESCRIPTION
Going to manage the namespace outside of kustomize.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified staging environment deployment configuration by removing namespace resource references from the overlay setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->