### PR TITLE
fix(deploy): enable TLS for SpiceDB with OpenShift service serving certs

### DIFF
--- a/deploy/apps/kartograph/base/api-deployment.yaml
+++ b/deploy/apps/kartograph/base/api-deployment.yaml
@@ -113,6 +113,8 @@ spec:
                 configMapKeyRef:
                   name: kartograph-config
                   key: SPICEDB_USE_TLS
+            - name: SPICEDB_CERT_PATH
+              value: /etc/spicedb-ca/service-ca.crt
             # Outbox worker config
             - name: KARTOGRAPH_OUTBOX_ENABLED
               valueFrom:
@@ -140,6 +142,10 @@ spec:
                   name: kartograph-sso-client-swagger-docs
                   key: client_id
 
+          volumeMounts:
+            - name: spicedb-ca
+              mountPath: /etc/spicedb-ca
+              readOnly: true
           livenessProbe:
             httpGet:
               path: /health
@@ -163,3 +169,10 @@ spec:
             limits:
               cpu: 500m
               memory: 3Gi
+      volumes:
+        - name: spicedb-ca
+          configMap:
+            name: kartograph-spicedb-ca
+            items:
+              - key: service-ca.crt
+                path: service-ca.crt

--- a/deploy/apps/kartograph/base/kustomization.yaml
+++ b/deploy/apps/kartograph/base/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
   # Config
   - configmap.yaml
   - spicedb-schema-configmap.yaml
+  - spicedb-ca-configmap.yaml
 
 commonLabels:
   app.kubernetes.io/name: kartograph

--- a/deploy/apps/kartograph/base/spicedb-ca-configmap.yaml
+++ b/deploy/apps/kartograph/base/spicedb-ca-configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kartograph-spicedb-ca
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"

--- a/deploy/apps/kartograph/base/spicedb-deployment.yaml
+++ b/deploy/apps/kartograph/base/spicedb-deployment.yaml
@@ -53,6 +53,8 @@ spec:
           args:
             - serve
             - --http-enabled=true
+            - --grpc-tls-cert-path=/tls/tls.crt
+            - --grpc-tls-key-path=/tls/tls.key
           ports:
             - containerPort: 50051
               name: grpc
@@ -71,6 +73,10 @@ spec:
                 secretKeyRef:
                   name: kartograph-spicedb-credentials
                   key: SPICEDB_PRESHARED_KEY
+          volumeMounts:
+            - name: spicedb-tls
+              mountPath: /tls
+              readOnly: true
           livenessProbe:
             grpc:
               port: 50051
@@ -92,3 +98,7 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+      volumes:
+        - name: spicedb-tls
+          secret:
+            secretName: kartograph-spicedb-tls

--- a/deploy/apps/kartograph/base/spicedb-service.yaml
+++ b/deploy/apps/kartograph/base/spicedb-service.yaml
@@ -4,6 +4,8 @@ metadata:
   name: kartograph-spicedb
   labels:
     app.kubernetes.io/component: authorization
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: kartograph-spicedb-tls
 spec:
   selector:
     app.kubernetes.io/component: authorization

--- a/src/api/shared_kernel/authorization/spicedb/client.py
+++ b/src/api/shared_kernel/authorization/spicedb/client.py
@@ -27,7 +27,7 @@ from authzed.api.v1 import (
     WriteRelationshipsRequest,
 )
 from authzed.api.v1.permission_service_pb2 import CheckPermissionResponse
-from grpcutil import insecure_bearer_token_credentials
+import grpc.aio
 
 from shared_kernel.authorization.observability import (
     AuthorizationProbe,
@@ -43,6 +43,48 @@ from shared_kernel.authorization.types import (
     RelationshipTuple,
     SubjectRelation,
 )
+
+
+class _BearerTokenInterceptor(
+    grpc.aio.UnaryUnaryClientInterceptor,
+    grpc.aio.UnaryStreamClientInterceptor,
+):
+    """Injects a bearer token into gRPC metadata for insecure channels.
+
+    Needed because grpc.local_channel_credentials rejects non-loopback
+    addresses, but in-cluster SpiceDB serves plaintext gRPC on pod IPs.
+    """
+
+    def __init__(self, token: str):
+        self._metadata = (("authorization", f"Bearer {token}"),)
+
+    def _inject_metadata(self, client_call_details):
+        metadata = list(client_call_details.metadata or [])
+        metadata.extend(self._metadata)
+        return grpc.aio.ClientCallDetails(
+            client_call_details.method,
+            client_call_details.timeout,
+            metadata,
+            client_call_details.credentials,
+            client_call_details.wait_for_ready,
+        )
+
+    async def intercept_unary_unary(self, continuation, client_call_details, request):
+        return await continuation(self._inject_metadata(client_call_details), request)
+
+    async def intercept_unary_stream(self, continuation, client_call_details, request):
+        return await continuation(self._inject_metadata(client_call_details), request)
+
+
+def _create_insecure_channel(endpoint: str, preshared_key: str) -> grpc.aio.Channel:
+    """Create an insecure gRPC channel with bearer token metadata injection.
+
+    Unlike grpc.local_channel_credentials (which restricts to loopback),
+    this works for any address — necessary for in-cluster connections
+    where SpiceDB serves plaintext gRPC on pod/service IPs.
+    """
+    interceptor = _BearerTokenInterceptor(preshared_key)
+    return grpc.aio.insecure_channel(endpoint, interceptors=[interceptor])
 
 
 class RelationshipOperation(IntEnum):
@@ -244,22 +286,21 @@ class SpiceDBClient(AuthorizationProvider):
                     try:
                         from authzed.api.v1 import AsyncClient
 
-                        # Create credentials with preshared key
                         if self._use_tls:
                             credentials = _create_tls_credentials(
                                 self._preshared_key, self._cert_path
                             )
-                        else:
-                            credentials = insecure_bearer_token_credentials(
-                                self._preshared_key
+                            self._client = AsyncClient(
+                                self._endpoint,
+                                credentials,
                             )
+                        else:
                             self._probe.insecure_connection_used(self._endpoint)
-
-                        # Initialize client
-                        self._client = AsyncClient(
-                            self._endpoint,
-                            credentials,
-                        )
+                            channel = _create_insecure_channel(
+                                self._endpoint, self._preshared_key
+                            )
+                            self._client = AsyncClient.__new__(AsyncClient)
+                            self._client.init_stubs(channel)
                     except Exception as e:
                         self._probe.connection_failed(
                             endpoint=self._endpoint,

--- a/src/api/uv.lock
+++ b/src/api/uv.lock
@@ -1171,7 +1171,7 @@ wheels = [
 
 [[package]]
 name = "kartograph-api"
-version = "3.31.3"
+version = "3.32.1"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Fixes SpiceDB connectivity in stage by enabling real TLS via OpenShift service serving certificates, and fixes the Python gRPC client to work with non-loopback addresses in insecure mode (for local dev).

**Two-part fix:**

### 1. Client code (insecure mode fix for local dev)
- Replaced `grpc.local_channel_credentials` (loopback-only) with `grpc.aio.insecure_channel` + bearer token interceptor
- Works on any address — localhost for dev, pod IPs for cluster
- Verified locally: correct key authenticates, wrong key is rejected

### 2. Stage deployment (real TLS)
- SpiceDB service annotated with `service.beta.openshift.io/serving-cert-secret-name` for auto-provisioned TLS cert
- SpiceDB deployment mounts cert at `/tls/` and serves gRPC with TLS
- API deployment mounts service CA bundle via `inject-cabundle` ConfigMap
- `SPICEDB_CERT_PATH` points to the injected CA for cert verification
- zed schema-write job uses `--no-verify-ca` with `ZED_INSECURE=false`

## Root cause
`grpc.local_channel_credentials(LOCAL_TCP)` only allows connections to loopback addresses. In the cluster, `kartograph-spicedb:50051` resolves to a pod IP (`172.30.x.x`), causing: `"Endpoint is neither UDS or TCP loopback address."`

## Test plan
- [x] Insecure channel verified locally against plaintext SpiceDB (correct key authenticates, wrong key rejected)
- [x] TLS path verified locally against existing dev stack with certs
- [x] Unit tests pass (1997 passed)
- [ ] Stage deployment: verify SpiceDB serves TLS with service cert
- [ ] Stage deployment: verify API connects with service CA
- [ ] Stage deployment: verify zed schema-write completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enabled TLS encryption for authorization service gRPC communication with certificate management
  * Configured automated cluster CA certificate injection for secure connections

* **Infrastructure**
  * Updated authorization client to use interceptor-based authentication for improved request handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->