### PR TITLE
fix(deploy): use HTTP scheme for SpiceDB health probes

### DIFF
--- a/deploy/apps/kartograph/base/spicedb-deployment.yaml
+++ b/deploy/apps/kartograph/base/spicedb-deployment.yaml
@@ -81,7 +81,7 @@ spec:
             httpGet:
               path: /
               port: 8443
-              scheme: HTTPS
+              scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
@@ -90,7 +90,7 @@ spec:
             httpGet:
               path: /
               port: 8443
-              scheme: HTTPS
+              scheme: HTTP
             initialDelaySeconds: 5
             periodSeconds: 5
             timeoutSeconds: 3

--- a/src/api/uv.lock
+++ b/src/api/uv.lock
@@ -1171,7 +1171,7 @@ wheels = [
 
 [[package]]
 name = "kartograph-api"
-version = "3.32.1"
+version = "3.32.2"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

SpiceDB's HTTP gateway (port 8443) serves plaintext even when gRPC has TLS enabled. The HTTPS health probes from #427 fail because the HTTP listener doesn't have TLS certs.

Changed `scheme: HTTPS` to `scheme: HTTP` for both liveness and readiness probes. gRPC port 50051 still serves TLS for actual client traffic.

## Test plan
- [ ] SpiceDB pod becomes ready (readiness probe passes)
- [ ] SpiceDB pod stays alive (liveness probe passes)
- [ ] API connects to SpiceDB via TLS on gRPC port

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated health check configuration for the spicedb service to improve monitoring accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->