### PR TITLE
fix(deploy): correct stage OIDC URL configuration for Dev UI

### DIFF
--- a/deploy/apps/kartograph/overlays/stage/configmap-patch.yaml
+++ b/deploy/apps/kartograph/overlays/stage/configmap-patch.yaml
@@ -8,6 +8,6 @@ data:
   # Dev UI
   DEV_UI_API_BASE_URL: "https://kartograph-api-kartograph-stage.apps.rosa.appsres09ue1.24ep.p3.openshiftapps.com"
   DEV_UI_MCP_ENDPOINT_URL: "https://kartograph-api-kartograph-stage.apps.rosa.appsres09ue1.24ep.p3.openshiftapps.com/query/mcp"
-  DEV_UI_KEYCLOAK_URL: "https://auth.stage.redhat.com/auth/realms/EmployeeIDP"
-  DEV_UI_KEYCLOAK_REALM: "kartograph"
+  DEV_UI_KEYCLOAK_URL: "https://auth.stage.redhat.com/auth"
+  DEV_UI_KEYCLOAK_REALM: "EmployeeIDP"
   DEV_UI_KEYCLOAK_CLIENT_ID: "kartograph-ui"


### PR DESCRIPTION
## Summary
- Fixed misconfigured stage OIDC settings that produced a malformed authority URL
- The Dev UI was building `https://auth.stage.redhat.com/auth/realms/EmployeeIDP/realms/kartograph` (double `/realms/`)
- Made correction in config,ap-patch.yaml so the code correctly builds `https://auth.stage.redhat.com/auth/realms/EmployeeIDP`

## Root Cause
The stage configmap had the full issuer URL in `DEV_UI_KEYCLOAK_URL` while `useAuth.ts` appends `/realms/${realm}` to that value. Local dev worked because it uses just the base URL (`http://keycloak:8080`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated stage authentication configuration to use the base authentication endpoint and set the realm to EmployeeIDP, while keeping the client identifier unchanged. This aligns stage sign-in endpoints and may affect authentication behavior in the stage environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->