### PR TITLE
fix(deploy): revert SpiceDB health probes to gRPC

### DIFF
--- a/deploy/apps/kartograph/base/spicedb-deployment.yaml
+++ b/deploy/apps/kartograph/base/spicedb-deployment.yaml
@@ -78,19 +78,15 @@ spec:
               mountPath: /tls
               readOnly: true
           livenessProbe:
-            httpGet:
-              path: /
-              port: 8443
-              scheme: HTTP
+            grpc:
+              port: 50051
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
-            httpGet:
-              path: /
-              port: 8443
-              scheme: HTTP
+            grpc:
+              port: 50051
             initialDelaySeconds: 5
             periodSeconds: 5
             timeoutSeconds: 3


### PR DESCRIPTION
## Summary

Reverts health probes from HTTP to gRPC. The HTTP gateway (`GET /` on port 8443) doesn't return 200 — it's a gRPC-REST gateway, not a health endpoint. SpiceDB implements the standard gRPC health check protocol.

Kubernetes native gRPC probes handle TLS negotiation automatically — the earlier concern about gRPC probes not working with TLS was incorrect.

## Test plan
- [ ] SpiceDB pod becomes ready
- [ ] Pod stays alive without restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for enhanced health monitoring.

---

**Note:** This release includes infrastructure-level updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->