### PR TITLE
fix(deploy): use /metrics path for SpiceDB health probes

### DIFF
--- a/deploy/apps/kartograph/base/spicedb-deployment.yaml
+++ b/deploy/apps/kartograph/base/spicedb-deployment.yaml
@@ -78,15 +78,17 @@ spec:
               mountPath: /tls
               readOnly: true
           livenessProbe:
-            grpc:
-              port: 50051
+            httpGet:
+              path: /metrics
+              port: 9090
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
-            grpc:
-              port: 50051
+            httpGet:
+              path: /metrics
+              port: 9090
             initialDelaySeconds: 5
             periodSeconds: 5
             timeoutSeconds: 3


### PR DESCRIPTION
## Summary

The previous probe change (#436) used `path: /` on port 9090 which returns 404. SpiceDB's metrics endpoint is at `/metrics`.

Verified locally: `curl http://localhost:9091/metrics` returns HTTP 200 on plaintext port 9090 even with gRPC TLS enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated health check configuration for improved service reliability and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->