### PR TITLE
fix(deploy): use FQDN for SpiceDB endpoint in stage

### DIFF
--- a/deploy/apps/kartograph/overlays/stage/configmap-patch.yaml
+++ b/deploy/apps/kartograph/overlays/stage/configmap-patch.yaml
@@ -4,6 +4,8 @@ metadata:
   name: kartograph-config
 data:
   # Stage-specific overrides (merged with base)
+  # FQDN required for TLS cert SAN matching (service cert issued for kartograph-spicedb.kartograph-stage.svc)
+  SPICEDB_ENDPOINT: "kartograph-spicedb.kartograph-stage.svc:50051"
   KARTOGRAPH_CORS_ORIGINS: "https://kartograph-stage.devshift.net,https://kartograph-dev-ui-kartograph-stage.apps.rosa.appsres09ue1.24ep.p3.openshiftapps.com"
   # Dev UI
   DEV_UI_API_BASE_URL: "https://kartograph-api-kartograph-stage.apps.rosa.appsres09ue1.24ep.p3.openshiftapps.com"


### PR DESCRIPTION
## Summary

OpenShift service serving certs have SANs for the full service DNS name (`kartograph-spicedb.kartograph-stage.svc`), not the short name (`kartograph-spicedb`). The TLS client verifies the hostname against the cert and fails with: `"Peer name kartograph-spicedb is not in peer certificate"`.

Adds `SPICEDB_ENDPOINT` override in the stage overlay to use the FQDN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration for the stage deployment environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->