### PR TITLE
fix(deploy): add CORS origins env var to API deployment

### DIFF
--- a/deploy/apps/kartograph/base/api-deployment.yaml
+++ b/deploy/apps/kartograph/base/api-deployment.yaml
@@ -115,6 +115,13 @@ spec:
                   key: SPICEDB_USE_TLS
             - name: SPICEDB_CERT_PATH
               value: /etc/spicedb-ca/service-ca.crt
+            # CORS config
+            - name: KARTOGRAPH_CORS_ORIGINS
+              valueFrom:
+                configMapKeyRef:
+                  name: kartograph-config
+                  key: KARTOGRAPH_CORS_ORIGINS
+                  optional: true
             # Outbox worker config
             - name: KARTOGRAPH_OUTBOX_ENABLED
               valueFrom:


### PR DESCRIPTION
## Summary

The CORS origins were in the ConfigMap but the API deployment never read the key — `KARTOGRAPH_CORS_ORIGINS` was missing from the container's env spec. The CORS middleware never initialized, causing OPTIONS preflight requests to return 405.

Adds `configMapKeyRef` for `KARTOGRAPH_CORS_ORIGINS` with `optional: true` so deployments without CORS config still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API CORS origins can now be configured per deployment environment without code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->