### PR TITLE
fix(deploy): add IAM single tenant mode configuration

### DIFF
--- a/deploy/apps/kartograph/base/api-deployment.yaml
+++ b/deploy/apps/kartograph/base/api-deployment.yaml
@@ -115,6 +115,13 @@ spec:
                   key: SPICEDB_USE_TLS
             - name: SPICEDB_CERT_PATH
               value: /etc/spicedb-ca/service-ca.crt
+            # IAM config
+            - name: KARTOGRAPH_IAM_SINGLE_TENANT_MODE
+              valueFrom:
+                configMapKeyRef:
+                  name: kartograph-config
+                  key: KARTOGRAPH_IAM_SINGLE_TENANT_MODE
+                  optional: true
             # CORS config
             - name: KARTOGRAPH_CORS_ORIGINS
               valueFrom:


### PR DESCRIPTION
## Summary
Passes KARTOGRAPH_IAM_SINGLE_TENANT_MODE to api

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added environment variable configuration support to the API deployment for single-tenant IAM mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->