### PR TITLE
fix(ui): replace font-bold with font-semibold in page headers to comply with design language spec

### DIFF
--- a/src/dev-ui/app/pages/api-keys/index.vue
+++ b/src/dev-ui/app/pages/api-keys/index.vue
@@ -291,7 +291,7 @@ function maskedSecret(secret: string): string {
           <KeyRound class="size-5 text-primary" />
         </div>
         <div>
-          <h1 class="text-2xl font-bold tracking-tight">API Keys</h1>
+          <h1 class="text-2xl font-semibold tracking-tight">API Keys</h1>
           <p class="text-sm text-muted-foreground">
             Create, view, and manage API keys for authenticating with Kartograph.
           </p>

--- a/src/dev-ui/app/pages/data-sources/index.vue
+++ b/src/dev-ui/app/pages/data-sources/index.vue
@@ -865,7 +865,7 @@ function closeLogs() {
           <Cable class="size-5 text-primary" />
         </div>
         <div>
-          <h1 class="text-2xl font-bold tracking-tight">Data Sources</h1>
+          <h1 class="text-2xl font-semibold tracking-tight">Data Sources</h1>
           <p class="text-sm text-muted-foreground">
             Connect external data sources to your knowledge graphs for automated extraction
           </p>

--- a/src/dev-ui/app/pages/graph/explorer.vue
+++ b/src/dev-ui/app/pages/graph/explorer.vue
@@ -396,7 +396,7 @@ watch(tenantVersion, () => {
     <div>
       <div class="flex items-center gap-3">
         <Share2 class="size-6 text-muted-foreground" />
-        <h1 class="text-2xl font-bold tracking-tight">Graph Explorer</h1>
+        <h1 class="text-2xl font-semibold tracking-tight">Graph Explorer</h1>
       </div>
       <p class="mt-1 text-muted-foreground">Browse, search, and traverse nodes in the knowledge graph.</p>
     </div>

--- a/src/dev-ui/app/pages/graph/mutations.vue
+++ b/src/dev-ui/app/pages/graph/mutations.vue
@@ -401,7 +401,7 @@ onBeforeUnmount(() => {
       <div>
         <div class="flex items-center gap-3">
           <FileCode class="size-6 text-muted-foreground" />
-          <h1 class="text-2xl font-bold tracking-tight">Mutations Console</h1>
+          <h1 class="text-2xl font-semibold tracking-tight">Mutations Console</h1>
         </div>
         <p class="mt-1 text-muted-foreground">Author and submit JSONL mutations to the knowledge graph.</p>
       </div>

--- a/src/dev-ui/app/pages/graph/schema.vue
+++ b/src/dev-ui/app/pages/graph/schema.vue
@@ -264,7 +264,7 @@ onUnmounted(() => {
     <div>
       <div class="flex items-center gap-3">
         <Database class="size-6 text-muted-foreground" />
-        <h1 class="text-2xl font-bold tracking-tight">Schema Browser</h1>
+        <h1 class="text-2xl font-semibold tracking-tight">Schema Browser</h1>
       </div>
       <p class="mt-1 text-muted-foreground">
         Browse and inspect the knowledge graph schema definitions.

--- a/src/dev-ui/app/pages/groups/index.vue
+++ b/src/dev-ui/app/pages/groups/index.vue
@@ -319,7 +319,7 @@ watch(tenantVersion, () => {
       <div class="flex items-center gap-3">
         <Users class="size-6 text-muted-foreground" />
         <div>
-          <h1 class="text-2xl font-bold tracking-tight">Groups</h1>
+          <h1 class="text-2xl font-semibold tracking-tight">Groups</h1>
           <p class="text-sm text-muted-foreground">Create and manage user groups for permissions</p>
         </div>
       </div>

--- a/src/dev-ui/app/pages/index.vue
+++ b/src/dev-ui/app/pages/index.vue
@@ -318,7 +318,7 @@ watch(tenantVersion, () => {
         <div class="flex items-center gap-3">
           <LayoutDashboard class="size-6 text-muted-foreground" />
           <div>
-            <h1 class="text-2xl font-bold tracking-tight">
+            <h1 class="text-2xl font-semibold tracking-tight">
               Welcome to Kartograph
             </h1>
             <p class="text-sm text-muted-foreground">
@@ -356,7 +356,7 @@ watch(tenantVersion, () => {
                 <component :is="stat.icon" class="size-4 text-muted-foreground" />
               </div>
               <div class="min-w-0">
-                <div class="text-2xl font-bold tracking-tight">
+                <div class="text-2xl font-semibold tracking-tight">
                   <template v-if="statsLoading">
                     <Loader2 class="size-5 animate-spin text-muted-foreground" />
                   </template>

--- a/src/dev-ui/app/pages/integrate/mcp.vue
+++ b/src/dev-ui/app/pages/integrate/mcp.vue
@@ -292,7 +292,7 @@ async function copyHeaderValue(key: string, value: string) {
         <Plug class="size-5 text-primary" />
       </div>
       <div>
-        <h1 class="text-2xl font-bold tracking-tight">MCP Integration</h1>
+        <h1 class="text-2xl font-semibold tracking-tight">MCP Integration</h1>
         <p class="text-sm text-muted-foreground">
           Connect AI agents to your knowledge graph via the Model Context Protocol.
         </p>

--- a/src/dev-ui/app/pages/knowledge-graphs/index.vue
+++ b/src/dev-ui/app/pages/knowledge-graphs/index.vue
@@ -177,7 +177,7 @@ watch(tenantVersion, () => {
           <BookOpen class="size-5 text-primary" />
         </div>
         <div>
-          <h1 class="text-2xl font-bold tracking-tight">Knowledge Graphs</h1>
+          <h1 class="text-2xl font-semibold tracking-tight">Knowledge Graphs</h1>
           <p class="text-sm text-muted-foreground">
             Create and manage knowledge graphs that map your data sources into structured graphs
           </p>

--- a/src/dev-ui/app/pages/query/index.vue
+++ b/src/dev-ui/app/pages/query/index.vue
@@ -388,7 +388,7 @@ onBeforeUnmount(() => {
     <div class="flex items-center justify-between">
       <div class="flex items-center gap-3">
         <Terminal class="size-6 text-muted-foreground" />
-        <h1 class="text-2xl font-bold tracking-tight">Cypher Console</h1>
+        <h1 class="text-2xl font-semibold tracking-tight">Cypher Console</h1>
       </div>
       <div class="flex items-center gap-1 xl:hidden">
         <Tooltip>

--- a/src/dev-ui/app/pages/tenants/index.vue
+++ b/src/dev-ui/app/pages/tenants/index.vue
@@ -268,7 +268,7 @@ onMounted(fetchTenants)
       <div class="flex items-center gap-3">
         <Building2 class="size-6 text-muted-foreground" />
         <div>
-          <h1 class="text-2xl font-bold tracking-tight">Tenants</h1>
+          <h1 class="text-2xl font-semibold tracking-tight">Tenants</h1>
           <p class="text-sm text-muted-foreground">Manage tenant organizations and membership</p>
         </div>
       </div>

--- a/src/dev-ui/app/pages/workspaces/index.vue
+++ b/src/dev-ui/app/pages/workspaces/index.vue
@@ -394,7 +394,7 @@ watch(tenantVersion, () => {
       <div class="flex items-center gap-3">
         <FolderTree class="size-6 text-muted-foreground" />
         <div>
-          <h1 class="text-2xl font-bold tracking-tight">Workspaces</h1>
+          <h1 class="text-2xl font-semibold tracking-tight">Workspaces</h1>
           <p class="text-sm text-muted-foreground">Organize resources with hierarchical workspaces</p>
         </div>
       </div>

--- a/src/dev-ui/app/tests/design-language.test.ts
+++ b/src/dev-ui/app/tests/design-language.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'fs'
+import { readFileSync, readdirSync } from 'fs'
 import { resolve } from 'path'
 
 // ── Design Language Tests ─────────────────────────────────────────────────────
@@ -338,4 +338,43 @@ describe('Design Language — Scenario: Elevation', () => {
       expect(badgeContent).not.toContain('shadow-xl')
     })
   })
+})
+
+// ── Scenario: Typography — font weight constraints in page files ───────────────
+//
+// Spec: "font weights are limited to regular (400), medium (500), and semibold (600)"
+// Applied to "any text in the UI" — including page-level <h1> headings.
+//
+// Regression guard: scan all .vue files under pages/ and assert that no
+// font-bold (700) class appears inside the <template> block.
+
+function collectPageFiles(dir: string): string[] {
+  const entries = readdirSync(dir, { withFileTypes: true })
+  const files: string[] = []
+  for (const entry of entries) {
+    const full = resolve(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...collectPageFiles(full))
+    } else if (entry.name.endsWith('.vue')) {
+      files.push(full)
+    }
+  }
+  return files
+}
+
+const pagesDir = resolve(__dirname, '../pages')
+const pageFiles = collectPageFiles(pagesDir)
+
+describe('Design Language — Scenario: Typography (page files, font-weight regression)', () => {
+  for (const filePath of pageFiles) {
+    const relativeName = filePath.split('/pages/')[1]
+    it(`pages/${relativeName} does not use font-bold (max semibold per spec)`, () => {
+      const content = readFileSync(filePath, 'utf-8')
+      // Extract only the <template> section to avoid false positives from
+      // string literals inside <script> that name Tailwind classes
+      const templateMatch = content.match(/<template>([\s\S]*)<\/template>/)
+      const templateContent = templateMatch ? templateMatch[1] : content
+      expect(templateContent).not.toContain('font-bold')
+    })
+  }
 })


### PR DESCRIPTION
## What & Why

The `experience.spec.md` Design Language requirement states:

> **Scenario: Typography**
> - GIVEN any text in the UI
> - AND font weights are limited to regular (400), medium (500), and semibold (600)

Every page-level `<h1>` heading across the dev-UI currently uses the Tailwind class
`font-bold` (font-weight: 700). This violates the spec's explicit cap of semibold (600)
across **all** text in the UI.

The existing typography tests in `design-language.test.ts` verify that the `Button` and
`Badge` UI components do not use `font-bold`, but they do not scan page files — leaving
the violation undetected by CI.

This PR fixes all violations and adds regression tests that will catch future
reintroductions.

## Spec Requirements Satisfied

**Requirement: Design Language — Scenario: Typography** from
`specs/ui/experience.spec.md@e77913c2cc6d8b719291e2dbb6870519a94d50da`:

> GIVEN any text in the UI
> THEN the system font stack is used (no custom fonts)
> AND body text uses `text-sm` (0.875rem)
> AND section headers use uppercase `text-[11px]` with `tracking-wider`
> AND font weights are limited to regular (400), medium (500), and semibold (600)

The constraint "font weights are limited to regular (400), medium (500), and semibold
(600)" applies to **any text in the UI**, which includes page-level headings.

## Key Design Decisions

- **`font-bold` → `font-semibold`**: Page titles are already `text-2xl` — the visual
  weight difference between semibold (600) and bold (700) at 24px is subtle, and the
  design is intentionally flat and restrained. `font-semibold` is the heaviest weight
  permitted by the spec and still produces a clearly prominent heading.
- **Keep `tracking-tight`**: The `tracking-tight` modifier on page headings is
  independent of font weight and should be retained for visual consistency.
- **Regression tests scan all page files**: New tests in `design-language.test.ts` read
  each page `.vue` file via `readFileSync` and assert that `font-bold` does not appear
  in template content. This is the same source-inspection approach used by the existing
  typography tests for `Button` and `Badge`.

## Files Affected

**Implementation fixes** (replace `font-bold` with `font-semibold` in `<h1>` elements):

- `src/dev-ui/app/pages/api-keys/index.vue`
- `src/dev-ui/app/pages/data-sources/index.vue`
- `src/dev-ui/app/pages/graph/explorer.vue`
- `src/dev-ui/app/pages/graph/mutations.vue`
- `src/dev-ui/app/pages/graph/schema.vue`
- `src/dev-ui/app/pages/groups/index.vue`
- `src/dev-ui/app/pages/integrate/mcp.vue`
- `src/dev-ui/app/pages/knowledge-graphs/index.vue`
- `src/dev-ui/app/pages/query/index.vue`
- `src/dev-ui/app/pages/tenants/index.vue`
- `src/dev-ui/app/pages/workspaces/index.vue`
- `src/dev-ui/app/pages/index.vue` (two occurrences: the page title h1 and a
  stat card value div that also uses `font-bold`)

**Test additions** (new describe block in the existing test file):

- `src/dev-ui/app/tests/design-language.test.ts` — add a describe block that reads
  each page file and asserts no `font-bold` class is present. The block must cover all
  11 page files listed above.

## How to Verify

1. Open any page in the running dev-UI and inspect the page title (`<h1>`):
   DevTools → Computed → font-weight should read `600`, not `700`.
2. Run `cd src/dev-ui && pnpm test` — the new regression tests pass; no existing
   tests regress.
3. Search the repo: `grep -r "font-bold" src/dev-ui/app/pages/` should return zero
   matches (once this PR lands).

## Caveats

- **Only page files are in scope**: UI component files (`components/ui/`) are already
  guarded by the existing tests for `Button` and `Badge`. Non-page component files
  (`components/graph/`, `components/query/`, `components/settings/`) are not scanned
  by this PR — a follow-up can extend the regression tests if future violations are
  found there.
- `font-bold` IS permitted for contrast-testing fixture data or inline code samples
  if any exist — the tests should use a template-section-scoped check to avoid
  false positives from `<script>` blocks that reference the string as a Tailwind class
  name in logic (unlikely but possible).
- This change has no backend dependency and no API contract implications.

## TDD Cycle

1. **Write failing tests first** — add the new describe block to
   `design-language.test.ts` that asserts no `font-bold` in each page file.
   Run `pnpm test` → tests **fail** for all 11 page files (RED).
2. **Fix implementation** — replace `font-bold` with `font-semibold` across all 11
   page files.
3. **Run tests** → all tests **pass** (GREEN).
4. **Commit atomically** with a conventional commit message.

---

**Task:** `task-066`
**Spec:** `specs/ui/experience.spec.md@e77913c2cc6d8b719291e2dbb6870519a94d50da`

### Merge

The orchestrator will squash-merge this PR automatically
once all pipeline steps pass.

---

This PR was created by [hyperloop](https://github.com/jsell-rh/hyperloop),
an AI agent orchestrator.