### PR TITLE
fix(ui): replace font-bold with font-semibold in QueryResultsPanel keyboard shortcut badges

### DIFF
--- a/src/dev-ui/app/components/query/QueryResultsPanel.vue
+++ b/src/dev-ui/app/components/query/QueryResultsPanel.vue
@@ -276,21 +276,21 @@ watch(() => props.result, (newResult) => {
         <div class="flex items-center justify-between">
           <TabsList>
             <TabsTrigger value="table">
-              <span v-if="altHeld" class="mr-1 inline-flex size-4 items-center justify-center rounded bg-primary text-[10px] font-bold text-primary-foreground">1</span>
+              <span v-if="altHeld" class="mr-1 inline-flex size-4 items-center justify-center rounded bg-primary text-[10px] font-semibold text-primary-foreground">1</span>
               Table
               <Badge v-if="result" variant="secondary" class="ml-1.5 h-4 px-1 font-mono text-[10px]">
                 {{ result.row_count }}
               </Badge>
             </TabsTrigger>
             <TabsTrigger value="json">
-              <span v-if="altHeld" class="mr-1 inline-flex size-4 items-center justify-center rounded bg-primary text-[10px] font-bold text-primary-foreground">2</span>
+              <span v-if="altHeld" class="mr-1 inline-flex size-4 items-center justify-center rounded bg-primary text-[10px] font-semibold text-primary-foreground">2</span>
               JSON
             </TabsTrigger>
             <Tooltip>
               <TooltipTrigger as-child>
                 <span>
                   <TabsTrigger value="graph" :disabled="!hasGraphElements">
-                    <span v-if="altHeld && hasGraphElements" class="mr-1 inline-flex size-4 items-center justify-center rounded bg-primary text-[10px] font-bold text-primary-foreground">3</span>
+                    <span v-if="altHeld && hasGraphElements" class="mr-1 inline-flex size-4 items-center justify-center rounded bg-primary text-[10px] font-semibold text-primary-foreground">3</span>
                     Graph
                     <Badge v-if="graphNodeCount > 0" variant="secondary" class="ml-1.5 h-4 px-1 font-mono text-[10px]">
                       {{ graphNodeCount }}

--- a/src/dev-ui/app/tests/design-language.test.ts
+++ b/src/dev-ui/app/tests/design-language.test.ts
@@ -348,13 +348,13 @@ describe('Design Language — Scenario: Elevation', () => {
 // Regression guard: scan all .vue files under pages/ and assert that no
 // font-bold (700) class appears inside the <template> block.
 
-function collectPageFiles(dir: string): string[] {
+function collectVueFiles(dir: string): string[] {
   const entries = readdirSync(dir, { withFileTypes: true })
   const files: string[] = []
   for (const entry of entries) {
     const full = resolve(dir, entry.name)
     if (entry.isDirectory()) {
-      files.push(...collectPageFiles(full))
+      files.push(...collectVueFiles(full))
     } else if (entry.name.endsWith('.vue')) {
       files.push(full)
     }
@@ -363,12 +363,37 @@ function collectPageFiles(dir: string): string[] {
 }
 
 const pagesDir = resolve(__dirname, '../pages')
-const pageFiles = collectPageFiles(pagesDir)
+const pageFiles = collectVueFiles(pagesDir)
 
 describe('Design Language — Scenario: Typography (page files, font-weight regression)', () => {
   for (const filePath of pageFiles) {
     const relativeName = filePath.split('/pages/')[1]
     it(`pages/${relativeName} does not use font-bold (max semibold per spec)`, () => {
+      const content = readFileSync(filePath, 'utf-8')
+      // Extract only the <template> section to avoid false positives from
+      // string literals inside <script> that name Tailwind classes
+      const templateMatch = content.match(/<template>([\s\S]*)<\/template>/)
+      const templateContent = templateMatch ? templateMatch[1] : content
+      expect(templateContent).not.toContain('font-bold')
+    })
+  }
+})
+
+// ── Scenario: Typography — font weight constraints in component files ──────────
+//
+// Spec: "font weights are limited to regular (400), medium (500), and semibold (600)"
+// Applied to "any text in the UI" — including component template content.
+//
+// Regression guard: scan all .vue files under components/ recursively and assert
+// that no font-bold (700) class appears inside the <template> block.
+
+const componentsDir = resolve(__dirname, '../components')
+const componentFiles = collectVueFiles(componentsDir)
+
+describe('Design Language — Scenario: Typography (component files, font-weight regression)', () => {
+  for (const filePath of componentFiles) {
+    const relativeName = filePath.split('/components/')[1]
+    it(`components/${relativeName} does not use font-bold (max semibold per spec)`, () => {
       const content = readFileSync(filePath, 'utf-8')
       // Extract only the <template> section to avoid false positives from
       // string literals inside <script> that name Tailwind classes


### PR DESCRIPTION
## What & Why

The `experience.spec.md` Design Language requirement states:

> **Scenario: Typography**
> - GIVEN any text in the UI
> - AND font weights are limited to regular (400), medium (500), and semibold (600)

Three keyboard shortcut indicator badges in `QueryResultsPanel.vue` (lines 279, 286, 293)
use `font-bold` (font-weight: 700), violating the explicit cap of semibold (600) for all
UI text.

Task-066 fixed `font-bold` violations in all page files and added regression tests for
pages. It explicitly deferred component files in its caveats:

> "Non-page component files (components/graph/, components/query/, components/settings/)
> are not scanned by this PR — a follow-up can extend the regression tests if future
> violations are found there."

This PR is that follow-up. It fixes the three violations in `QueryResultsPanel.vue` and
extends the regression tests to cover all non-page component `.vue` files.

## Spec Requirements Satisfied

**Requirement: Design Language — Scenario: Typography** from
`specs/ui/experience.spec.md@e77913c2cc6d8b719291e2dbb6870519a94d50da`:

> GIVEN any text in the UI
> THEN the system font stack is used (no custom fonts)
> AND font weights are limited to regular (400), medium (500), and semibold (600)

The phrase "any text in the UI" includes keyboard shortcut indicator badges in component
files, not only page headings. All three `font-bold` occurrences in `QueryResultsPanel`
are therefore out of compliance.

## Key Design Decisions

- **`font-bold` → `font-semibold`**: The affected spans are `text-[10px]` numeric
  keyboard shortcut labels shown only when the user holds Alt. At 10px the weight
  difference between 700 and 600 is minimal but the spec is explicit. `font-semibold`
  still produces legible, visually distinct labels.
- **Regression tests extend to components**: New tests in `design-language.test.ts`
  scan all `.vue` files under `app/components/` using `readFileSync` + `<template>`
  extraction (same technique used by task-066 for pages). This catches future
  reintroductions anywhere in the component tree.
- **Scope is components only**: Page files are already guarded by task-066's tests.
  This PR adds the complementary component coverage, completing the full-UI audit.

## Files Affected

**Implementation fix:**
- `src/dev-ui/app/components/query/QueryResultsPanel.vue` — replace all three
  `font-bold` occurrences with `font-semibold` inside the `<template>` block (lines
  279, 286, 293).

**Test additions:**
- `src/dev-ui/app/tests/design-language.test.ts` — add a new `describe` block that
  enumerates all `.vue` files under `app/components/` recursively and asserts none
  contain `font-bold` in their `<template>` section.

## How to Verify

1. Open the Query Console (`/query`) and execute any query that returns results.
2. Hold the Alt key — the Tab labels show numeric badges (1, 2, 3).
3. Inspect the badge spans in DevTools → Computed → `font-weight` should be `600`.
4. Run `cd src/dev-ui && pnpm test` — new component typography tests pass; no
   regressions in task-066's page typography tests or any other test.
5. `grep -r "font-bold" src/dev-ui/app/components/ src/dev-ui/app/pages/` → zero
   matches.

## Caveats

- Depends on task-066 landing first, since this PR extends the testing pattern
  established there and should not duplicate the page-scan logic.
- The fix is purely cosmetic at `text-[10px]` — no functional or accessibility
  regression expected.
- Only component `.vue` files are added to the regression tests; layout files
  (`app/layouts/`) are not scanned by either task-066 or this PR. The layout
  (`default.vue`) does not use `font-bold` (confirmed by grep), so this is a
  known acceptable scope limit.

---

**Task:** `task-067`
**Spec:** `specs/ui/experience.spec.md@e77913c2cc6d8b719291e2dbb6870519a94d50da`

### Merge

The orchestrator will squash-merge this PR automatically
once all pipeline steps pass.

---

This PR was created by [hyperloop](https://github.com/jsell-rh/hyperloop),
an AI agent orchestrator.