### PR TITLE
feat(management): add optional workspace_id filter to knowledge-graphs list endpoint

### DIFF
--- a/src/api/management/application/services/knowledge_graph_service.py
+++ b/src/api/management/application/services/knowledge_graph_service.py
@@ -268,6 +268,67 @@ class KnowledgeGraphService:
 
         return kgs
 
+    async def list_for_workspace_with_permission(
+        self,
+        user_id: str,
+        workspace_id: str,
+        permission: Permission = Permission.VIEW,
+    ) -> list[KnowledgeGraph]:
+        """List knowledge graphs in a workspace filtered by per-KG permission.
+
+        Discovers KGs linked to the workspace via SpiceDB relationships, then
+        filters to those the user has the requested permission on.
+
+        Unlike list_for_workspace(), this method does NOT require workspace-level
+        VIEW permission — per-KG permission checks are sufficient. This supports
+        the Mutations Console KG selector which must show KGs the user can EDIT
+        within the selected workspace, regardless of their workspace role.
+
+        Args:
+            user_id: The user requesting the list
+            workspace_id: The workspace to filter by
+            permission: Minimum permission to check on each KG (VIEW or EDIT)
+
+        Returns:
+            KGs in the workspace that the user has the requested permission on.
+            Returns an empty list when the workspace has no KGs or when the user
+            lacks the requested permission on all workspace KGs.
+        """
+        # Discover KG IDs linked to the workspace via SpiceDB relationships
+        tuples = await self._authz.read_relationships(
+            resource_type=ResourceType.KNOWLEDGE_GRAPH,
+            relation=RelationType.WORKSPACE,
+            subject_type=ResourceType.WORKSPACE,
+            subject_id=workspace_id,
+        )
+
+        # Extract KG IDs from relationship tuples (format: "knowledge_graph:<id>")
+        kg_ids: list[str] = []
+        for rel_tuple in tuples:
+            parts = rel_tuple.resource.split(":")
+            if len(parts) == 2:
+                kg_ids.append(parts[1])
+
+        # Filter by per-KG permission (no workspace-level check required)
+        kgs: list[KnowledgeGraph] = []
+        for kg_id in kg_ids:
+            has_perm = await self._check_permission(
+                user_id=user_id,
+                resource_type=ResourceType.KNOWLEDGE_GRAPH,
+                resource_id=kg_id,
+                permission=permission,
+            )
+            if has_perm:
+                kg = await self._kg_repo.get_by_id(KnowledgeGraphId(value=kg_id))
+                if kg is not None and kg.tenant_id == self._scope_to_tenant:
+                    kgs.append(kg)
+
+        self._probe.knowledge_graphs_listed(
+            workspace_id=workspace_id,
+            count=len(kgs),
+        )
+        return kgs
+
     async def list_all(
         self,
         user_id: str,

--- a/src/api/management/presentation/knowledge_graphs/routes.py
+++ b/src/api/management/presentation/knowledge_graphs/routes.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
@@ -45,19 +45,36 @@ async def list_knowledge_graphs(
             )
         ),
     ] = "view",
+    workspace_id: Annotated[
+        Optional[str],
+        Query(
+            description=(
+                "Optional workspace ID. When provided, results are filtered to "
+                "knowledge graphs in that workspace that the user has the requested "
+                "permission on. Used by the Mutations Console KG selector to satisfy "
+                "the 'within the current workspace' scoping clause."
+            )
+        ),
+    ] = None,
 ) -> KnowledgeGraphListResponse:
-    """List all knowledge graphs accessible to the current user in their tenant.
+    """List knowledge graphs accessible to the current user in their tenant.
 
     Returns knowledge graphs filtered by SpiceDB permission checks.
 
     - ``?permission=view`` (default): returns all KGs the user can read.
     - ``?permission=edit``: returns only KGs the user can mutate — used by the
       Mutations Console to populate the knowledge-graph selector.
+    - ``?workspace_id=<id>``: further scopes results to a specific workspace.
+      Does NOT require workspace-level VIEW permission — per-KG permission checks
+      are sufficient. Used by the Mutations Console KG selector.
+    - Without ``?workspace_id=``: returns all accessible KGs in the tenant
+      (existing behaviour, no regression).
 
     Args:
         current_user: Current authenticated user with tenant context
         service: Knowledge graph service for orchestration
         permission: Minimum permission level to filter by (view or edit)
+        workspace_id: Optional workspace to scope results to
 
     Returns:
         KnowledgeGraphListResponse with all accessible KGs
@@ -67,10 +84,17 @@ async def list_knowledge_graphs(
     """
     perm = Permission.EDIT if permission == "edit" else Permission.VIEW
     try:
-        kgs = await service.list_all(
-            user_id=current_user.user_id.value,
-            permission=perm,
-        )
+        if workspace_id:
+            kgs = await service.list_for_workspace_with_permission(
+                user_id=current_user.user_id.value,
+                workspace_id=workspace_id,
+                permission=perm,
+            )
+        else:
+            kgs = await service.list_all(
+                user_id=current_user.user_id.value,
+                permission=perm,
+            )
         kg_responses = [KnowledgeGraphResponse.from_domain(kg) for kg in kgs]
         return KnowledgeGraphListResponse(
             knowledge_graphs=kg_responses,

--- a/src/api/tests/unit/management/application/test_knowledge_graph_service.py
+++ b/src/api/tests/unit/management/application/test_knowledge_graph_service.py
@@ -1036,3 +1036,192 @@ class TestKnowledgeGraphServiceListAll:
 
         assert len(result) == 1
         assert result[0].id.value == kg.id.value
+
+
+# ---- list_for_workspace_with_permission ----
+
+
+class TestListForWorkspaceWithPermission:
+    """Tests for KnowledgeGraphService.list_for_workspace_with_permission.
+
+    Spec: Mutations Console KG selector must list all KGs the user has 'edit'
+    permission on *within the current workspace*.
+    GET /management/knowledge-graphs?workspace_id=<id>&permission=edit
+
+    Unlike list_for_workspace(), this method does NOT require workspace-level
+    VIEW permission — per-KG permission checks are sufficient.
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_only_kgs_in_workspace_with_edit_permission(
+        self, service, authz, kg_repo, user_id, workspace_id, tenant_id
+    ):
+        """Returns only KGs linked to the workspace that user can EDIT."""
+        kg1 = _make_kg(kg_id="kg-001", tenant_id=tenant_id, workspace_id=workspace_id)
+        kg2 = _make_kg(kg_id="kg-002", tenant_id=tenant_id, workspace_id=workspace_id)
+        kg_repo.seed(kg1, kg2)
+
+        # Both KGs are linked to the workspace via SpiceDB relationships
+        await authz.write_relationship(
+            "knowledge_graph:kg-001", "workspace", f"workspace:{workspace_id}"
+        )
+        await authz.write_relationship(
+            "knowledge_graph:kg-002", "workspace", f"workspace:{workspace_id}"
+        )
+
+        # Only kg1 has EDIT permission
+        await _grant_kg_edit(authz, kg1.id.value, user_id)
+        # kg2 has VIEW only
+        await _grant_kg_view(authz, kg2.id.value, user_id)
+
+        result = await service.list_for_workspace_with_permission(
+            user_id=user_id,
+            workspace_id=workspace_id,
+            permission=Permission.EDIT,
+        )
+
+        assert len(result) == 1
+        assert result[0].id.value == kg1.id.value
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_no_kgs_in_workspace(
+        self, service, authz, user_id, workspace_id
+    ):
+        """Returns an empty list when no KGs are linked to the workspace."""
+        # No workspace→KG relationships
+        result = await service.list_for_workspace_with_permission(
+            user_id=user_id,
+            workspace_id=workspace_id,
+            permission=Permission.EDIT,
+        )
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_user_has_no_edit_permission_on_any_kg(
+        self, service, authz, kg_repo, user_id, workspace_id, tenant_id
+    ):
+        """Returns empty list when user can only view all KGs in the workspace."""
+        kg = _make_kg(kg_id="kg-readonly", tenant_id=tenant_id)
+        kg_repo.seed(kg)
+
+        await authz.write_relationship(
+            "knowledge_graph:kg-readonly", "workspace", f"workspace:{workspace_id}"
+        )
+        # VIEW only — not EDIT
+        await _grant_kg_view(authz, kg.id.value, user_id)
+
+        result = await service.list_for_workspace_with_permission(
+            user_id=user_id,
+            workspace_id=workspace_id,
+            permission=Permission.EDIT,
+        )
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_does_not_require_workspace_view_permission(
+        self, service, authz, kg_repo, user_id, workspace_id, tenant_id
+    ):
+        """Does NOT raise UnauthorizedError even when user has no workspace-level role.
+
+        Unlike list_for_workspace(), this method performs per-KG permission checks
+        only. A user with EDIT on a KG can see it in the Mutations Console selector
+        regardless of their workspace-level role.
+        """
+        kg = _make_kg(kg_id="kg-edit-only", tenant_id=tenant_id)
+        kg_repo.seed(kg)
+
+        await authz.write_relationship(
+            "knowledge_graph:kg-edit-only", "workspace", f"workspace:{workspace_id}"
+        )
+        # Grant EDIT on KG directly, but NO workspace-level permission
+        await _grant_kg_edit(authz, kg.id.value, user_id)
+
+        # Should NOT raise UnauthorizedError
+        result = await service.list_for_workspace_with_permission(
+            user_id=user_id,
+            workspace_id=workspace_id,
+            permission=Permission.EDIT,
+        )
+
+        assert len(result) == 1
+        assert result[0].id.value == kg.id.value
+
+    @pytest.mark.asyncio
+    async def test_filters_kgs_from_other_tenants(
+        self, service, authz, kg_repo, user_id, workspace_id, tenant_id
+    ):
+        """Excludes KGs that belong to a different tenant even if linked to workspace."""
+        kg_own = _make_kg(kg_id="kg-own", tenant_id=tenant_id)
+        kg_other = _make_kg(kg_id="kg-other", tenant_id="other-tenant")
+        kg_repo.seed(kg_own, kg_other)
+
+        await authz.write_relationship(
+            "knowledge_graph:kg-own", "workspace", f"workspace:{workspace_id}"
+        )
+        await authz.write_relationship(
+            "knowledge_graph:kg-other", "workspace", f"workspace:{workspace_id}"
+        )
+        await _grant_kg_edit(authz, kg_own.id.value, user_id)
+        await _grant_kg_edit(authz, kg_other.id.value, user_id)
+
+        result = await service.list_for_workspace_with_permission(
+            user_id=user_id,
+            workspace_id=workspace_id,
+            permission=Permission.EDIT,
+        )
+
+        assert len(result) == 1
+        assert result[0].id.value == kg_own.id.value
+
+    @pytest.mark.asyncio
+    async def test_calls_probe_on_success(
+        self, service, authz, kg_repo, probe, user_id, workspace_id, tenant_id
+    ):
+        """Calls probe.knowledge_graphs_listed() with workspace_id and count."""
+        kg = _make_kg(kg_id="kg-probe", tenant_id=tenant_id)
+        kg_repo.seed(kg)
+
+        await authz.write_relationship(
+            "knowledge_graph:kg-probe", "workspace", f"workspace:{workspace_id}"
+        )
+        await _grant_kg_edit(authz, kg.id.value, user_id)
+
+        await service.list_for_workspace_with_permission(
+            user_id=user_id,
+            workspace_id=workspace_id,
+            permission=Permission.EDIT,
+        )
+
+        assert len(probe.knowledge_graphs_listed_calls) == 1
+        call = probe.knowledge_graphs_listed_calls[0]
+        assert call["workspace_id"] == workspace_id
+        assert call["count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_view_permission_returns_viewable_kgs_in_workspace(
+        self, service, authz, kg_repo, user_id, workspace_id, tenant_id
+    ):
+        """list_for_workspace_with_permission(permission=VIEW) returns viewable KGs."""
+        kg1 = _make_kg(kg_id="kg-viewable", tenant_id=tenant_id)
+        kg2 = _make_kg(kg_id="kg-no-perm", tenant_id=tenant_id)
+        kg_repo.seed(kg1, kg2)
+
+        await authz.write_relationship(
+            "knowledge_graph:kg-viewable", "workspace", f"workspace:{workspace_id}"
+        )
+        await authz.write_relationship(
+            "knowledge_graph:kg-no-perm", "workspace", f"workspace:{workspace_id}"
+        )
+        await _grant_kg_view(authz, kg1.id.value, user_id)
+        # No permission on kg2
+
+        result = await service.list_for_workspace_with_permission(
+            user_id=user_id,
+            workspace_id=workspace_id,
+            permission=Permission.VIEW,
+        )
+
+        assert len(result) == 1
+        assert result[0].id.value == kg1.id.value

--- a/src/api/tests/unit/management/presentation/test_knowledge_graphs_routes.py
+++ b/src/api/tests/unit/management/presentation/test_knowledge_graphs_routes.py
@@ -147,6 +147,88 @@ class TestListKnowledgeGraphsRoute:
         result = response.json()
         assert result["knowledge_graphs"] == []
 
+    def test_list_knowledge_graphs_with_workspace_id_calls_list_for_workspace_with_permission(
+        self,
+        test_client: TestClient,
+        mock_kg_service: AsyncMock,
+        mock_current_user: CurrentUser,
+        sample_knowledge_graph: KnowledgeGraph,
+    ) -> None:
+        """When ?workspace_id= is provided, route calls list_for_workspace_with_permission."""
+        mock_kg_service.list_for_workspace_with_permission.return_value = [
+            sample_knowledge_graph
+        ]
+        workspace_id = "01JPQRST1234567890ABCDEFWS"
+
+        response = test_client.get(
+            f"/management/knowledge-graphs?workspace_id={workspace_id}&permission=edit"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_kg_service.list_for_workspace_with_permission.assert_called_once_with(
+            user_id=mock_current_user.user_id.value,
+            workspace_id=workspace_id,
+            permission=Permission.EDIT,
+        )
+        # list_all must NOT be called when workspace_id is provided
+        mock_kg_service.list_all.assert_not_called()
+
+    def test_list_knowledge_graphs_with_workspace_id_returns_filtered_kgs(
+        self,
+        test_client: TestClient,
+        mock_kg_service: AsyncMock,
+        sample_knowledge_graph: KnowledgeGraph,
+    ) -> None:
+        """Response contains only the KGs returned by list_for_workspace_with_permission."""
+        mock_kg_service.list_for_workspace_with_permission.return_value = [
+            sample_knowledge_graph
+        ]
+        workspace_id = "01JPQRST1234567890ABCDEFWS"
+
+        response = test_client.get(
+            f"/management/knowledge-graphs?workspace_id={workspace_id}"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        result = response.json()
+        assert len(result["knowledge_graphs"]) == 1
+        assert result["knowledge_graphs"][0]["id"] == sample_knowledge_graph.id.value
+
+    def test_list_knowledge_graphs_without_workspace_id_calls_list_all(
+        self,
+        test_client: TestClient,
+        mock_kg_service: AsyncMock,
+        mock_current_user: CurrentUser,
+    ) -> None:
+        """When no ?workspace_id=, route calls list_all (backward-compatible behaviour)."""
+        mock_kg_service.list_all.return_value = []
+
+        test_client.get("/management/knowledge-graphs?permission=edit")
+
+        mock_kg_service.list_all.assert_called_once_with(
+            user_id=mock_current_user.user_id.value,
+            permission=Permission.EDIT,
+        )
+        mock_kg_service.list_for_workspace_with_permission.assert_not_called()
+
+    def test_list_knowledge_graphs_with_workspace_id_uses_view_permission_by_default(
+        self,
+        test_client: TestClient,
+        mock_kg_service: AsyncMock,
+        mock_current_user: CurrentUser,
+    ) -> None:
+        """When workspace_id is provided without ?permission=, defaults to VIEW."""
+        mock_kg_service.list_for_workspace_with_permission.return_value = []
+        workspace_id = "01JPQRST1234567890ABCDEFWS"
+
+        test_client.get(f"/management/knowledge-graphs?workspace_id={workspace_id}")
+
+        mock_kg_service.list_for_workspace_with_permission.assert_called_once_with(
+            user_id=mock_current_user.user_id.value,
+            workspace_id=workspace_id,
+            permission=Permission.VIEW,
+        )
+
 
 class TestGetKnowledgeGraphRoute:
     """Tests for GET /management/knowledge-graphs/{kg_id} endpoint."""

--- a/src/dev-ui/app/pages/graph/mutations.vue
+++ b/src/dev-ui/app/pages/graph/mutations.vue
@@ -144,7 +144,8 @@ async function loadKnowledgeGraphs() {
     const { apiFetch } = useApiClient()
     // Request only KGs the user has 'edit' permission on within the selected
     // workspace — the spec requires "within the current workspace" scoping.
-    // TODO: backend must support ?workspace_id= filter on GET /management/knowledge-graphs
+    // Backend supports ?workspace_id= filter on GET /management/knowledge-graphs
+    // via KnowledgeGraphService.list_for_workspace_with_permission().
     const result = await apiFetch<{ knowledge_graphs: KnowledgeGraphItem[] }>(
       '/management/knowledge-graphs',
       { query: { permission: 'edit', workspace_id: selectedWorkspaceId.value } },


### PR DESCRIPTION
## What & Why

The Mutations Console UI (task-074) must satisfy this spec clause:

> AND the selector lists all knowledge graphs the user has `edit` permission on
> **within the current workspace**

The UI already calls:

```
GET /management/knowledge-graphs?workspace_id={id}&permission=edit
```

(`src/dev-ui/app/pages/graph/mutations.vue`, line ~149, includes a `TODO` comment
acknowledging this backend dependency.)

However, the `GET /management/knowledge-graphs` route currently only accepts
`?permission=view|edit`. The `workspace_id` query parameter is silently ignored by
FastAPI (not a declared parameter), so the endpoint returns **all editable KGs in the
tenant** regardless of the workspace filter. The spec clause — "within the current
workspace" — is therefore not satisfied end-to-end.

This PR adds optional `workspace_id` query parameter support to
`GET /management/knowledge-graphs`. When provided, the response is filtered to
knowledge graphs belonging to that workspace that the user also has the requested
permission on.

## Spec Requirements Satisfied

**Requirement: Mutations Console — Scenario: Knowledge graph selection**
from `specs/ui/experience.spec.md@e77913c2cc6d8b719291e2dbb6870519a94d50da`:

> AND the selector lists all knowledge graphs the user has `edit` permission on
> within the current workspace

The "within the current workspace" clause requires the backend to support
workspace-scoped + permission-filtered KG listing simultaneously.

**Requirement: Backend API Alignment — Scenario: Resource operations succeed end-to-end**

The UI passes `workspace_id` to this endpoint. Without backend support, the
"corresponding backend API call succeeds" clause fails to return the correct
workspace-scoped results even when the HTTP status is 200.

## Key Design Decisions

- **New service method `list_for_workspace_with_permission`**: Rather than modifying
  the existing `list_for_workspace` (which is called from the workspace-scoped route
  and has different semantics — it checks workspace VIEW permission first, then returns
  all KGs in the workspace), a new method combines workspace membership discovery with
  per-KG permission filtering. This preserves the SRP of each existing method.

- **Route change is additive (no breaking change)**: The `workspace_id` parameter is
  optional (`Optional[str] = None`). When absent, existing behaviour is unchanged
  (`list_all` is called). When present, the new `list_for_workspace_with_permission`
  method is called.

- **Workspace membership check**: The new method reuses the same SpiceDB
  `read_relationships` pattern from `list_for_workspace` to discover KG IDs linked to
  the workspace, then applies per-KG permission filtering (same loop as `list_all`).
  No new SpiceDB calls are added beyond what already exists.

- **Authorization model**: The caller does NOT need VIEW permission on the workspace
  (unlike `list_for_workspace`). SpiceDB per-KG permission checks are sufficient
  — a user with `edit` on a KG in workspace W can see that KG in the mutations
  console KG selector regardless of their workspace-level role.

- **Probe instrumentation**: The existing `knowledge_graphs_listed` probe is called
  with `workspace_id` so DOO tracing captures the workspace scope.

## Files Affected

- `src/api/management/application/services/knowledge_graph_service.py` — add
  `list_for_workspace_with_permission(user_id, workspace_id, permission)` method.
- `src/api/management/presentation/knowledge_graphs/routes.py` — add
  `workspace_id: Optional[str] = None` query parameter to
  `list_knowledge_graphs`; route to new service method when workspace_id is provided.
- `src/api/tests/unit/management/test_knowledge_graph_service.py` (or equivalent
  unit test file) — new tests for `list_for_workspace_with_permission`.
- `src/api/tests/integration/management/test_knowledge_graphs_routes.py` (or
  equivalent integration test file) — new integration tests for the `?workspace_id=`
  filter on the list endpoint.

## How to Verify

1. Run `make test-unit` — new unit tests for `list_for_workspace_with_permission`
   pass green.
2. Start the dev instance (`make dev` or `make instance-up`) and run
   `make test-integration` — new route tests pass.
3. Call `GET /management/knowledge-graphs?workspace_id=<a_real_ws_id>&permission=edit`
   — verify only KGs in that workspace with edit permission are returned.
4. Call `GET /management/knowledge-graphs?permission=edit` (no workspace_id) — verify
   all tenant-wide editable KGs are returned (unchanged behaviour).
5. Navigate to the Mutations Console in the dev UI, select a workspace — verify the
   KG dropdown is populated only with KGs from that workspace.
6. Remove the `TODO` comment from `mutations.vue` line ~147.

## TDD Cycle

1. Write unit tests for `list_for_workspace_with_permission` (RED).
2. Implement `list_for_workspace_with_permission` in the service (GREEN).
3. Write integration test for the route with `?workspace_id=` (RED).
4. Update the route to accept `workspace_id` and call the new service method (GREEN).
5. Run full test suite: `make test-unit && make test-integration`.
6. Commit atomically.

## Caveats

- If the `workspace_id` provided does not exist or the user has no KGs with the
  requested permission in that workspace, return an empty list (not 403 or 404).
  This matches the filtering semantics of `list_all`: missing or inaccessible items
  are silently excluded, not rejected.
- The existing `GET /management/workspaces/{workspace_id}/knowledge-graphs` route
  is unchanged. It continues to check VIEW permission on the workspace and return
  all visible KGs — suitable for the Workspace Management page. This PR targets
  the tenant-level listing route only.
- This task unblocks task-074 (Mutations Console workspace-scoped KG selector).
  task-074's TODO comment in `mutations.vue` can be removed once this PR lands.

---

**Task:** `task-077`
**Spec:** `specs/ui/experience.spec.md@e77913c2cc6d8b719291e2dbb6870519a94d50da`

### Merge

The orchestrator will squash-merge this PR automatically
once all pipeline steps pass.

---

This PR was created by [hyperloop](https://github.com/jsell-rh/hyperloop),
an AI agent orchestrator.