### PR TITLE
feat(query): route MCP queries to per-tenant AGE graph

### DIFF
--- a/src/api/graph/infrastructure/age_client.py
+++ b/src/api/graph/infrastructure/age_client.py
@@ -154,6 +154,38 @@ class AgeGraphClient(GraphClientProtocol):
                 self._connection.commit()
                 self._probe.graph_created(self._graph_name)
 
+    def graph_exists(self, graph_name: str) -> bool:
+        """Check whether an AGE graph with the given name exists.
+
+        Queries the Apache AGE catalog (``ag_catalog.ag_graph``) to determine
+        whether the named graph has been provisioned. This is a lightweight
+        read-only SQL query that does NOT require the AGE extension to be
+        set up for the specific graph_name.
+
+        Used by the Querying context to validate tenant graph existence
+        before executing Cypher queries.
+
+        Args:
+            graph_name: The name of the graph to check (e.g., ``"tenant_xyz"``).
+
+        Returns:
+            True if the graph exists in ag_catalog.ag_graph, False otherwise.
+
+        Raises:
+            DatabaseConnectionError: If not connected to the database.
+        """
+        if not self.is_connected():
+            from infrastructure.database.exceptions import DatabaseConnectionError
+
+            raise DatabaseConnectionError("Not connected to database")
+
+        with self._connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT 1 FROM ag_catalog.ag_graph WHERE name = %s",
+                (graph_name,),
+            )
+            return cursor.fetchone() is not None
+
     def disconnect(self) -> None:
         """Close the database connection and return it to the pool."""
         if (

--- a/src/api/graph/ports/protocols.py
+++ b/src/api/graph/ports/protocols.py
@@ -123,6 +123,23 @@ class GraphQueryExecutorProtocol(Protocol):
         """
         ...
 
+    def graph_exists(self, graph_name: str) -> bool:
+        """Check whether an AGE graph with the given name exists.
+
+        Used by the Querying context to validate that the tenant's AGE graph
+        has been provisioned before executing any Cypher query against it.
+
+        Args:
+            graph_name: The name of the graph to check (e.g., ``"tenant_xyz"``).
+
+        Returns:
+            True if the graph exists in ag_catalog.ag_graph, False otherwise.
+
+        Raises:
+            DatabaseConnectionError: If not connected to the database.
+        """
+        ...
+
     @contextmanager
     def transaction(self) -> Iterator[GraphTransactionProtocol]:
         """Create a transaction context for atomic operations.

--- a/src/api/query/dependencies.py
+++ b/src/api/query/dependencies.py
@@ -27,6 +27,7 @@ from query.application.observability import (
 )
 from query.application.services import MCPQueryService
 from query.infrastructure.query_repository import QueryGraphRepository
+from shared_kernel.middleware.mcp_auth import get_mcp_auth_context
 
 if TYPE_CHECKING:
     from graph.infrastructure.age_client import AgeGraphClient
@@ -42,11 +43,19 @@ def get_query_service_probe() -> QueryServiceProbe:
 
 
 @contextmanager
-def mcp_graph_client_context() -> Generator["AgeGraphClient", None, None]:
+def mcp_graph_client_context(
+    graph_name: Optional[str] = None,
+) -> Generator["AgeGraphClient", None, None]:
     """Context manager for MCP graph client lifecycle.
 
     Creates a connected graph client and ensures proper cleanup.
     Uses the shared connection pool for efficiency.
+
+    Args:
+        graph_name: Optional graph name override. When provided (e.g.,
+            ``"tenant_{tenant_id}"``), the client targets that specific
+            AGE graph instead of the default from settings. Pass this
+            for per-tenant graph isolation (spec: Per-Tenant Graph Routing).
 
     Yields:
         Connected AgeGraphClient instance
@@ -57,7 +66,7 @@ def mcp_graph_client_context() -> Generator["AgeGraphClient", None, None]:
     pool = get_age_connection_pool()
     settings = get_database_settings()
     factory = ConnectionFactory(settings, pool=pool)
-    client = AgeGraphClient(settings, connection_factory=factory)
+    client = AgeGraphClient(settings, connection_factory=factory, graph_name=graph_name)
     client.connect()
     try:
         yield client
@@ -74,10 +83,21 @@ def get_mcp_query_service() -> Iterator[MCPQueryService]:
 
     Handles graph client lifecycle (connect/disconnect) automatically.
 
+    Per-tenant graph routing:
+        Reads the authenticated MCP caller's tenant_id from the request
+        context and routes all queries to the corresponding AGE graph
+        (``tenant_{tenant_id}``). This guarantees tenant isolation at the
+        database level — all queries run against a graph that is dedicated to
+        and owned by the authenticated tenant.
+
     Yields:
-        MCPQueryService instance with active database connection
+        MCPQueryService instance with active database connection targeting
+        the authenticated tenant's AGE graph.
     """
-    with mcp_graph_client_context() as client:
+    auth_context = get_mcp_auth_context()
+    tenant_graph_name = f"tenant_{auth_context.tenant_id}"
+
+    with mcp_graph_client_context(graph_name=tenant_graph_name) as client:
         probe = get_query_service_probe()
         repository = QueryGraphRepository(client=client)
         yield MCPQueryService(repository=repository, probe=probe)

--- a/src/api/query/infrastructure/query_repository.py
+++ b/src/api/query/infrastructure/query_repository.py
@@ -102,6 +102,10 @@ class QueryGraphRepository(IQueryGraphRepository):
             QueryTimeoutError: If the database cancels the statement.
             QueryExecutionError: On other query failures.
         """
+        # Safeguard 0: Validate tenant graph existence (per-tenant routing spec).
+        # Must run before the Cypher query reaches the database.
+        self._validate_graph_exists()
+
         # Safeguard 1: Reject mutation keywords (secondary read-only defense)
         self._validate_read_only(query)
 
@@ -142,6 +146,27 @@ class QueryGraphRepository(IQueryGraphRepository):
 
         # Convert results to dictionaries
         return [self._row_to_dict(row) for row in result.rows]
+
+    def _validate_graph_exists(self) -> None:
+        """Validate that the tenant AGE graph has been provisioned.
+
+        This is the pre-flight guard for per-tenant graph routing (spec:
+        Per-Tenant Graph Routing — Tenant graph not found scenario).
+
+        The check queries ``ag_catalog.ag_graph`` to confirm the graph named
+        ``self._client.graph_name`` (expected to be ``tenant_{tenant_id}``)
+        exists before any Cypher query is submitted to the database.
+
+        Raises:
+            QueryExecutionError: If the graph does not exist, with a message
+                identifying the missing graph name.
+        """
+        graph_name = self._client.graph_name
+        if not self._client.graph_exists(graph_name):
+            raise QueryExecutionError(
+                f"Tenant graph '{graph_name}' does not exist. "
+                "The graph may not have been provisioned yet.",
+            )
 
     def _validate_read_only(self, query: str) -> None:
         """Validate that query contains no mutation keywords.

--- a/src/api/tests/unit/query/test_dependencies.py
+++ b/src/api/tests/unit/query/test_dependencies.py
@@ -25,15 +25,41 @@ class TestMCPGraphClientContext:
         # After context exit, client should be disconnected
         assert not client.is_connected()
 
+    @patch("query.dependencies.get_age_connection_pool")
+    @patch("query.dependencies.get_database_settings")
+    def test_accepts_graph_name_override(self, mock_get_settings, mock_get_pool):
+        """Should create client with the specified graph_name override.
+
+        Spec: Per-Tenant Graph Routing → graph_name passed as tenant_{tenant_id}.
+        """
+        from graph.infrastructure.age_client import AgeGraphClient
+
+        mock_get_pool.return_value = MagicMock()
+        mock_get_settings.return_value = MagicMock()
+
+        with mcp_graph_client_context(graph_name="tenant_test-tenant") as client:
+            assert isinstance(client, AgeGraphClient)
+            # Client must target the specified tenant graph
+            assert client.graph_name == "tenant_test-tenant"
+
 
 class TestGetMCPQueryService:
     """Tests for get_mcp_query_service dependency provider."""
 
     @patch("query.dependencies.mcp_graph_client_context")
-    def test_returns_mcp_query_service(self, mock_client_context):
+    @patch("query.dependencies.get_mcp_auth_context")
+    def test_returns_mcp_query_service(
+        self, mock_get_auth_context, mock_client_context
+    ):
         """Should yield MCPQueryService instance with active connection."""
         from graph.infrastructure.age_client import AgeGraphClient
+        from shared_kernel.middleware.mcp_auth import MCPAuthContext
 
+        mock_get_auth_context.return_value = MCPAuthContext(
+            user_id="user-1",
+            tenant_id="tenant-xyz",
+            api_key_id="key-1",
+        )
         mock_client = MagicMock(spec=AgeGraphClient)
         mock_client_context.return_value.__enter__ = MagicMock(return_value=mock_client)
         mock_client_context.return_value.__exit__ = MagicMock(return_value=False)
@@ -41,3 +67,70 @@ class TestGetMCPQueryService:
         with get_mcp_query_service() as service:
             assert isinstance(service, MCPQueryService)
             assert service._repository is not None
+
+
+class TestTenantGraphRouting:
+    """Tests for per-tenant graph routing in dependency injection.
+
+    Spec: Per-Tenant Graph Routing — the service factory MUST create a graph client
+    targeting the authenticated tenant's AGE graph (tenant_{tenant_id}).
+    """
+
+    @patch("query.dependencies.mcp_graph_client_context")
+    @patch("query.dependencies.get_mcp_auth_context")
+    def test_creates_client_with_tenant_graph_name(
+        self, mock_get_auth_context, mock_client_context
+    ):
+        """Should create MCPQueryService targeting tenant_{tenant_id} AGE graph.
+
+        Spec: Query routed to tenant graph → `tenant_{tenant_id}`.
+        The dependency factory MUST pass `graph_name=f"tenant_{tenant_id}"` to
+        the graph client context so the client is bound to the correct graph.
+        """
+        from graph.infrastructure.age_client import AgeGraphClient
+        from shared_kernel.middleware.mcp_auth import MCPAuthContext
+
+        tenant_id = "abc-def-123-xyz"
+        mock_get_auth_context.return_value = MCPAuthContext(
+            user_id="user-1",
+            tenant_id=tenant_id,
+            api_key_id="key-1",
+        )
+        mock_client = MagicMock(spec=AgeGraphClient)
+        mock_client_context.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_context.return_value.__exit__ = MagicMock(return_value=False)
+
+        with get_mcp_query_service():
+            pass
+
+        # The client context MUST be called with the tenant-specific graph name
+        mock_client_context.assert_called_once_with(graph_name=f"tenant_{tenant_id}")
+
+    @patch("query.dependencies.mcp_graph_client_context")
+    @patch("query.dependencies.get_mcp_auth_context")
+    def test_tenant_routing_uses_auth_context_tenant_id(
+        self, mock_get_auth_context, mock_client_context
+    ):
+        """Graph name must be derived from the auth context tenant_id, not hard-coded.
+
+        Spec: AND queries never cross tenant boundaries regardless of query content.
+        Each tenant gets their own isolated graph.
+        """
+        from graph.infrastructure.age_client import AgeGraphClient
+        from shared_kernel.middleware.mcp_auth import MCPAuthContext
+
+        # Test with a different tenant_id to prove it's dynamic
+        tenant_id = "completely-different-tenant-777"
+        mock_get_auth_context.return_value = MCPAuthContext(
+            user_id="user-2",
+            tenant_id=tenant_id,
+            api_key_id="key-2",
+        )
+        mock_client = MagicMock(spec=AgeGraphClient)
+        mock_client_context.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_context.return_value.__exit__ = MagicMock(return_value=False)
+
+        with get_mcp_query_service():
+            pass
+
+        mock_client_context.assert_called_once_with(graph_name=f"tenant_{tenant_id}")

--- a/src/api/tests/unit/query/test_query_repository.py
+++ b/src/api/tests/unit/query/test_query_repository.py
@@ -24,6 +24,8 @@ def mock_client():
     """Create mock graph client."""
     client = create_autospec(GraphClientProtocol, instance=True)
     client.graph_name = "test_graph"
+    # Default: graph exists (so existing tests that don't test routing still pass)
+    client.graph_exists.return_value = True
     return client
 
 
@@ -503,3 +505,110 @@ class TestEdgeToDict:
         result = repository._edge_to_dict(edge)
 
         assert result["properties"] == {}
+
+
+class TestTenantGraphRouting:
+    """Tests for per-tenant graph routing (spec: Per-Tenant Graph Routing).
+
+    The system SHALL route all queries to the caller's tenant-specific AGE graph.
+    - Query executes against `tenant_{tenant_id}` graph.
+    - If that graph has not been provisioned, reject with execution error BEFORE
+      the Cypher query reaches the database.
+    """
+
+    def test_rejects_query_if_tenant_graph_not_found(self, mock_client):
+        """Should raise QueryExecutionError when the tenant graph does not exist.
+
+        Spec: Tenant graph not found → rejected with execution error before
+        reaching the database (i.e., before the Cypher query is executed).
+        """
+        mock_client.graph_name = "tenant_missing-tenant"
+        mock_client.graph_exists.return_value = False
+        repository = QueryGraphRepository(client=mock_client)
+
+        with pytest.raises(QueryExecutionError) as exc_info:
+            repository.execute_cypher("MATCH (n) RETURN n")
+
+        # Must NOT open a transaction — rejection happens before DB Cypher execution
+        mock_client.transaction.assert_not_called()
+
+        # Error message should identify the missing graph
+        error_msg = str(exc_info.value)
+        assert any(
+            keyword in error_msg.lower()
+            for keyword in ["not found", "does not exist", "tenant"]
+        ), f"Error message should indicate graph not found, got: {error_msg!r}"
+
+    def test_proceeds_when_tenant_graph_exists(self, mock_client, mock_transaction):
+        """Should proceed with query execution when tenant graph exists.
+
+        Spec: Query routed to tenant graph → executes against tenant_{tenant_id}.
+        """
+        mock_client.graph_name = "tenant_existing-tenant"
+        mock_client.graph_exists.return_value = True
+        mock_client.transaction.return_value.__enter__ = MagicMock(
+            return_value=mock_transaction
+        )
+        mock_client.transaction.return_value.__exit__ = MagicMock(return_value=False)
+        mock_transaction.execute_cypher.return_value = CypherResult(
+            rows=(), row_count=0
+        )
+        repository = QueryGraphRepository(client=mock_client)
+
+        result = repository.execute_cypher("MATCH (n) RETURN n")
+
+        # Transaction must be opened (graph exists → proceed to Cypher)
+        mock_client.transaction.assert_called_once()
+        assert result == []
+
+    def test_checks_client_graph_name_for_existence(
+        self, mock_client, mock_transaction
+    ):
+        """Should check existence of the exact graph name configured on the client.
+
+        Spec: Query routed to tenant graph → `tenant_{tenant_id}`.
+        The existence check MUST use the client's graph_name (not a hard-coded name).
+        """
+        graph_name = "tenant_abc-def-123"
+        mock_client.graph_name = graph_name
+        mock_client.graph_exists.return_value = True
+        mock_client.transaction.return_value.__enter__ = MagicMock(
+            return_value=mock_transaction
+        )
+        mock_client.transaction.return_value.__exit__ = MagicMock(return_value=False)
+        mock_transaction.execute_cypher.return_value = CypherResult(
+            rows=(), row_count=0
+        )
+        repository = QueryGraphRepository(client=mock_client)
+
+        repository.execute_cypher("MATCH (n) RETURN n")
+
+        # The repository MUST call graph_exists with the client's graph name
+        mock_client.graph_exists.assert_called_once_with(graph_name)
+
+    def test_graph_not_found_error_is_execution_error_type(self, mock_client):
+        """Graph-not-found rejection MUST be categorised as QueryExecutionError.
+
+        Spec: Error Categorization → execution_error type for graph not found.
+        """
+        mock_client.graph_name = "tenant_ghost"
+        mock_client.graph_exists.return_value = False
+        repository = QueryGraphRepository(client=mock_client)
+
+        with pytest.raises(QueryExecutionError):
+            repository.execute_cypher("MATCH (n) RETURN n")
+
+    def test_graph_check_precedes_keyword_blacklist(self, mock_client):
+        """Graph existence check must happen before or alongside keyword blacklist.
+
+        Both checks protect the database; ordering is flexible but the graph
+        check must NOT be skipped when the query is otherwise valid.
+        Note: forbidden queries may be rejected by the blacklist first (OK).
+        """
+        mock_client.graph_name = "tenant_nonexistent"
+        mock_client.graph_exists.return_value = False
+        repository = QueryGraphRepository(client=mock_client)
+
+        # A valid read-only query against a non-existent graph must raise
+        with pytest.raises(QueryExecutionError):
+            repository.execute_cypher("MATCH (n) RETURN n")


### PR DESCRIPTION
## What & Why

`query-execution.spec.md` was updated with a new requirement:

> **Requirement: Per-Tenant Graph Routing**
> The system SHALL route all queries to the caller's tenant-specific AGE graph.

with two scenarios:

**Scenario: Query routed to tenant graph**
> GIVEN an authenticated query request
> WHEN the query is executed
> THEN it executes against the AGE graph named `tenant_{tenant_id}` for the resolved tenant
> AND queries never cross tenant boundaries regardless of query content

**Scenario: Tenant graph not found**
> GIVEN a tenant whose AGE graph has not been provisioned
> WHEN a query is submitted
> THEN the request is rejected with an execution error before reaching the database

Currently `get_mcp_query_service()` in `src/api/query/dependencies.py` creates an
`AgeGraphClient` without a `graph_name` override, so all MCP queries execute against
the default graph name from settings — a single shared graph for all tenants. This
violates tenant isolation.

`AgeGraphClient` already accepts a `graph_name` constructor parameter (defaulting to
`settings.graph_name`) and `auto_create=False` prevents accidental graph provisioning.
`get_mcp_auth_context()` already exposes `tenant_id`. The wiring is simply missing.

## What This PR Does

### 1. Tenant-scoped client in `query/dependencies.py`

Modify `mcp_graph_client_context()` to read the MCP auth context and pass the
tenant-specific graph name to `AgeGraphClient`:

```python
@contextmanager
def mcp_graph_client_context() -> Generator["AgeGraphClient", None, None]:
    from graph.infrastructure.age_client import AgeGraphClient
    from shared_kernel.middleware.mcp_auth import get_mcp_auth_context

    auth_context = get_mcp_auth_context()
    graph_name = f"tenant_{auth_context.tenant_id}"

    pool = get_age_connection_pool()
    settings = get_database_settings()
    factory = ConnectionFactory(settings, pool=pool)
    client = AgeGraphClient(settings, connection_factory=factory, graph_name=graph_name)
    client.connect()
    try:
        yield client
    finally:
        client.disconnect()
```

### 2. Graph existence check in `QueryGraphRepository`

Add a `_verify_graph_exists(tx)` helper that runs before any Cypher query:

```python
def _verify_graph_exists(self, tx) -> None:
    """Check that the tenant's AGE graph is provisioned.

    Raises:
        QueryExecutionError: If the graph does not exist in ag_catalog.ag_graph.
    """
    result = tx.execute_sql(
        "SELECT 1 FROM ag_catalog.ag_graph WHERE name = %s",
        (self._client.graph_name,),
    )
    if not result:
        raise QueryExecutionError(
            f"Tenant graph '{self._client.graph_name}' has not been provisioned.",
        )
```

Call `_verify_graph_exists(tx)` as the first step inside the transaction block in
`execute_cypher()`, before the Cypher query is issued. This satisfies the spec's
"rejected with an execution error **before reaching the database**" intent — the check
queries the catalog (metadata), not the tenant graph itself, so the Cypher query
never fires against the missing graph.

Note: If `tx.execute_sql` doesn't return rows natively, use the raw psycopg2
cursor pattern consistent with how `_ensure_graph_exists()` works in `AgeGraphClient`.
Inspect the `GraphTransactionProtocol` to find the right API surface; adapt as needed
and keep the unit test mockable.

### 3. Unit tests

Add a new test class (or extend `TestExecuteCypher`) in
`src/api/tests/unit/query/test_query_repository.py`:

- **`test_execute_cypher_uses_client_graph_name`** — create `QueryGraphRepository`
  with a mock client whose `graph_name` is `"tenant_abc123"`; assert the graph name
  stored on the client is used, not a hardcoded default.
- **`test_tenant_isolation_different_tenant_ids_produce_different_graph_names`** —
  two repositories built with clients named `"tenant_aaa"` and `"tenant_bbb"` must
  have distinct `_client.graph_name` values.
- **`test_raises_execution_error_when_tenant_graph_not_found`** — mock the
  graph-existence SQL check to return an empty result; assert `QueryExecutionError`
  is raised before `execute_cypher` is called on the transaction.
- **`test_execution_error_before_cypher_when_graph_missing`** — same setup; confirm
  that `mock_transaction.execute_cypher` is **never** called.

Also add a test in `src/api/tests/unit/query/test_dependencies.py` (or a new
`test_mcp_graph_routing.py`):

- **`test_mcp_graph_client_uses_tenant_graph_name`** — mock `get_mcp_auth_context()`
  to return a context with `tenant_id="t1"`, then assert that `AgeGraphClient` is
  constructed with `graph_name="tenant_t1"`.

## Files Affected

- `src/api/query/dependencies.py` — read `auth_context.tenant_id` in
  `mcp_graph_client_context()` and pass `graph_name` to `AgeGraphClient`
- `src/api/query/infrastructure/query_repository.py` — add graph-existence check
  inside `execute_cypher()` before query dispatch
- `src/api/tests/unit/query/test_query_repository.py` — new test cases for
  tenant routing and missing-graph rejection
- `src/api/tests/unit/query/test_dependencies.py` — new test for graph name wiring

## How to Verify

1. Unit tests pass: `make test-unit`
2. With a running instance: authenticate as a tenant whose AGE graph exists, execute
   a `query_graph` call, confirm results come back. Then attempt a call with a
   fabricated tenant whose graph does not exist and confirm a `QueryExecutionError`
   is returned (not a raw psycopg2 error).
3. Confirm that two tenants cannot read each other's data even if both graphs exist
   (tenant isolation is structural — each query is wired to its own graph name).

## Design Decisions

- **Where to read the tenant ID** — `mcp_graph_client_context()` is the correct
  call site because it owns the `AgeGraphClient` lifecycle. Reading it there ensures
  the graph name is fixed for the entire request; the repository never needs to be
  aware of the auth context.
- **Graph existence check location** — inside the transaction in
  `QueryGraphRepository.execute_cypher()`. This keeps the repository self-contained
  and mockable, and runs the check in the same transaction context as the query.
- **No `auto_create` for query path** — the query path must never provision graphs
  (that is the responsibility of the provisioning/admin path). `auto_create` stays
  `False` (the default).
- **Error type** — `QueryExecutionError` is the correct type per the spec's
  "execution error" language. It maps to `"execution_error"` in the `MCPQueryService`
  error categorization.

## Caveats

The `GraphTransactionProtocol` may not expose a raw SQL execution method that
returns rows. If that is the case, either extend the protocol or execute the
existence check using the client's raw connection before starting the transaction.
The key invariant is: the Cypher query must never be dispatched if the graph is
absent.

---

**Task:** `task-086`
**Spec:** `specs/query/query-execution.spec.md@dbcf0d7c2fa9c2456896ee20adbfdc8cc33090c2`

### Merge

The orchestrator will squash-merge this PR automatically
once all pipeline steps pass.

---

This PR was created by [hyperloop](https://github.com/jsell-rh/hyperloop),
an AI agent orchestrator.