### PR TITLE
test(query): verify MCP Authentication scenarios against mcp-server spec

### DIFF
--- a/src/api/tests/unit/shared_kernel/middleware/test_mcp_auth_middleware.py
+++ b/src/api/tests/unit/shared_kernel/middleware/test_mcp_auth_middleware.py
@@ -597,6 +597,182 @@ class TestMCPApiKeyAuthMiddlewareBearerFallback:
         assert capture.json == {"error": "X-API-Key header is required"}
 
 
+class TestMCPApiKeyAuthMiddlewareBearerValidationError:
+    """Tests that Bearer token backend errors produce controlled 503 responses.
+
+    Spec: Requirement: MCP Authentication — Scenario: Authentication service unavailable
+    GIVEN a request when the authentication backend is unreachable
+    WHEN the MCP request is processed
+    THEN a 503 response is returned
+
+    The MCPApiKeyAuthMiddleware wraps both validate_api_key (API key path) AND
+    validate_bearer_token (Bearer path) in try/except blocks. This class verifies
+    the Bearer path's 503 behaviour, complementing
+    TestMCPApiKeyAuthMiddlewareValidationError which covers the API key path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_503_when_bearer_validator_raises(self) -> None:
+        """Should return 503 when validate_bearer_token raises an exception.
+
+        Spec: Authentication service unavailable — THEN a 503 response is returned.
+
+        This verifies that exceptions from the Bearer token validator (network
+        errors, DB unavailability, etc.) are caught and converted to a 503 with
+        the standard error message. The raw exception is never surfaced to the
+        MCP client.
+        """
+
+        async def _exploding_bearer_validate(token: str, tenant_id: str | None) -> None:
+            raise ConnectionError("OIDC provider is down")
+
+        probe = MagicMock()
+        middleware = MCPApiKeyAuthMiddleware(
+            app=_dummy_app,
+            validate_api_key=_make_validate_fn(return_value=None),
+            validate_bearer_token=_exploding_bearer_validate,
+            probe=probe,
+        )
+
+        scope = _make_http_scope(headers=[(b"authorization", b"Bearer some-jwt")])
+        capture = _ResponseCapture()
+        await middleware(scope, _noop_receive, capture)
+
+        assert capture.status == 503
+        assert capture.json == {
+            "error": "Authentication service temporarily unavailable"
+        }
+        probe.mcp_auth_validation_error.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_bearer_503_probe_receives_error_message(self) -> None:
+        """The probe must receive the exception message for observability.
+
+        When validate_bearer_token raises, the probe's mcp_auth_validation_error
+        is called with the exception's str representation so operators can see
+        what caused the failure in structured logs.
+        """
+
+        async def _exploding_bearer_validate(token: str, tenant_id: str | None) -> None:
+            raise TimeoutError("Connection to OIDC timed out after 5 seconds")
+
+        probe = MagicMock()
+        middleware = MCPApiKeyAuthMiddleware(
+            app=_dummy_app,
+            validate_api_key=_make_validate_fn(return_value=None),
+            validate_bearer_token=_exploding_bearer_validate,
+            probe=probe,
+        )
+
+        scope = _make_http_scope(headers=[(b"authorization", b"Bearer some-jwt")])
+        capture = _ResponseCapture()
+        await middleware(scope, _noop_receive, capture)
+
+        assert capture.status == 503
+        # The error kwarg must contain the exception's message
+        probe.mcp_auth_validation_error.assert_called_once()
+        call_kwargs = probe.mcp_auth_validation_error.call_args.kwargs
+        assert "OIDC timed out" in call_kwargs.get("error", "")
+
+
+class TestMCPApiKeyAuthMiddlewareTenantIDPassthrough:
+    """Tests that the X-Tenant-ID header value is forwarded to the Bearer validator.
+
+    Spec: Requirement: MCP Authentication — Scenario: Bearer token authentication
+    GIVEN a valid Authorization: Bearer header (and no API key)
+    WHEN the MCP request is processed
+    THEN the JWT is validated
+    AND the tenant is resolved from the X-Tenant-ID header
+
+    The middleware must pass the raw X-Tenant-ID header value to validate_bearer_token
+    as its second argument. This is distinct from the tenant_id that emerges from
+    the result object — here we verify the *input* side of the validator call.
+    """
+
+    @pytest.mark.asyncio
+    async def test_x_tenant_id_header_is_passed_to_bearer_validator(self) -> None:
+        """X-Tenant-ID header value MUST be forwarded as tenant_id to the validator.
+
+        Spec: AND the tenant is resolved from the X-Tenant-ID header.
+
+        The validator receives the raw header string so it can embed the tenant
+        claim in its JWT validation logic or lookup. Passing the wrong value (or
+        None when the header is present) would cause tenant resolution to fail.
+        """
+        received_tenant_id: list[str | None] = []
+
+        @dataclass
+        class FakeBearerResult:
+            user_id: str
+            tenant_id: str
+
+        async def validator_capturing_tenant(
+            token: str, tenant_id: str | None
+        ) -> FakeBearerResult | None:
+            received_tenant_id.append(tenant_id)
+            return FakeBearerResult(user_id="user-1", tenant_id=tenant_id or "")
+
+        probe = MagicMock()
+        middleware = MCPApiKeyAuthMiddleware(
+            app=_dummy_app,
+            validate_api_key=_make_validate_fn(return_value=None),
+            validate_bearer_token=validator_capturing_tenant,
+            probe=probe,
+        )
+
+        scope = _make_http_scope(
+            headers=[
+                (b"authorization", b"Bearer valid-jwt"),
+                (b"x-tenant-id", b"my-specific-tenant"),
+            ]
+        )
+        capture = _ResponseCapture()
+        await middleware(scope, _noop_receive, capture)
+
+        assert capture.status == 200
+        # The validator must have been called with the exact X-Tenant-ID value
+        assert len(received_tenant_id) == 1
+        assert received_tenant_id[0] == "my-specific-tenant"
+
+    @pytest.mark.asyncio
+    async def test_missing_x_tenant_id_passes_none_to_validator(self) -> None:
+        """When X-Tenant-ID is absent, the validator receives None.
+
+        Some deployments may not require the tenant ID header (e.g., when the
+        JWT itself encodes tenant information). The middleware passes None in
+        this case rather than an empty string or raising.
+        """
+        received_tenant_id: list[str | None] = []
+
+        @dataclass
+        class FakeBearerResult:
+            user_id: str
+            tenant_id: str
+
+        async def validator_capturing_tenant(
+            token: str, tenant_id: str | None
+        ) -> FakeBearerResult | None:
+            received_tenant_id.append(tenant_id)
+            return FakeBearerResult(user_id="user-2", tenant_id=tenant_id or "unknown")
+
+        probe = MagicMock()
+        middleware = MCPApiKeyAuthMiddleware(
+            app=_dummy_app,
+            validate_api_key=_make_validate_fn(return_value=None),
+            validate_bearer_token=validator_capturing_tenant,
+            probe=probe,
+        )
+
+        # No X-Tenant-ID header — only the Authorization header
+        scope = _make_http_scope(headers=[(b"authorization", b"Bearer valid-jwt")])
+        capture = _ResponseCapture()
+        await middleware(scope, _noop_receive, capture)
+
+        assert capture.status == 200
+        assert len(received_tenant_id) == 1
+        assert received_tenant_id[0] is None
+
+
 class TestMCPApiKeyAuthMiddlewareNonHTTP:
     """Tests that non-HTTP scopes pass through without auth."""
 


### PR DESCRIPTION
## What & Why

The **Requirement: MCP Authentication** in `specs/query/mcp-server.spec.md` has
never had a hyperloop task created for it. All four scenarios are currently
implemented in `shared_kernel/middleware/mcp_api_key_auth.py`
(`MCPApiKeyAuthMiddleware`) and tested in
`tests/unit/shared_kernel/middleware/test_mcp_auth_middleware.py` (17 tests).
Task-038 covers this requirement from the *shared-kernel tenant context spec*
perspective; this task provides traceability to the *MCP server spec*.

The primary goal is to verify line-by-line that every spec scenario is correctly
implemented **and** adequately tested. If any test is missing or tests the wrong
thing, add it before closing this task.

## Spec Scenarios

### Scenario: API key authentication
> GIVEN a valid `X-API-Key` header
> WHEN the MCP request is processed
> THEN the request is authenticated using the API key's creator identity
> AND the tenant is resolved from the API key's tenant scope

**Implementation:** `MCPApiKeyAuthMiddleware._authenticate_api_key()` calls
`validate_api_key(secret)`. On success it builds an `MCPAuthContext` with
`user_id=str(key.created_by_user_id)` and `tenant_id=str(key.tenant_id)`.
The context is set on the `_mcp_auth_context_var` ContextVar for downstream tools.

**Tests to verify:**
- `test_sets_auth_context_on_valid_key` — auth context set with correct fields
- `test_auth_context_has_correct_fields` — user_id comes from `created_by_user_id`
- `test_api_key_takes_precedence_over_bearer` — API key checked before Bearer token

### Scenario: Bearer token authentication
> GIVEN a valid `Authorization: Bearer` header (and no API key)
> WHEN the MCP request is processed
> THEN the JWT is validated
> AND the tenant is resolved from the `X-Tenant-ID` header

**Implementation:** `MCPApiKeyAuthMiddleware._authenticate_bearer()` reads
the `X-Tenant-ID` header from scope and calls `validate_bearer_token(token, tenant_id)`.
On success it builds an `MCPAuthContext` with `api_key_id="bearer"`.

**Tests to verify:**
- `test_falls_back_to_bearer_when_api_key_missing` — Bearer used when no API key
- `test_bearer_returns_401_when_token_invalid` — invalid Bearer → 401

**Gap to check:** Is there a test confirming the `X-Tenant-ID` header value is
passed to the validator? If not, add it.

### Scenario: No credentials
> GIVEN a request with no authentication headers
> WHEN the MCP request is processed
> THEN a 401 response is returned

**Implementation:** If neither `X-API-Key` nor `Authorization: Bearer` is present,
`MCPApiKeyAuthMiddleware.__call__()` calls `_send_json_error(send, 401, ...)`.
The response includes `WWW-Authenticate: ApiKey realm="kartograph"`.

**Tests to verify:**
- `test_returns_401_when_header_missing` — missing both headers → 401
- `test_no_bearer_validator_returns_401_as_before` — backward compat when
  `validate_bearer_token=None`

### Scenario: Authentication service unavailable
> GIVEN a request when the authentication backend is unreachable
> WHEN the MCP request is processed
> THEN a 503 response is returned

**Implementation:** `_authenticate_api_key()` wraps `validate_api_key()` in a
`try/except Exception`. Any exception (network error, DB down) triggers
`_send_json_error(send, 503, "Authentication service temporarily unavailable")`.
Same wrapping in `_authenticate_bearer()`.

**Tests to verify:**
- `test_returns_503_when_validator_raises` — validator raises → 503

**Gap to check:** Is there a corresponding 503 test for the Bearer token path when
`validate_bearer_token` raises? If not, add `test_returns_503_when_bearer_validator_raises`.

## Files Affected

No implementation changes expected. Potential test additions only:

- `src/api/tests/unit/shared_kernel/middleware/test_mcp_auth_middleware.py`
  — add missing scenario tests if the gap check above reveals any

## How to Verify

1. Run: `cd src/api && uv run pytest tests/unit/shared_kernel/middleware/test_mcp_auth_middleware.py -v`
2. All 17 (or more) tests pass.
3. Manually trace each spec scenario line to the corresponding test assertion.
4. If the `X-Tenant-ID` passthrough test is missing, add it and confirm it passes.
5. If the Bearer 503 test is missing, add it and confirm it passes.

## Design Context

- `MCPApiKeyAuthMiddleware` is framework-agnostic ASGI middleware — it does not
  import FastAPI. This keeps the shared kernel decoupled from the presentation layer.
- The middleware injects `MCPAuthContext` into a `ContextVar`, which MCP tools
  retrieve via `get_mcp_auth_context()`.
- The `api_key_id="bearer"` sentinel in the Bearer auth path distinguishes API-key
  sessions from Bearer-token sessions for observability without a type field.
- The `WWW-Authenticate` header on 401 responses follows RFC 9110 §11.6.1.

## Gap Analysis

Task-038 was the original task for MCP authentication, but it references
`specs/shared-kernel/tenant-context.spec.md`, not `specs/query/mcp-server.spec.md`.
All previous mcp-server.spec.md tasks (task-011, task-085, task-086, task-089,
task-091, task-092) covered other requirements. This task provides spec traceability
for the MCP Authentication requirement and prompts the agent to check for any
missing test coverage in the Bearer token error paths.

---

**Task:** `task-093`
**Spec:** `specs/query/mcp-server.spec.md@2ac8d03afbf2153e3b569f1289e10b5ad5d21d6e`

### Merge

The orchestrator will squash-merge this PR automatically
once all pipeline steps pass.

---

This PR was created by [hyperloop](https://github.com/jsell-rh/hyperloop),
an AI agent orchestrator.