### PR TITLE
test(query): add unit tests for _filter_internal_properties in query_graph tool

### DIFF
--- a/src/api/tests/unit/query/test_mcp_query_tool.py
+++ b/src/api/tests/unit/query/test_mcp_query_tool.py
@@ -1,20 +1,34 @@
-"""Unit tests for the query_graph MCP tool's error response format.
+"""Unit tests for the query_graph MCP tool helper functions.
 
-Tests the `_build_error_response` helper function which constructs the error
-response dict returned by the `query_graph` tool.
+Tests two extracted helpers from the `query_graph` MCP tool:
 
-The key contract under test:
+1. `_build_error_response` — constructs the error response dict.
+2. `_filter_internal_properties` — strips internal implementation properties
+   (e.g. `all_content_lower`) from query results before returning to agents.
+
+Key contracts under test:
+
+_build_error_response:
   - Forbidden errors include correlation_id (spec: keyword blacklist scenario).
   - Timeout errors include correlation_id (spec: query exceeds timeout scenario).
   - Execution errors omit correlation_id key (avoids misleading null).
   - Unknown errors omit correlation_id key.
   - Successful responses don't have correlation_id.
 
+_filter_internal_properties:
+  - `all_content_lower` is stripped from all dicts, including nested ones.
+  - Non-internal properties are preserved.
+  - Filtering is recursive: applies to dicts inside lists and dicts inside dicts.
+  - Scalars (int, str, bool, float, None) pass through unchanged.
+
 Note: `query_graph` is wrapped by `@mcp.tool` and cannot be called directly
-in unit tests. We test the extracted helper `_build_error_response` to verify
-the error-dict construction contract in isolation.
+in unit tests. We test the extracted helpers to verify their contracts in
+isolation.
 
 Spec references:
+  specs/query/mcp-server.spec.md
+  - Req: Graph Query Tool / Scenario: Internal property filtering
+    "THEN internal properties are stripped from the response"
   specs/query/query-execution.spec.md
   - Req: Read-Only Enforcement / Scenario: Keyword blacklist (secondary)
     "AND the error response includes a correlation ID for log lookup"
@@ -25,7 +39,7 @@ Spec references:
 from __future__ import annotations
 
 from query.domain.value_objects import QueryError
-from query.presentation.mcp import _build_error_response
+from query.presentation.mcp import _build_error_response, _filter_internal_properties
 
 
 class TestBuildErrorResponseForbiddenErrors:
@@ -242,3 +256,352 @@ class TestBuildErrorResponseBaseContract:
 
         assert "correlation_id" in result_with
         assert "correlation_id" not in result_without
+
+
+# ---------------------------------------------------------------------------
+# TestFilterInternalProperties
+# ---------------------------------------------------------------------------
+
+
+class TestFilterInternalPropertiesBasicFiltering:
+    """Basic filtering: flat dict with/without internal properties.
+
+    Spec: Graph Query Tool — Scenario: Internal property filtering
+    GIVEN query results containing internal properties (e.g., `all_content_lower`)
+    WHEN the results are returned to the client
+    THEN internal properties are stripped from the response
+    """
+
+    def test_strips_all_content_lower_from_flat_dict(self) -> None:
+        """all_content_lower MUST be stripped from a flat dict.
+
+        This is the primary internal property that the implementation currently
+        guards against. It is a concatenated lowercase search-index field that
+        must never be exposed to MCP clients.
+        """
+        data = {"all_content_lower": "foo", "name": "bar"}
+
+        result = _filter_internal_properties(data)
+
+        assert "all_content_lower" not in result
+        assert result == {"name": "bar"}
+
+    def test_preserves_non_internal_properties(self) -> None:
+        """Non-internal properties must be preserved unchanged."""
+        data = {"name": "Alice", "label": "Person", "age": 30}
+
+        result = _filter_internal_properties(data)
+
+        assert result == {"name": "Alice", "label": "Person", "age": 30}
+
+    def test_empty_dict_returns_empty_dict(self) -> None:
+        """An empty dict must remain an empty dict after filtering."""
+        result = _filter_internal_properties({})
+
+        assert result == {}
+
+    def test_dict_with_only_internal_props_returns_empty(self) -> None:
+        """A dict containing only internal properties becomes empty after filtering.
+
+        The empty dict is the correct result — stripping all internal
+        properties yields no remaining data.
+        """
+        data = {"all_content_lower": "alice engineer"}
+
+        result = _filter_internal_properties(data)
+
+        assert result == {}
+
+    def test_strips_all_defined_internal_properties(self) -> None:
+        """All properties in INTERNAL_PROPERTIES must be stripped.
+
+        Currently only `all_content_lower` is defined. This test asserts that
+        a dict containing this property alongside `name` produces a result
+        containing only `name`. When a second internal property is added to
+        INTERNAL_PROPERTIES in the future, this test should be updated to
+        verify it is also stripped.
+        """
+        data = {"all_content_lower": "alice", "name": "Alice"}
+
+        result = _filter_internal_properties(data)
+
+        assert "all_content_lower" not in result
+        assert result["name"] == "Alice"
+
+
+class TestFilterInternalPropertiesNodeDict:
+    """Node dict filtering — the primary use case.
+
+    Query results arrive as NodeDicts ({"node": {id, label, properties}}).
+    The `all_content_lower` field lives inside `properties`.
+    """
+
+    def test_strips_internal_props_from_node_dict(self) -> None:
+        """all_content_lower MUST be stripped from node properties.
+
+        Spec: Internal property filtering — `all_content_lower` is stripped
+        before returning results to the MCP client.
+        """
+        data = {
+            "node": {
+                "id": "1",
+                "label": "Person",
+                "properties": {
+                    "name": "Alice",
+                    "role": "Engineer",
+                    "all_content_lower": "alice engineer",
+                },
+            }
+        }
+
+        result = _filter_internal_properties(data)
+
+        node_props = result["node"]["properties"]
+        assert "all_content_lower" not in node_props
+        assert node_props["name"] == "Alice"
+        assert node_props["role"] == "Engineer"
+
+    def test_preserves_node_dict_structure(self) -> None:
+        """id, label, and non-internal properties MUST be preserved unchanged.
+
+        The filter must not alter the shape of the NodeDict — only strip
+        internal properties from `properties`.
+        """
+        data = {
+            "node": {
+                "id": "42",
+                "label": "Service",
+                "properties": {
+                    "name": "payment-service",
+                    "version": "1.0.0",
+                },
+            }
+        }
+
+        result = _filter_internal_properties(data)
+
+        node = result["node"]
+        assert node["id"] == "42"
+        assert node["label"] == "Service"
+        assert node["properties"]["name"] == "payment-service"
+        assert node["properties"]["version"] == "1.0.0"
+
+
+class TestFilterInternalPropertiesEdgeDict:
+    """Edge dict filtering.
+
+    EdgeDicts have the same `properties` nesting as NodeDicts.
+    `all_content_lower` must be stripped from edge properties while
+    preserving `id`, `label`, `start_id`, and `end_id`.
+    """
+
+    def test_strips_internal_props_from_edge_dict(self) -> None:
+        """all_content_lower MUST be stripped from edge properties.
+
+        Edge structural fields (id, label, start_id, end_id) must survive.
+        """
+        data = {
+            "edge": {
+                "id": "10",
+                "label": "DEPENDS_ON",
+                "start_id": "1",
+                "end_id": "2",
+                "properties": {
+                    "since": 2020,
+                    "all_content_lower": "depends on since 2020",
+                },
+            }
+        }
+
+        result = _filter_internal_properties(data)
+
+        edge = result["edge"]
+        assert "all_content_lower" not in edge["properties"]
+        assert edge["properties"]["since"] == 2020
+        assert edge["id"] == "10"
+        assert edge["label"] == "DEPENDS_ON"
+        assert edge["start_id"] == "1"
+        assert edge["end_id"] == "2"
+
+
+class TestFilterInternalPropertiesRecursion:
+    """Recursive filtering — dicts inside dicts, lists inside dicts.
+
+    `_filter_internal_properties` is a recursive function. It must
+    propagate filtering through arbitrarily nested data structures.
+    """
+
+    def test_filters_recursively_through_nested_dicts(self) -> None:
+        """Filtering must propagate into nested dicts.
+
+        A nested dict `{"a": {"all_content_lower": "x", "b": 1}}` must
+        produce `{"a": {"b": 1}}` — the inner `all_content_lower` is stripped.
+        """
+        data = {"a": {"all_content_lower": "x", "b": 1}}
+
+        result = _filter_internal_properties(data)
+
+        assert result == {"a": {"b": 1}}
+
+    def test_filters_recursively_through_lists(self) -> None:
+        """Filtering must propagate into items inside a list.
+
+        `[{"all_content_lower": "x"}, {"name": "foo"}]` must produce
+        `[{}, {"name": "foo"}]`.
+        """
+        data = [{"all_content_lower": "x"}, {"name": "foo"}]
+
+        result = _filter_internal_properties(data)
+
+        assert result == [{}, {"name": "foo"}]
+
+    def test_filters_list_inside_dict(self) -> None:
+        """A list nested inside a dict must be filtered recursively.
+
+        `{"items": [{"all_content_lower": "x", "n": 1}]}` must produce
+        `{"items": [{"n": 1}]}`.
+        """
+        data = {"items": [{"all_content_lower": "x", "n": 1}]}
+
+        result = _filter_internal_properties(data)
+
+        assert result == {"items": [{"n": 1}]}
+
+    def test_filters_deeply_nested_structure(self) -> None:
+        """Filtering must work at arbitrary nesting depth.
+
+        A three-level nesting with `all_content_lower` at the leaf level must
+        be stripped, while all other structure is preserved.
+        """
+        data = {
+            "outer": {
+                "inner": {
+                    "all_content_lower": "deep value",
+                    "id": "node-123",
+                }
+            }
+        }
+
+        result = _filter_internal_properties(data)
+
+        inner = result["outer"]["inner"]
+        assert "all_content_lower" not in inner
+        assert inner["id"] == "node-123"
+
+
+class TestFilterInternalPropertiesScalarPassThrough:
+    """Scalars pass through unchanged.
+
+    Filtering is a no-op for any non-dict, non-list value. This covers
+    integers, strings, booleans, floats, and None.
+    """
+
+    def test_scalars_pass_through_unchanged(self) -> None:
+        """Scalar values MUST be returned as-is without any modification."""
+        for value in (42, "hello", True, False, 3.14):
+            result = _filter_internal_properties(value)
+            assert result == value, (
+                f"Expected scalar {value!r} to pass through unchanged, "
+                f"but got {result!r}"
+            )
+
+    def test_none_passes_through(self) -> None:
+        """None MUST pass through unchanged.
+
+        None may appear as a property value or in optional fields.
+        The filter must not modify it.
+        """
+        result = _filter_internal_properties(None)
+
+        assert result is None
+
+    def test_integer_zero_passes_through(self) -> None:
+        """Zero (falsy integer) MUST pass through unchanged.
+
+        Ensures the implementation does not special-case falsy values.
+        """
+        result = _filter_internal_properties(0)
+
+        assert result == 0
+
+    def test_empty_string_passes_through(self) -> None:
+        """Empty string MUST pass through unchanged."""
+        result = _filter_internal_properties("")
+
+        assert result == ""
+
+
+class TestFilterInternalPropertiesRowStructure:
+    """Filtering applied to the full query result row shape.
+
+    The `query_graph` tool operates on `list[QueryResultRow]`. Each row is
+    a dict like `{"node": NodeDict}`, `{"edge": EdgeDict}`, or `{"value": scalar}`.
+    This class exercises the complete row-level filtering contract.
+    """
+
+    def test_filters_full_node_row(self) -> None:
+        """A complete node row with all_content_lower must have it stripped.
+
+        This simulates the actual row format produced by QueryGraphRepository.
+        """
+        rows = [
+            {
+                "node": {
+                    "id": "1",
+                    "label": "DocumentationModule",
+                    "properties": {
+                        "name": "install-guide",
+                        "content_summary": "A brief guide.",
+                        "all_content_lower": "install guide a brief guide.",
+                    },
+                }
+            }
+        ]
+
+        result = _filter_internal_properties(rows)
+
+        node_props = result[0]["node"]["properties"]
+        assert "all_content_lower" not in node_props
+        assert node_props["name"] == "install-guide"
+        assert node_props["content_summary"] == "A brief guide."
+
+    def test_scalar_row_passes_through_unchanged(self) -> None:
+        """A scalar row (e.g., count) must pass through without modification."""
+        rows = [{"value": 42}]
+
+        result = _filter_internal_properties(rows)
+
+        assert result == [{"value": 42}]
+
+    def test_multiple_rows_each_filtered(self) -> None:
+        """All rows in a multi-row result must be filtered individually."""
+        rows = [
+            {
+                "node": {
+                    "id": "1",
+                    "label": "Person",
+                    "properties": {
+                        "name": "Alice",
+                        "all_content_lower": "alice",
+                    },
+                }
+            },
+            {
+                "node": {
+                    "id": "2",
+                    "label": "Person",
+                    "properties": {
+                        "name": "Bob",
+                        "all_content_lower": "bob",
+                    },
+                }
+            },
+        ]
+
+        result = _filter_internal_properties(rows)
+
+        for row in result:
+            assert "all_content_lower" not in row["node"]["properties"]
+
+        assert result[0]["node"]["properties"]["name"] == "Alice"
+        assert result[1]["node"]["properties"]["name"] == "Bob"


### PR DESCRIPTION
## What & Why

The **Requirement: Graph Query Tool — Scenario: Internal property filtering** in
`specs/query/mcp-server.spec.md` states:

> GIVEN query results containing internal properties (e.g., `all_content_lower`)
> WHEN the results are returned to the client
> THEN internal properties are stripped from the response

The `_filter_internal_properties` helper in
`src/api/query/presentation/mcp.py` implements this correctly, but it has
**zero dedicated unit tests**. This is a spec coverage gap: no test can
currently catch a regression (e.g., forgetting to add a new internal
property to `INTERNAL_PROPERTIES`, or breaking recursive filtering).

The existing test file `tests/unit/query/test_mcp_query_tool.py` covers only
`_build_error_response`. This task adds a new test class for
`_filter_internal_properties` in that same file.

## Implementation Reference

```python
# src/api/query/presentation/mcp.py
INTERNAL_PROPERTIES = {"all_content_lower"}

def _filter_internal_properties(data: Any) -> Any:
    if isinstance(data, dict):
        return {
            k: _filter_internal_properties(v)
            for k, v in data.items()
            if k not in INTERNAL_PROPERTIES
        }
    elif isinstance(data, list):
        return [_filter_internal_properties(item) for item in data]
    else:
        return data
```

The function recursively filters `INTERNAL_PROPERTIES` from dicts, recurses
into lists, and passes scalars through unchanged.

## Spec Scenario

- GIVEN query results containing internal properties (e.g., `all_content_lower`)
- WHEN the results are returned to the client
- THEN internal properties are stripped from the response

## TDD Approach

Follow the project TDD pattern: write all tests FIRST (they will pass immediately
since the implementation already exists, but this confirms the spec is met), then
verify no regressions exist.

Write tests in `src/api/tests/unit/query/test_mcp_query_tool.py` as a new class
`TestFilterInternalProperties`.

## Test Cases Required

### Basic filtering
- `test_strips_all_content_lower_from_flat_dict`
  — `{"all_content_lower": "foo", "name": "bar"}` → `{"name": "bar"}`
- `test_preserves_non_internal_properties`
  — `{"name": "bar", "label": "baz"}` → unchanged

### Node dict filtering (the primary use case)
- `test_strips_internal_props_from_node_dict`
  — Node dict: `{"node": {"id": "1", "label": "Person", "properties":
    {"name": "Alice", "all_content_lower": "alice engineer"}}}` →
    `all_content_lower` stripped from properties, other fields intact
- `test_preserves_node_dict_structure`
  — `id`, `label`, and non-internal properties in `properties` are preserved

### Edge dict filtering
- `test_strips_internal_props_from_edge_dict`
  — Edge dict with `all_content_lower` in properties → stripped; `id`,
    `label`, `start_id`, `end_id` preserved

### Recursive filtering (map results)
- `test_filters_recursively_through_nested_dicts`
  — Nested dict: `{"a": {"all_content_lower": "x", "b": 1}}` →
    `{"a": {"b": 1}}`
- `test_filters_recursively_through_lists`
  — List: `[{"all_content_lower": "x"}, {"name": "foo"}]` →
    `[{}, {"name": "foo"}]`
- `test_filters_list_inside_dict`
  — `{"items": [{"all_content_lower": "x", "n": 1}]}` →
    `{"items": [{"n": 1}]}`

### Scalar pass-through
- `test_scalars_pass_through_unchanged`
  — `42`, `"hello"`, `True`, `None`, `3.14` all returned as-is
- `test_none_passes_through`
  — `None` → `None`

### Multiple internal properties (future-proofing)
- `test_strips_all_defined_internal_properties`
  — If `INTERNAL_PROPERTIES` contains more than one property, all are
    stripped. Test with `{"all_content_lower": "x", "name": "Alice"}` and
    assert only `name` remains; if a second internal property is ever added,
    update this test.

### Empty dict edge case
- `test_empty_dict_returns_empty_dict` — `{}` → `{}`
- `test_dict_with_only_internal_props_returns_empty` — `{"all_content_lower": "x"}` → `{}`

## Files Affected

- `src/api/tests/unit/query/test_mcp_query_tool.py`
  — add `TestFilterInternalProperties` class with the test cases above
- No implementation changes expected (implementation is correct)

## How to Verify

```bash
cd src/api && uv run pytest tests/unit/query/test_mcp_query_tool.py -v
```

All existing tests continue to pass. All new `TestFilterInternalProperties` tests
pass. No implementation changes needed (the function is already correct).

## Caveats

- `_filter_internal_properties` is a module-level private function in `mcp.py`.
  It can be imported directly for testing:
  `from query.presentation.mcp import _filter_internal_properties`
- The integration tests do not create nodes with `all_content_lower` properties,
  so they provide no regression protection for this scenario.
- If future requirements add more internal properties, update `INTERNAL_PROPERTIES`
  in `mcp.py` AND add a test case here.

---

**Task:** `task-094`
**Spec:** `specs/query/mcp-server.spec.md@2ac8d03afbf2153e3b569f1289e10b5ad5d21d6e`

### Merge

The orchestrator will squash-merge this PR automatically
once all pipeline steps pass.

---

This PR was created by [hyperloop](https://github.com/jsell-rh/hyperloop),
an AI agent orchestrator.