### PR TITLE
test(query): add MCPQueryService unit tests for all Error Categorization scenarios

### DIFF
--- a/src/api/tests/unit/query/test_mcp_query_service.py
+++ b/src/api/tests/unit/query/test_mcp_query_service.py
@@ -1,0 +1,555 @@
+"""Unit tests for MCPQueryService error categorization.
+
+Spec: specs/query/query-execution.spec.md
+Requirement: Error Categorization
+
+The system SHALL categorize query errors into distinct types for consumer
+handling. MCPQueryService.execute_cypher_query() is the application-layer
+component responsible for mapping repository exceptions to typed QueryError
+value objects.
+
+These tests exercise MCPQueryService in isolation using a FakeQueryRepository
+(not the real QueryGraphRepository or a MagicMock) per the project's
+testing philosophy of "fakes over mocks" for port collaborators.
+
+If the except clauses in execute_cypher_query() were accidentally reordered,
+merged, or their error_type strings changed, these tests would catch it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from query.application.services import MCPQueryService
+from query.domain.value_objects import (
+    CypherQueryResult,
+    NodeDict,
+    QueryError,
+    QueryExecutionError,
+    QueryForbiddenError,
+    QueryResultRow,
+    QueryTimeoutError,
+)
+from query.ports.repositories import IQueryGraphRepository
+
+
+# ---------------------------------------------------------------------------
+# Fakes — no MagicMock for domain/application collaborators
+# ---------------------------------------------------------------------------
+
+
+class FakeQueryRepository:
+    """Fake IQueryGraphRepository that raises a configurable exception or returns rows.
+
+    Using a fake rather than MagicMock per testing.spec.md: "mocking is NOT
+    acceptable for repositories or probe protocols."
+    """
+
+    def __init__(
+        self,
+        rows: list[QueryResultRow] | None = None,
+        raises: Exception | None = None,
+    ) -> None:
+        self._rows: list[QueryResultRow] = rows or []
+        self._raises = raises
+
+    def execute_cypher(
+        self,
+        query: str,
+        timeout_seconds: int = 30,
+        max_rows: int = 1000,
+    ) -> list[QueryResultRow]:
+        if self._raises is not None:
+            raise self._raises
+        return self._rows
+
+
+# Verify the fake satisfies the runtime-checkable protocol.
+assert isinstance(FakeQueryRepository(), IQueryGraphRepository)
+
+
+class FakeQueryServiceProbe:
+    """Fake QueryServiceProbe that records calls without side effects.
+
+    Structured fakes are preferred over MagicMock for probe collaborators.
+    """
+
+    def __init__(self) -> None:
+        self.received_calls: list[dict] = []
+        self.executed_calls: list[dict] = []
+        self.rejected_calls: list[dict] = []
+        self.failed_calls: list[dict] = []
+
+    def cypher_query_received(self, query: str, query_length: int) -> None:
+        self.received_calls.append({"query": query, "query_length": query_length})
+
+    def cypher_query_executed(
+        self,
+        query: str,
+        row_count: int,
+        execution_time_ms: float,
+        truncated: bool,
+    ) -> None:
+        self.executed_calls.append(
+            {
+                "query": query,
+                "row_count": row_count,
+                "execution_time_ms": execution_time_ms,
+                "truncated": truncated,
+            }
+        )
+
+    def cypher_query_rejected(
+        self,
+        query: str,
+        reason: str,
+        correlation_id: str | None = None,
+    ) -> None:
+        self.rejected_calls.append(
+            {"query": query, "reason": reason, "correlation_id": correlation_id}
+        )
+
+    def cypher_query_failed(
+        self,
+        query: str,
+        error: str,
+        correlation_id: str | None = None,
+    ) -> None:
+        self.failed_calls.append(
+            {"query": query, "error": error, "correlation_id": correlation_id}
+        )
+
+    def with_context(self, context) -> FakeQueryServiceProbe:  # type: ignore[override]
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def probe() -> FakeQueryServiceProbe:
+    """Fresh FakeQueryServiceProbe for each test."""
+    return FakeQueryServiceProbe()
+
+
+def make_service(
+    rows: list[QueryResultRow] | None = None,
+    raises: Exception | None = None,
+    probe: FakeQueryServiceProbe | None = None,
+) -> MCPQueryService:
+    """Convenience factory: wire MCPQueryService with a fake repository."""
+    repo = FakeQueryRepository(rows=rows, raises=raises)
+    return MCPQueryService(
+        repository=repo,
+        probe=probe,
+        default_timeout_seconds=30,
+        default_max_rows=1000,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Requirement: Error Categorization — four spec scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestErrorCategorization:
+    """Error categorization scenarios from specs/query/query-execution.spec.md.
+
+    Each test maps to one spec scenario in Requirement: Error Categorization.
+    """
+
+    # Scenario: Forbidden query
+    def test_forbidden_error_type_when_repo_raises_query_forbidden_error(self):
+        """GIVEN a query containing mutation keywords
+        THEN the error type is "forbidden".
+
+        Spec: Error Categorization — Forbidden query scenario.
+        """
+        exc = QueryForbiddenError(
+            "Query must be read-only. Found forbidden keyword: CREATE",
+            query="CREATE (n:Test)",
+            correlation_id="corr-forbidden-1",
+        )
+        service = make_service(raises=exc)
+
+        result = service.execute_cypher_query("CREATE (n:Test)")
+
+        assert isinstance(result, QueryError)
+        assert result.error_type == "forbidden"
+
+    def test_forbidden_error_preserves_correlation_id(self):
+        """Correlation ID from QueryForbiddenError MUST be propagated to QueryError.
+
+        Spec: Keyword blacklist scenario — error response includes a correlation ID.
+        """
+        exc = QueryForbiddenError(
+            "Forbidden keyword: CREATE",
+            query="CREATE (n:Test)",
+            correlation_id="corr-forbidden-preserved",
+        )
+        service = make_service(raises=exc)
+
+        result = service.execute_cypher_query("CREATE (n:Test)")
+
+        assert isinstance(result, QueryError)
+        assert result.correlation_id == "corr-forbidden-preserved"
+
+    def test_forbidden_error_message_is_propagated(self):
+        """Error message should be present in QueryError."""
+        exc = QueryForbiddenError(
+            "Query must be read-only. Found forbidden keyword: DELETE",
+        )
+        service = make_service(raises=exc)
+
+        result = service.execute_cypher_query("MATCH (n) DELETE n")
+
+        assert isinstance(result, QueryError)
+        assert "DELETE" in result.message or "read-only" in result.message.lower()
+
+    # Scenario: Timeout error
+    def test_timeout_error_type_when_repo_raises_query_timeout_error(self):
+        """GIVEN a query that exceeds the timeout
+        THEN the error type is "timeout".
+
+        Spec: Error Categorization — Timeout error scenario.
+        """
+        exc = QueryTimeoutError(
+            "Query exceeded 30s timeout",
+            query="MATCH (n) RETURN n",
+            correlation_id="corr-timeout-1",
+        )
+        service = make_service(raises=exc)
+
+        result = service.execute_cypher_query("MATCH (n) RETURN n")
+
+        assert isinstance(result, QueryError)
+        assert result.error_type == "timeout"
+
+    def test_timeout_error_preserves_correlation_id(self):
+        """Correlation ID from QueryTimeoutError MUST be propagated to QueryError.
+
+        Spec: Query exceeds timeout — error returned with a correlation ID for debugging.
+        """
+        exc = QueryTimeoutError(
+            "Query exceeded timeout",
+            query="MATCH (n) RETURN n",
+            correlation_id="corr-timeout-preserved",
+        )
+        service = make_service(raises=exc)
+
+        result = service.execute_cypher_query("MATCH (n) RETURN n")
+
+        assert isinstance(result, QueryError)
+        assert result.correlation_id == "corr-timeout-preserved"
+
+    def test_timeout_error_without_correlation_id(self):
+        """Timeout errors without a correlation_id should still return error_type timeout."""
+        exc = QueryTimeoutError("Query exceeded timeout")
+        service = make_service(raises=exc)
+
+        result = service.execute_cypher_query("MATCH (n) RETURN n")
+
+        assert isinstance(result, QueryError)
+        assert result.error_type == "timeout"
+
+    # Scenario: Execution error
+    def test_execution_error_type_when_repo_raises_query_execution_error(self):
+        """GIVEN a query with a syntax error or runtime failure
+        THEN the error type is "execution_error".
+
+        Spec: Error Categorization — Execution error scenario.
+        """
+        exc = QueryExecutionError(
+            "Syntax error in query",
+            query="MATCH (n RETURN n",
+        )
+        service = make_service(raises=exc)
+
+        result = service.execute_cypher_query("MATCH (n RETURN n")
+
+        assert isinstance(result, QueryError)
+        assert result.error_type == "execution_error"
+
+    def test_execution_error_has_no_correlation_id_by_default(self):
+        """QueryExecutionError does not carry a correlation_id (unlike forbidden/timeout).
+
+        The correlation_id is used for redacted-log cross-reference and is
+        only relevant for forbidden and timeout errors.
+        """
+        exc = QueryExecutionError("Syntax error", query="MATCH (n RETURN n")
+        service = make_service(raises=exc)
+
+        result = service.execute_cypher_query("MATCH (n RETURN n")
+
+        assert isinstance(result, QueryError)
+        assert result.error_type == "execution_error"
+        assert result.correlation_id is None
+
+    def test_execution_error_message_includes_original_error(self):
+        """Execution error message should reference the original failure."""
+        exc = QueryExecutionError("Tenant graph 'tenant_xyz' does not exist.")
+        service = make_service(raises=exc)
+
+        result = service.execute_cypher_query("MATCH (n) RETURN n")
+
+        assert isinstance(result, QueryError)
+        assert "does not exist" in result.message or "tenant" in result.message.lower()
+
+    # Scenario: Unexpected error
+    def test_unknown_error_type_when_repo_raises_unexpected_exception(self):
+        """GIVEN an unexpected failure during query execution
+        THEN the error type is "unknown_error".
+
+        Spec: Error Categorization — Unexpected error scenario.
+        """
+        exc = RuntimeError("Unexpected DB connection failure")
+        service = make_service(raises=exc)
+
+        result = service.execute_cypher_query("MATCH (n) RETURN n")
+
+        assert isinstance(result, QueryError)
+        assert result.error_type == "unknown_error"
+
+    def test_unknown_error_for_value_error(self):
+        """ValueError (unexpected) should be categorised as unknown_error."""
+        service = make_service(raises=ValueError("Unexpected value error"))
+
+        result = service.execute_cypher_query("MATCH (n) RETURN n")
+
+        assert isinstance(result, QueryError)
+        assert result.error_type == "unknown_error"
+
+    def test_unknown_error_for_type_error(self):
+        """TypeError (unexpected) should be categorised as unknown_error."""
+        service = make_service(raises=TypeError("Unexpected type error"))
+
+        result = service.execute_cypher_query("MATCH (n) RETURN n")
+
+        assert isinstance(result, QueryError)
+        assert result.error_type == "unknown_error"
+
+    def test_unknown_error_has_no_correlation_id(self):
+        """Unexpected errors carry no correlation_id."""
+        service = make_service(raises=RuntimeError("Something broke"))
+
+        result = service.execute_cypher_query("MATCH (n) RETURN n")
+
+        assert isinstance(result, QueryError)
+        assert result.correlation_id is None
+
+    def test_error_categorization_ordering_matters(self):
+        """QueryForbiddenError and QueryTimeoutError are QueryExecutionError subclasses.
+
+        The service MUST catch them in the correct order: subclasses before the
+        base class. If QueryExecutionError is caught first, forbidden/timeout errors
+        would be swallowed and returned with error_type="execution_error".
+
+        This test verifies ordering by checking that a QueryForbiddenError (which IS-A
+        QueryExecutionError) produces error_type="forbidden" not "execution_error".
+        """
+        exc = QueryForbiddenError("Mutation keyword detected")
+        service = make_service(raises=exc)
+
+        result = service.execute_cypher_query("CREATE (n)")
+
+        assert isinstance(result, QueryError)
+        assert result.error_type == "forbidden", (
+            "QueryForbiddenError must be caught before the base QueryExecutionError. "
+            f"Got error_type={result.error_type!r} instead of 'forbidden'. "
+            "Check except clause ordering in execute_cypher_query()."
+        )
+
+    def test_timeout_categorization_before_base_exception(self):
+        """QueryTimeoutError IS-A QueryExecutionError — must be caught separately."""
+        exc = QueryTimeoutError("DB cancelled statement due to timeout")
+        service = make_service(raises=exc)
+
+        result = service.execute_cypher_query("MATCH (n) RETURN n")
+
+        assert isinstance(result, QueryError)
+        assert result.error_type == "timeout", (
+            "QueryTimeoutError must be caught before the base QueryExecutionError. "
+            f"Got error_type={result.error_type!r} instead of 'timeout'."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Requirement: Timeout Enforcement — happy path (Query within timeout)
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessfulExecution:
+    """Tests for successful query execution (Timeout Enforcement — happy path)."""
+
+    def test_returns_cypher_query_result_on_success(self):
+        """GIVEN a query that completes within the timeout
+        WHEN the query executes
+        THEN results are returned normally (CypherQueryResult, not QueryError).
+
+        Spec: Timeout Enforcement — Query within timeout scenario.
+        """
+        node: NodeDict = {  # type: ignore[assignment]
+            "id": "1",
+            "label": "Person",
+            "properties": {"name": "Alice"},
+        }
+        rows: list[QueryResultRow] = [{"node": node}]
+        service = make_service(rows=rows)
+
+        result = service.execute_cypher_query("MATCH (n) RETURN n")
+
+        assert isinstance(result, CypherQueryResult)
+        assert result.row_count == 1
+        assert result.rows == rows
+
+    def test_success_result_is_not_truncated_for_small_result_set(self):
+        """Results below the limit should not be marked as truncated."""
+        rows: list[QueryResultRow] = [{"value": i} for i in range(5)]
+        service = make_service(rows=rows)
+
+        result = service.execute_cypher_query("MATCH (n) RETURN n")
+
+        assert isinstance(result, CypherQueryResult)
+        assert result.truncated is False
+
+    def test_success_result_tracks_execution_time(self):
+        """Successful result should include execution_time_ms."""
+        service = make_service(rows=[])
+
+        result = service.execute_cypher_query("MATCH (n) RETURN n")
+
+        assert isinstance(result, CypherQueryResult)
+        assert result.execution_time_ms is not None
+        assert result.execution_time_ms >= 0
+
+    def test_empty_result_set_is_valid(self):
+        """Empty result set is a normal successful execution."""
+        service = make_service(rows=[])
+
+        result = service.execute_cypher_query("MATCH (n:NonExistent) RETURN n")
+
+        assert isinstance(result, CypherQueryResult)
+        assert result.row_count == 0
+        assert result.rows == []
+
+
+# ---------------------------------------------------------------------------
+# Observability: probe is called correctly
+# ---------------------------------------------------------------------------
+
+
+class TestProbeObservability:
+    """Tests verifying Domain-Oriented Observability probe behaviour.
+
+    Each error path should call the appropriate probe method with correct args.
+    """
+
+    def test_probe_cypher_query_received_called_on_every_invocation(
+        self, probe: FakeQueryServiceProbe
+    ) -> None:
+        """Probe must record every incoming query."""
+        service = make_service(rows=[], probe=probe)
+
+        service.execute_cypher_query("MATCH (n) RETURN n")
+
+        assert len(probe.received_calls) == 1
+        assert probe.received_calls[0]["query"] == "MATCH (n) RETURN n"
+
+    def test_probe_cypher_query_executed_called_on_success(
+        self, probe: FakeQueryServiceProbe
+    ) -> None:
+        """Probe records execution on successful path."""
+        service = make_service(rows=[{"value": 1}], probe=probe)
+
+        service.execute_cypher_query("MATCH (n) RETURN n")
+
+        assert len(probe.executed_calls) == 1
+        assert probe.executed_calls[0]["row_count"] == 1
+
+    def test_probe_cypher_query_rejected_called_on_forbidden(
+        self, probe: FakeQueryServiceProbe
+    ) -> None:
+        """Probe records rejection for forbidden queries.
+
+        Spec: Keyword blacklist — a redacted reference is logged.
+        """
+        exc = QueryForbiddenError(
+            "Forbidden keyword: CREATE",
+            query="CREATE (n)",
+            correlation_id="c-1",
+        )
+        service = make_service(raises=exc, probe=probe)
+
+        service.execute_cypher_query("CREATE (n)")
+
+        assert len(probe.rejected_calls) == 1
+        assert probe.rejected_calls[0]["correlation_id"] == "c-1"
+
+    def test_probe_cypher_query_rejected_not_called_on_other_errors(
+        self, probe: FakeQueryServiceProbe
+    ) -> None:
+        """cypher_query_rejected must NOT be called for non-forbidden errors."""
+        service = make_service(raises=QueryTimeoutError("Timeout"), probe=probe)
+
+        service.execute_cypher_query("MATCH (n) RETURN n")
+
+        assert len(probe.rejected_calls) == 0
+
+    def test_probe_cypher_query_failed_called_on_timeout(
+        self, probe: FakeQueryServiceProbe
+    ) -> None:
+        """Probe records failure with correlation_id on timeout."""
+        exc = QueryTimeoutError(
+            "Query timed out",
+            query="MATCH (n) RETURN n",
+            correlation_id="t-1",
+        )
+        service = make_service(raises=exc, probe=probe)
+
+        service.execute_cypher_query("MATCH (n) RETURN n")
+
+        assert len(probe.failed_calls) == 1
+        assert probe.failed_calls[0]["correlation_id"] == "t-1"
+
+    def test_probe_cypher_query_failed_called_on_execution_error(
+        self, probe: FakeQueryServiceProbe
+    ) -> None:
+        """Probe records failure for execution errors."""
+        exc = QueryExecutionError("Syntax error")
+        service = make_service(raises=exc, probe=probe)
+
+        service.execute_cypher_query("MATCH (n RETURN n")
+
+        assert len(probe.failed_calls) == 1
+
+    def test_probe_cypher_query_failed_called_on_unknown_error(
+        self, probe: FakeQueryServiceProbe
+    ) -> None:
+        """Probe records failure for unexpected errors."""
+        service = make_service(raises=RuntimeError("Unexpected"), probe=probe)
+
+        service.execute_cypher_query("MATCH (n) RETURN n")
+
+        assert len(probe.failed_calls) == 1
+
+    def test_probe_not_called_with_raw_query_on_rejection(
+        self, probe: FakeQueryServiceProbe
+    ) -> None:
+        """The probe's rejected_calls record query, but DefaultQueryServiceProbe
+        MUST NOT forward the raw query to the logger (separate contract tested
+        in TestDefaultQueryServiceProbe in test_application_services.py).
+
+        This test verifies the probe receives the query argument (so the impl
+        can use it for correlation without logging it).
+        """
+        raw_query = "CREATE (n:Secret {password: 's3cr3t'})"
+        exc = QueryForbiddenError("Forbidden keyword: CREATE")
+        service = make_service(raises=exc, probe=probe)
+
+        service.execute_cypher_query(raw_query)
+
+        # Probe is called with the query for correlation purposes
+        assert len(probe.rejected_calls) == 1
+        assert probe.rejected_calls[0]["query"] == raw_query


### PR DESCRIPTION
## What & Why

The **Requirement: Error Categorization** in `specs/query/query-execution.spec.md`
specifies four distinct error types that the system must produce:

| Spec scenario | Error type |
|---|---|
| Query containing mutation keywords | `"forbidden"` |
| Query that exceeds the timeout | `"timeout"` |
| Query with syntax error or runtime failure | `"execution_error"` |
| Unexpected failure during query execution | `"unknown_error"` |

The application service layer (`MCPQueryService`) is the component responsible for
converting repository exceptions into typed `QueryError` value objects. Currently:

- `QueryGraphRepository` raises `QueryForbiddenError`, `QueryTimeoutError`,
  `QueryExecutionError`, or generic `Exception` for each scenario.
- `MCPQueryService.execute_cypher_query()` catches each exception type and maps it
  to the corresponding `error_type` string.
- The MCP presentation layer (`mcp.py`) reads the `error_type` from the `QueryError`
  and includes it in the JSON response.

**The gap**: `MCPQueryService` has no dedicated unit test file. The service's
error categorisation contract is only tested indirectly:

- `test_query_repository.py` — tests the repository raises the right exceptions
- `test_mcp_query_tool.py` — tests `_build_error_response()` (presentation layer
  helper) converts `QueryError` objects to response dicts

Neither test file exercises `MCPQueryService` in isolation with a fake repository.
If the `except` clauses in `execute_cypher_query()` were accidentally reordered or
one was removed, existing tests would not catch it.

## What This PR Does

### 1. Create `tests/unit/query/test_mcp_query_service.py`

TDD: write all tests before any implementation changes. Use a `FakeQueryRepository`
that raises configurable exceptions.

```python
class FakeQueryRepository(IQueryGraphRepository):
    """Fake repository that raises a pre-configured exception or returns rows."""

    def __init__(
        self,
        rows: list | None = None,
        raises: Exception | None = None,
    ) -> None:
        self._rows = rows or []
        self._raises = raises

    def execute_cypher(self, query: str, timeout_seconds: int = 30, max_rows: int = 1000):
        if self._raises is not None:
            raise self._raises
        return self._rows
```

### 2. Error Categorization tests (four spec scenarios)

**Scenario: Forbidden query → error_type "forbidden"**

```python
def test_forbidden_error_type_when_repo_raises_query_forbidden_error():
    repo = FakeQueryRepository(raises=QueryForbiddenError(
        "Forbidden keyword", query="CREATE (n)", correlation_id="corr-1"
    ))
    service = MCPQueryService(repository=repo)
    result = service.execute_cypher_query(query="CREATE (n)")
    assert isinstance(result, QueryError)
    assert result.error_type == "forbidden"
    assert result.correlation_id == "corr-1"
```

**Scenario: Timeout error → error_type "timeout"**

```python
def test_timeout_error_type_when_repo_raises_query_timeout_error():
    repo = FakeQueryRepository(raises=QueryTimeoutError(
        "Query timed out", query="MATCH (n) RETURN n", correlation_id="corr-2"
    ))
    service = MCPQueryService(repository=repo)
    result = service.execute_cypher_query(query="MATCH (n) RETURN n")
    assert isinstance(result, QueryError)
    assert result.error_type == "timeout"
    assert result.correlation_id == "corr-2"
```

**Scenario: Execution error → error_type "execution_error"**

```python
def test_execution_error_type_when_repo_raises_query_execution_error():
    repo = FakeQueryRepository(raises=QueryExecutionError(
        "Syntax error", query="MATCH (n RETURN n"
    ))
    service = MCPQueryService(repository=repo)
    result = service.execute_cypher_query(query="MATCH (n RETURN n")
    assert isinstance(result, QueryError)
    assert result.error_type == "execution_error"
    assert result.correlation_id is None
```

**Scenario: Unexpected error → error_type "unknown_error"**

```python
def test_unknown_error_type_when_repo_raises_unexpected_exception():
    repo = FakeQueryRepository(raises=RuntimeError("Unexpected DB failure"))
    service = MCPQueryService(repository=repo)
    result = service.execute_cypher_query(query="MATCH (n) RETURN n")
    assert isinstance(result, QueryError)
    assert result.error_type == "unknown_error"
    assert result.correlation_id is None
```

### 3. Successful query test (Requirement: Timeout Enforcement — happy path)

The spec states "Query within timeout → results returned normally." This tests that
the service returns a `CypherQueryResult` (not `QueryError`) when the repository
succeeds:

```python
def test_returns_cypher_query_result_on_success():
    from query.domain.value_objects import NodeDict
    node = NodeDict(id="1", label="Person", properties={"name": "Alice"})
    repo = FakeQueryRepository(rows=[{"node": node}])
    service = MCPQueryService(repository=repo)
    result = service.execute_cypher_query(query="MATCH (n) RETURN n")
    assert isinstance(result, CypherQueryResult)
    assert result.row_count == 1
    assert result.rows == [{"node": node}]
    assert result.truncated is False or result.truncated is True  # depends on limit
```

### 4. Probe observability tests

Verify the domain probe is called correctly (Domain-Oriented Observability pattern):

```python
def test_probe_cypher_query_received_called():
    """Probe records the incoming query."""
    probe = MagicMock(spec=QueryServiceProbe)
    repo = FakeQueryRepository(rows=[])
    service = MCPQueryService(repository=repo, probe=probe)
    service.execute_cypher_query(query="MATCH (n) RETURN n")
    probe.cypher_query_received.assert_called_once()

def test_probe_cypher_query_rejected_called_on_forbidden():
    """Probe records rejection with correlation_id."""
    probe = MagicMock(spec=QueryServiceProbe)
    repo = FakeQueryRepository(raises=QueryForbiddenError(
        "Forbidden", query="CREATE", correlation_id="c-1"
    ))
    service = MCPQueryService(repository=repo, probe=probe)
    service.execute_cypher_query(query="CREATE")
    probe.cypher_query_rejected.assert_called_once()
    call_kwargs = probe.cypher_query_rejected.call_args.kwargs
    assert call_kwargs.get("correlation_id") == "c-1"

def test_probe_cypher_query_failed_called_on_timeout():
    """Probe records failure with correlation_id on timeout."""
    probe = MagicMock(spec=QueryServiceProbe)
    repo = FakeQueryRepository(raises=QueryTimeoutError(
        "Timeout", query="MATCH (n) RETURN n", correlation_id="t-1"
    ))
    service = MCPQueryService(repository=repo, probe=probe)
    service.execute_cypher_query(query="MATCH (n) RETURN n")
    probe.cypher_query_failed.assert_called_once()
    call_kwargs = probe.cypher_query_failed.call_args.kwargs
    assert call_kwargs.get("correlation_id") == "t-1"
```

## Files Affected

- `src/api/tests/unit/query/test_mcp_query_service.py` — **new test file** with
  all tests listed above
- `src/api/query/application/services.py` — no changes expected; if any test fails,
  fix the service implementation (TDD: tests are authoritative)
- `src/api/query/domain/value_objects.py` — no changes expected

## How to Verify

1. `cd src/api && uv run pytest tests/unit/query/test_mcp_query_service.py -v`
   All new tests must pass (RED → GREEN cycle).
2. `cd src/api && uv run pytest tests/unit/query/ -v` — no regressions.
3. Trace each spec scenario to the test that covers it:
   - Forbidden query → `test_forbidden_error_type_when_repo_raises_query_forbidden_error`
   - Timeout → `test_timeout_error_type_when_repo_raises_query_timeout_error`
   - Execution error → `test_execution_error_type_when_repo_raises_query_execution_error`
   - Unexpected error → `test_unknown_error_type_when_repo_raises_unexpected_exception`

## Design Decisions

- **`FakeQueryRepository` not `MockRepository`**: Per the project's testing philosophy,
  fakes are preferred over mocks for ports (repository interfaces). The fake implements
  `IQueryGraphRepository` and raises a configurable exception, making tests readable
  without `MagicMock.side_effect` boilerplate.
- **Service layer isolation**: These tests exercise `MCPQueryService` in isolation,
  independent of the actual `QueryGraphRepository`, the AGE database, or the MCP
  presentation layer. This makes them fast and deterministic.
- **Correlation_id propagation**: `QueryForbiddenError` and `QueryTimeoutError` carry
  a `correlation_id` attribute set by the repository. The service must propagate this
  into the returned `QueryError`. These tests verify the propagation, complementing
  the repository-level tests that verify generation and the presentation-level tests
  that verify inclusion in the JSON response.
- **No mock for `DefaultQueryServiceProbe`**: Tests that don't verify probe behaviour
  use `MCPQueryService(repository=repo)` without a probe argument, relying on the
  `DefaultQueryServiceProbe` no-op. Tests verifying probe behaviour pass a `MagicMock`
  with `spec=QueryServiceProbe` so typos in probe method names are caught.

## Spec Requirement Coverage

**Requirement: Error Categorization** from `specs/query/query-execution.spec.md`:

| Scenario | Test |
|---|---|
| Forbidden query → `"forbidden"` | `test_forbidden_error_type_when_repo_raises_query_forbidden_error` |
| Timeout → `"timeout"` | `test_timeout_error_type_when_repo_raises_query_timeout_error` |
| Execution error → `"execution_error"` | `test_execution_error_type_when_repo_raises_query_execution_error` |
| Unexpected failure → `"unknown_error"` | `test_unknown_error_type_when_repo_raises_unexpected_exception` |

**Requirement: Timeout Enforcement — Scenario: Query within timeout** from
`specs/query/query-execution.spec.md`:

| Scenario | Test |
|---|---|
| Query within timeout → results returned normally | `test_returns_cypher_query_result_on_success` |

## Gap Analysis

`MCPQueryService.execute_cypher_query()` has four `except` clauses corresponding
to the four spec scenarios. Prior to this task, no unit test exercised the service
layer directly. If a future refactor accidentally merged two clauses or changed an
`error_type` string, no existing test would catch it. This task closes that gap with
direct, isolated unit tests.

Related tasks:
- task-088: Adds `correlation_id` to MCP error response dict (presentation layer)
- task-090: Per-tenant graph routing (infrastructure layer)
- The repository-level exception raising is tested in `test_query_repository.py`

## TDD Cycle

1. Create `src/api/tests/unit/query/test_mcp_query_service.py` with the tests above.
2. Run `cd src/api && uv run pytest tests/unit/query/test_mcp_query_service.py -v`
3. If all tests pass immediately (GREEN without code changes) — the implementation
   is correct; commit.
4. If any test fails — fix `MCPQueryService` to satisfy the failing test; re-run.
5. Commit atomically.

---

**Task:** `task-095`
**Spec:** `specs/query/query-execution.spec.md@dbcf0d7c2fa9c2456896ee20adbfdc8cc33090c2`

### Merge

The orchestrator will squash-merge this PR automatically
once all pipeline steps pass.

---

This PR was created by [hyperloop](https://github.com/jsell-rh/hyperloop),
an AI agent orchestrator.