### PR TITLE
fix(query): implement fetch-limit+1 truncation detection in MCPQueryService

### DIFF
--- a/src/api/query/application/services.py
+++ b/src/api/query/application/services.py
@@ -69,14 +69,23 @@ class MCPQueryService:
         start_time = time.perf_counter()
 
         try:
+            # Fetch one extra row to detect truncation without a false positive.
+            # Spec: "the server SHOULD fetch `limit + 1` rows and set `truncated`
+            # to true only if more than `limit` rows were available".
             rows = self._repository.execute_cypher(
                 query=query,
                 timeout_seconds=timeout,
-                max_rows=limit,
+                max_rows=limit + 1,
             )
 
             elapsed_ms = (time.perf_counter() - start_time) * 1000
-            truncated = len(rows) >= limit
+
+            # True only when a (limit+1)-th row actually exists
+            truncated = len(rows) > limit
+            if truncated:
+                # Return at most `limit` rows (spec: "the response returns
+                # at most `limit` rows")
+                rows = rows[:limit]
 
             self._probe.cypher_query_executed(
                 query=query,

--- a/src/api/tests/unit/query/test_application_services.py
+++ b/src/api/tests/unit/query/test_application_services.py
@@ -287,24 +287,32 @@ class TestExecuteCypherQuery:
         service: MCPQueryService,
         fake_repository: FakeQueryGraphRepository,
     ) -> None:
-        """Should use default max_rows when not specified."""
+        """Service requests limit + 1 rows from the repository (fetch-one-more strategy).
+
+        Spec: Result Truncation Flag — the server SHOULD fetch `limit + 1` rows.
+        When the default limit is 1000, the repository receives max_rows=1001.
+        """
         fake_repository.return_value = []
 
         service.execute_cypher_query("MATCH (n) RETURN n")
 
-        assert fake_repository.last_call["max_rows"] == 1000
+        assert fake_repository.last_call["max_rows"] == 1001
 
     def test_uses_custom_max_rows(
         self,
         service: MCPQueryService,
         fake_repository: FakeQueryGraphRepository,
     ) -> None:
-        """Should use custom max_rows when specified."""
+        """Service requests limit + 1 rows from the repository for custom limits.
+
+        Spec: Result Truncation Flag — the server SHOULD fetch `limit + 1` rows.
+        When the caller specifies limit=500, the repository receives max_rows=501.
+        """
         fake_repository.return_value = []
 
         service.execute_cypher_query("MATCH (n) RETURN n", max_rows=500)
 
-        assert fake_repository.last_call["max_rows"] == 500
+        assert fake_repository.last_call["max_rows"] == 501
 
     def test_records_query_received_observation(
         self,
@@ -341,13 +349,60 @@ class TestExecuteCypherQuery:
         service: MCPQueryService,
         fake_repository: FakeQueryGraphRepository,
     ) -> None:
-        """Should mark as truncated when row count equals limit."""
-        fake_repository.return_value = [{"n": i} for i in range(1000)]
+        """Should mark as truncated when repository returns limit + 1 rows.
+
+        Spec: Result Truncation Flag — the server SHOULD fetch `limit + 1`
+        rows and set `truncated` to true only if more than `limit` rows were
+        available.  The service asks for 1001 rows (limit + 1); when the DB
+        returns 1001, more data exists, so truncated = True.
+        """
+        # Service will request max_rows = limit + 1 = 1001; fake returns 1001
+        fake_repository.return_value = [{"n": i} for i in range(1001)]
 
         result = service.execute_cypher_query("MATCH (n) RETURN n")
 
         assert isinstance(result, CypherQueryResult)
         assert result.truncated is True
+
+    def test_not_truncated_when_exactly_at_limit(
+        self,
+        service: MCPQueryService,
+        fake_repository: FakeQueryGraphRepository,
+    ) -> None:
+        """Should NOT mark as truncated when the DB returns exactly `limit` rows.
+
+        Spec: Result Truncation Flag — truncated should be True *only* when
+        more rows are available.  When exactly 1000 rows exist (the service
+        fetches 1001 but only 1000 are returned), there are no additional rows,
+        so truncated = False.  This is the false-positive case the spec guards against.
+        """
+        # Service requests 1001 rows; DB has exactly 1000 → no more data
+        fake_repository.return_value = [{"n": i} for i in range(1000)]
+
+        result = service.execute_cypher_query("MATCH (n) RETURN n")
+
+        assert isinstance(result, CypherQueryResult)
+        assert result.truncated is False
+
+    def test_truncated_result_trimmed_to_limit(
+        self,
+        service: MCPQueryService,
+        fake_repository: FakeQueryGraphRepository,
+    ) -> None:
+        """Should trim rows to `limit` when truncated.
+
+        Spec: AND the response returns at most `limit` rows.
+        When the DB returns 1001 rows (confirming truncation), the result
+        must contain exactly 1000 rows — not 1001.
+        """
+        # Service requests 1001 rows; DB returns 1001 (there are more)
+        fake_repository.return_value = [{"n": i} for i in range(1001)]
+
+        result = service.execute_cypher_query("MATCH (n) RETURN n")
+
+        assert isinstance(result, CypherQueryResult)
+        assert result.truncated is True
+        assert len(result.rows) == 1000
 
     def test_not_truncated_when_below_limit(
         self,
@@ -361,6 +416,23 @@ class TestExecuteCypherQuery:
 
         assert isinstance(result, CypherQueryResult)
         assert result.truncated is False
+
+    def test_requests_limit_plus_one_from_repository(
+        self,
+        service: MCPQueryService,
+        fake_repository: FakeQueryGraphRepository,
+    ) -> None:
+        """Service MUST request limit + 1 rows from the repository.
+
+        Spec: Result Truncation Flag — the server SHOULD fetch `limit + 1`
+        rows to determine whether more data exists without over-fetching.
+        """
+        fake_repository.return_value = []
+
+        service.execute_cypher_query("MATCH (n) RETURN n", max_rows=500)
+
+        # Repository must have been asked for 501 rows, not 500
+        assert fake_repository.last_call["max_rows"] == 501
 
     def test_tracks_execution_time(
         self,


### PR DESCRIPTION
## What & Why

The **Result Truncation Flag** scenario in `specs/query/mcp-server.spec.md` specifies:

> THEN the server SHOULD fetch `limit + 1` rows and set `truncated` to true only
> if more than `limit` rows were available
> AND the response returns at most `limit` rows

The current implementation uses an approximation:

```python
truncated = len(rows) >= limit
```

This causes a false positive: when the database returns *exactly* `limit` rows,
`truncated` is set to `True` even though there may be no additional rows. The spec
explicitly calls for fetching `limit + 1` rows to distinguish "hit the cap" from
"exactly that many rows exist."

Additionally, the existing unit test `test_tracks_truncation_when_at_limit` in
`test_application_services.py` encodes the wrong behavior — it asserts
`truncated=True` when exactly `limit` rows are returned, which should be
`truncated=False` under the spec's approach. This test must be updated as part
of this fix.

## Spec Requirements Satisfied

- **Requirement: Graph Query Tool / Scenario: Result truncation flag**
  (specs/query/mcp-server.spec.md, lines 46–49)

## What This Change Does

### Application Layer (`query/application/services.py`)

`MCPQueryService.execute_cypher_query` is changed to:
1. Request `limit + 1` rows from the repository (`max_rows = limit + 1`).
2. Set `truncated = len(rows) > limit`.
3. Trim the result to `rows[:limit]` when truncated.

This ensures `truncated` is `True` *only* when a 1001st row (for limit=1000)
actually existed, not just when exactly 1000 rows were returned.

### Tests Updated (`tests/unit/query/test_application_services.py`)

The following changes align tests with the corrected behavior:

**Modified test** — `test_tracks_truncation_when_at_limit`:
- Old: returns exactly `limit` rows → expects `truncated=True` (wrong)
- New: returns `limit + 1` rows → expects `truncated=True` AND only `limit` rows in result

**New test** — `test_not_truncated_when_exactly_at_limit`:
- Returns exactly `limit` rows → expects `truncated=False` (was the false-positive case)

**New test** — `test_truncated_result_trimmed_to_limit`:
- Returns `limit + 1` rows → result contains exactly `limit` rows

## Files Affected

- `src/api/query/application/services.py`
  — `execute_cypher_query`: request `limit+1`, trim to `limit`, set `truncated` correctly
- `src/api/tests/unit/query/test_application_services.py`
  — update `test_tracks_truncation_when_at_limit`
  — add `test_not_truncated_when_exactly_at_limit`
  — add `test_truncated_result_trimmed_to_limit`

## TDD Cycle

1. Add/modify the three tests above — RED for the wrong cases
2. Run: `cd src/api && uv run pytest tests/unit/query/test_application_services.py -v`
3. Fix `execute_cypher_query` in services.py — GREEN
4. Run full unit suite to confirm no regressions:
   `cd src/api && uv run pytest tests/unit -v`
5. Commit atomically

## How to Verify

```bash
cd src/api
# Run targeted tests
uv run pytest tests/unit/query/test_application_services.py -k "truncat" -v
# Run all query unit tests
uv run pytest tests/unit/query/ -v
```

Expected outcomes:
- `test_tracks_truncation_when_at_limit`: repository returns 1001 rows →
  `result.truncated is True` AND `len(result.rows) == 1000`
- `test_not_truncated_when_exactly_at_limit`: repository returns 1000 rows →
  `result.truncated is False`
- `test_truncated_result_trimmed_to_limit`: confirms `len(result.rows) == 1000`
  not 1001

## Caveats

The spec uses SHOULD (not SHALL), so this is a best-practice improvement.
The fix closes the false-positive truncation report case and matches the spec's
intended semantics. No changes to the infrastructure (repository) layer are
required — only the service layer and its tests.

No integration test changes are required; integration tests validate the
end-to-end stack and the truncation flag is a service-layer concern.

---

**Task:** `task-097`
**Spec:** `specs/query/mcp-server.spec.md@2ac8d03afbf2153e3b569f1289e10b5ad5d21d6e`

### Merge

The orchestrator will squash-merge this PR automatically
once all pipeline steps pass.

---

This PR was created by [hyperloop](https://github.com/jsell-rh/hyperloop),
an AI agent orchestrator.