### PR TITLE
fix(query): return RemoteFileRepositoryResponse(success=False) for invalid URL in fetch_documentation_source

### DIFF
--- a/src/api/query/dependencies.py
+++ b/src/api/query/dependencies.py
@@ -154,7 +154,7 @@ def get_git_repository(
         Repository instance for the detected provider with appropriate token
 
     Raises:
-        ValueError: If URL is from an unsupported git provider
+        InvalidRemoteFileURL: If URL is from an unsupported git provider or has an invalid format
 
     Example:
         >>> # Factory auto-selects the right token based on URL

--- a/src/api/query/infrastructure/git_repository.py
+++ b/src/api/query/infrastructure/git_repository.py
@@ -441,10 +441,10 @@ class GitRepositoryFactory:
             parsed = urlparse(url)
             hostname = parsed.hostname
         except Exception:
-            raise ValueError(f"Invalid URL format: {url}")
+            raise InvalidRemoteFileURL(f"Invalid URL format: {url}")
 
         if not hostname:
-            raise ValueError(f"Missing hostname in URL: {url}")
+            raise InvalidRemoteFileURL(f"Missing hostname in URL: {url}")
 
         # Detect provider by URL pattern and select appropriate token
         if "/-/blob/" in url:
@@ -454,7 +454,7 @@ class GitRepositoryFactory:
             # GitHub pattern: /blob/ (without /-/)
             return GithubRepository(access_token=github_token, probe=probe)
 
-        raise ValueError(
+        raise InvalidRemoteFileURL(
             f"Unsupported git provider. URL must contain /blob/ (GitHub) "
             f"or /-/blob/ (GitLab). Got: {url}"
         )

--- a/src/api/query/presentation/mcp.py
+++ b/src/api/query/presentation/mcp.py
@@ -24,6 +24,7 @@ from query.dependencies import (
     get_mcp_query_service,
     get_prompt_repository,
 )
+from query.ports.exceptions import InvalidRemoteFileURL, RemoteFileFetchFailed
 from query.ports.file_repository_models import RemoteFileRepositoryResponse
 from shared_kernel.middleware.mcp_api_key_auth import MCPApiKeyAuthMiddleware
 from shared_kernel.middleware.mcp_auth import get_mcp_auth_context
@@ -322,11 +323,13 @@ def fetch_documentation_source(
         documentationmodule_view_uri: The view_uri from a DocumentationModule
             instance. Must be a GitHub blob URL like:
             https://github.com/openshift/openshift-docs/blob/main/modules/file.adoc
+            If the URL does not match GitHub or GitLab blob patterns, a
+            ``RemoteFileRepositoryResponse(success=False, error=...)`` is returned.
 
     Returns:
         class RemoteFileRepositoryResponse(BaseModel):
             success: bool
-            error: str | None = None
+            error: str | None = None  # populated when success=False
             content: str | None = None
             source_url: str | None = None
             raw_url: str | None = None
@@ -343,13 +346,23 @@ def fetch_documentation_source(
     github_token = headers.get("x-github-pat", None)
     gitlab_token = headers.get("x-gitlab-pat", None)
 
-    repository = get_git_repository(
-        url=documentationmodule_view_uri,
-        github_token=github_token,
-        gitlab_token=gitlab_token,
-    )
-
-    return repository.get_file(url=documentationmodule_view_uri)
+    try:
+        repository = get_git_repository(
+            url=documentationmodule_view_uri,
+            github_token=github_token,
+            gitlab_token=gitlab_token,
+        )
+        return repository.get_file(url=documentationmodule_view_uri)
+    except InvalidRemoteFileURL:
+        return RemoteFileRepositoryResponse(
+            success=False,
+            error="Invalid URL format: must be a GitHub or GitLab blob URL",
+        )
+    except RemoteFileFetchFailed as e:
+        return RemoteFileRepositoryResponse(
+            success=False,
+            error=str(e) or "Failed to fetch file from remote repository",
+        )
 
 
 @mcp.resource(

--- a/src/api/tests/unit/query/infrastructure/test_git_repository.py
+++ b/src/api/tests/unit/query/infrastructure/test_git_repository.py
@@ -824,17 +824,17 @@ class TestGitRepositoryFactory:
         assert isinstance(repo, GithubRepository)
 
     def test_raises_for_unsupported_provider(self):
-        """Should raise ValueError for unsupported providers."""
+        """Should raise InvalidRemoteFileURL for unsupported providers."""
         url = "https://bitbucket.org/owner/repo/src/main/file.txt"
 
-        with pytest.raises(ValueError, match="Unsupported git provider"):
+        with pytest.raises(InvalidRemoteFileURL, match="Unsupported git provider"):
             GitRepositoryFactory.create_from_url(url=url)
 
     def test_prevents_ssrf_with_github_in_path(self):
         """Should reject URLs with github.com in path (SSRF prevention)."""
         url = "https://evil.com/github.com/malicious"
 
-        with pytest.raises(ValueError, match="Unsupported git provider"):
+        with pytest.raises(InvalidRemoteFileURL, match="Unsupported git provider"):
             GitRepositoryFactory.create_from_url(url=url)
 
     def test_accepts_any_hostname_with_valid_pattern(self, mock_probe):
@@ -852,7 +852,7 @@ class TestGitRepositoryFactory:
         """Should reject URLs with github.com in query string (SSRF prevention)."""
         url = "https://evil.com/path?redirect=github.com"
 
-        with pytest.raises(ValueError, match="Unsupported git provider"):
+        with pytest.raises(InvalidRemoteFileURL, match="Unsupported git provider"):
             GitRepositoryFactory.create_from_url(url=url)
 
     def test_case_insensitive_hostname_matching(self):
@@ -863,15 +863,15 @@ class TestGitRepositoryFactory:
         assert isinstance(repo, GithubRepository)
 
     def test_rejects_invalid_url_format(self):
-        """Should raise ValueError for malformed URLs."""
+        """Should raise InvalidRemoteFileURL for malformed URLs."""
         url = "not-a-url"
 
-        with pytest.raises(ValueError, match="Missing hostname"):
+        with pytest.raises(InvalidRemoteFileURL, match="Missing hostname"):
             GitRepositoryFactory.create_from_url(url=url)
 
     def test_rejects_url_without_hostname(self):
-        """Should raise ValueError for URLs without hostname."""
+        """Should raise InvalidRemoteFileURL for URLs without hostname."""
         url = "file:///local/path/file.txt"
 
-        with pytest.raises(ValueError, match="Missing hostname"):
+        with pytest.raises(InvalidRemoteFileURL, match="Missing hostname"):
             GitRepositoryFactory.create_from_url(url=url)

--- a/src/api/tests/unit/query/test_mcp_tools.py
+++ b/src/api/tests/unit/query/test_mcp_tools.py
@@ -9,6 +9,7 @@ Spec references:
 - Scenario: Secure enclave redaction
 - Scenario: Internal property filtering
 - Scenario: Private repository with token (x-github-pat / x-gitlab-pat headers)
+- Scenario: Invalid URL format
 """
 
 from __future__ import annotations
@@ -16,6 +17,7 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+from query.ports.exceptions import RemoteFileFetchFailed
 from query.ports.file_repository_models import RemoteFileRepositoryResponse
 from query.presentation.mcp import (
     _filter_by_knowledge_graph,
@@ -469,4 +471,138 @@ class TestFetchDocumentationSourceHeaders:
             url=self._GITHUB_URL,
             github_token=None,
             gitlab_token=None,
+        )
+
+
+class TestFetchDocumentationSourceErrorHandling:
+    """Tests for fetch_documentation_source error response for invalid URLs.
+
+    Spec: Requirement: Documentation Fetch Tool — Scenario: Invalid URL format
+    GIVEN a URL that does not match GitHub or GitLab blob patterns
+    WHEN the tool is called
+    THEN an error response is returned
+
+    The tool MUST return RemoteFileRepositoryResponse(success=False, error=...)
+    rather than propagating exceptions. MCP clients pattern-match on
+    response.success and expect a typed response, not a JSON-RPC fault.
+
+    Spec reference: specs/query/mcp-server.spec.md
+    """
+
+    _INVALID_URL = "https://example.com/not-a-git-url"
+    _GITHUB_NO_BLOB = "https://github.com/owner/repo"
+
+    def test_invalid_url_returns_error_response(self) -> None:
+        """Calling fetch_documentation_source.fn with an unsupported URL MUST
+        return RemoteFileRepositoryResponse(success=False).
+
+        Spec: Invalid URL format — THEN an error response is returned.
+
+        The tool's return type is RemoteFileRepositoryResponse. A JSON-RPC
+        fault (propagated exception) is the wrong shape for MCP clients that
+        pattern-match on response.success.
+        """
+        with patch(
+            "query.presentation.mcp.get_http_headers",
+            return_value={},
+        ):
+            result = fetch_documentation_source.fn(self._INVALID_URL)
+
+        assert isinstance(result, RemoteFileRepositoryResponse), (
+            "fetch_documentation_source must always return RemoteFileRepositoryResponse, "
+            "even for invalid URLs. Propagating exceptions breaks MCP client contracts."
+        )
+        assert result.success is False, (
+            "Invalid URL must result in success=False, not True."
+        )
+
+    def test_invalid_url_error_field_is_not_none(self) -> None:
+        """The error field in the response MUST contain a non-empty message.
+
+        An error response with success=False but error=None provides no
+        actionable information to the MCP client.
+        """
+        with patch(
+            "query.presentation.mcp.get_http_headers",
+            return_value={},
+        ):
+            result = fetch_documentation_source.fn(self._INVALID_URL)
+
+        assert result.error is not None, (
+            "error field must be populated when success=False"
+        )
+        assert len(result.error) > 0, "error field must contain a non-empty message"
+
+    def test_invalid_url_does_not_raise(self) -> None:
+        """fetch_documentation_source.fn MUST NOT raise for an invalid URL.
+
+        Spec: Invalid URL format — THEN an error response is returned.
+
+        The tool must return rather than raise so that FastMCP can serialize
+        the response. Unhandled exceptions propagate as JSON-RPC errors (a
+        different shape from RemoteFileRepositoryResponse).
+        """
+        with patch(
+            "query.presentation.mcp.get_http_headers",
+            return_value={},
+        ):
+            try:
+                result = fetch_documentation_source.fn(self._INVALID_URL)
+            except Exception as exc:
+                raise AssertionError(
+                    f"fetch_documentation_source must not raise for invalid URLs. "
+                    f"Got {type(exc).__name__}: {exc}"
+                ) from exc
+
+        assert result is not None
+
+    def test_github_url_missing_blob_segment_returns_error_response(self) -> None:
+        """GitHub URL without /blob/ segment must produce an error response.
+
+        A bare repository URL (e.g., https://github.com/owner/repo) is not
+        a valid blob URL. The tool must return success=False rather than raise.
+
+        Spec: Invalid URL format — THEN an error response is returned.
+        """
+        with patch(
+            "query.presentation.mcp.get_http_headers",
+            return_value={},
+        ):
+            result = fetch_documentation_source.fn(self._GITHUB_NO_BLOB)
+
+        assert isinstance(result, RemoteFileRepositoryResponse)
+        assert result.success is False
+
+    def test_remote_fetch_failure_returns_error_response(self) -> None:
+        """RemoteFileFetchFailed from repository.get_file() MUST be caught and
+        returned as RemoteFileRepositoryResponse(success=False).
+
+        Spec: Invalid URL format — THEN an error response is returned.
+
+        This covers HTTP failures (404, 403, network errors) from get_file().
+        The tool must not propagate RemoteFileFetchFailed to FastMCP as a
+        JSON-RPC fault.
+        """
+        mock_repo = MagicMock()
+        mock_repo.get_file.side_effect = RemoteFileFetchFailed("HTTP 404: Not Found")
+
+        with (
+            patch(
+                "query.presentation.mcp.get_http_headers",
+                return_value={},
+            ),
+            patch(
+                "query.presentation.mcp.get_git_repository",
+                return_value=mock_repo,
+            ),
+        ):
+            result = fetch_documentation_source.fn(
+                "https://github.com/owner/repo/blob/main/private.adoc"
+            )
+
+        assert isinstance(result, RemoteFileRepositoryResponse)
+        assert result.success is False
+        assert result.error is not None
+        assert "404" in result.error, (
+            "Error message should reference the HTTP status code for diagnostics."
         )


### PR DESCRIPTION
## What & Why

The `fetch_documentation_source` MCP tool has the following return type contract:

```python
def fetch_documentation_source(url: str) -> RemoteFileRepositoryResponse:
```

`RemoteFileRepositoryResponse` has a `success=False` / `error=...` path for
signalling failures to callers. However, when the URL does not match any
supported git provider (GitHub blob URL or GitLab `/-/blob/` URL), the current
implementation propagates a `ValueError` raised by `get_git_repository` /
`GitRepositoryFactory.create_from_url`. FastMCP catches unhandled exceptions and
converts them to MCP JSON-RPC errors — a different shape from the tool's
declared return type.

### Spec Requirement

`specs/query/mcp-server.spec.md` — **Requirement: Documentation Fetch Tool**:

> **Scenario: Invalid URL format**
> GIVEN a URL that does not match GitHub or GitLab blob patterns
> WHEN the tool is called
> THEN an error response is returned

"An error response" in this context means `RemoteFileRepositoryResponse(success=False,
error="...")` — consistent with the tool's own return type and with how HTTP failures
are already handled (the repository raises `RemoteFileFetchFailed` which is also not
caught at the tool layer). The spec says *an* error response, not a JSON-RPC fault.
Returning a typed `RemoteFileRepositoryResponse(success=False)` is the correct
interpretation because:
- The tool's return type is `RemoteFileRepositoryResponse` — callers expect this shape.
- MCP clients that pattern-match on `response.success` would receive an unexpected
  JSON-RPC error object instead of a `RemoteFileRepositoryResponse`.
- The repository layer already has `InvalidRemoteFileURL` as a typed exception for
  this exact case (`query/ports/exceptions.py`).

### Test Gap

`tests/unit/query/infrastructure/test_git_repository.py` and
`TestGitRepositoryFactory.test_rejects_invalid_url_format` cover the factory level.
`tests/unit/query/test_mcp_tools.py` covers PAT header extraction but has no test
that calls `fetch_documentation_source.fn(invalid_url)` and asserts a typed
`RemoteFileRepositoryResponse(success=False)` is returned. This is the missing layer.

## Spec Requirements Satisfied

`specs/query/mcp-server.spec.md`:
- **Requirement: Documentation Fetch Tool** — Scenario: *Invalid URL format*

## What This Change Does

### 1. `src/api/query/presentation/mcp.py`

Wrap the `get_git_repository` call (and optionally `repository.get_file`) in a
`try/except` block that catches `InvalidRemoteFileURL` (and `RemoteFileFetchFailed`
if not already caught by the repository's template method) and returns:

```python
from query.ports.exceptions import InvalidRemoteFileURL, RemoteFileFetchFailed

@mcp.tool
def fetch_documentation_source(url: str) -> RemoteFileRepositoryResponse:
    headers = get_http_headers()
    github_token = headers.get("x-github-pat")
    gitlab_token = headers.get("x-gitlab-pat")

    try:
        repository = get_git_repository(
            url=url,
            github_token=github_token,
            gitlab_token=gitlab_token,
        )
        return repository.get_file(url=url)
    except InvalidRemoteFileURL:
        return RemoteFileRepositoryResponse(
            success=False,
            error="Invalid URL format: must be a GitHub or GitLab blob URL",
        )
    except RemoteFileFetchFailed as e:
        return RemoteFileRepositoryResponse(
            success=False,
            error=str(e) or "Failed to fetch file from remote repository",
        )
```

### 2. `src/api/tests/unit/query/test_mcp_tools.py`

Add a new test class `TestFetchDocumentationSourceErrorHandling` with tests that
call `fetch_documentation_source.fn(url)` and assert typed error responses:

**Write these tests BEFORE touching the implementation (TDD)**:

1. **`test_invalid_url_returns_error_response`** — call `.fn("https://example.com/not-a-git-url")`;
   assert `result.success is False` and `result.error` is not None.

2. **`test_invalid_url_does_not_raise`** — assert the tool does NOT raise an
   exception (it must return, not raise, for any URL pattern).

3. **`test_github_url_missing_blob_segment_returns_error`** — URL like
   `"https://github.com/owner/repo"` (no `/blob/`) returns `success=False`.

4. **`test_remote_fetch_failure_returns_error_response`** — mock
   `get_git_repository` to return a repository whose `.get_file()` raises
   `RemoteFileFetchFailed("HTTP 404")` and assert `result.success is False`
   and `result.error` contains "404".

## Files / Areas Affected

- `src/api/query/presentation/mcp.py` — add try/except in `fetch_documentation_source`
- `src/api/tests/unit/query/test_mcp_tools.py` — add `TestFetchDocumentationSourceErrorHandling`
- No domain or port changes required; `InvalidRemoteFileURL` and `RemoteFileFetchFailed`
  already exist in `query/ports/exceptions.py`

## How to Verify

1. TDD cycle: write failing tests in `test_mcp_tools.py` first
2. Add try/except to `fetch_documentation_source` in `mcp.py`
3. `cd src/api && uv run pytest tests/unit/query/test_mcp_tools.py -v -k "ErrorHandling"`
   — all 4 new tests pass
4. `uv run pytest tests/unit/query/ -v` — no regressions in existing tests

## Caveats

- `RemoteFileFetchFailed` is already caught inside the repository's `get_file`
  template method and re-raised; verify whether catching it at the tool layer is
  redundant or necessary (it should be necessary since the template method raises, not
  swallows).
- The tool's docstring documents `RemoteFileRepositoryResponse` as the return type —
  add a note in the Args section that invalid URLs return `success=False`.
- Do not suppress all exceptions: only `InvalidRemoteFileURL` and
  `RemoteFileFetchFailed` should be caught. Other unexpected errors should still
  propagate so FastMCP surfaces them as internal errors (not silent failures).

---

**Task:** `task-111`
**Spec:** `specs/query/mcp-server.spec.md@2ac8d03afbf2153e3b569f1289e10b5ad5d21d6e`

### Merge

The orchestrator will squash-merge this PR automatically
once all pipeline steps pass.

---

This PR was created by [hyperloop](https://github.com/jsell-rh/hyperloop),
an AI agent orchestrator.