### PR TITLE
test(query): add tests for query_graph tool parameter bounds enforcement

### DIFF
--- a/src/api/query/presentation/mcp.py
+++ b/src/api/query/presentation/mcp.py
@@ -202,6 +202,34 @@ def _build_error_response(result: QueryError) -> Dict[str, Any]:
     return response
 
 
+def _clamp_query_params(
+    timeout_seconds: int,
+    max_rows: int,
+    max_timeout: int = 60,
+    max_limit: int = 10_000,
+) -> tuple[int, int]:
+    """Clamp query parameters to their spec-defined maximums.
+
+    Extracts the bounds enforcement from ``query_graph`` into a pure, testable
+    helper so the clamping logic can be verified independently of the FastMCP
+    tool wrapper.
+
+    Spec: mcp-server.spec.md
+      - Scenario: Query timeout — "max 60 seconds"
+      - Scenario: Result limiting — "max 10000"
+
+    Args:
+        timeout_seconds: Requested query timeout. Clamped to ``max_timeout``.
+        max_rows: Requested row limit. Clamped to ``max_limit``.
+        max_timeout: Upper bound for timeout_seconds (default 60 s per spec).
+        max_limit: Upper bound for max_rows (default 10 000 per spec).
+
+    Returns:
+        A tuple of ``(clamped_timeout_seconds, clamped_max_rows)``.
+    """
+    return min(timeout_seconds, max_timeout), min(max_rows, max_limit)
+
+
 @mcp.tool
 async def query_graph(
     cypher: str,
@@ -264,9 +292,8 @@ async def query_graph(
         query_graph("MATCH (p:Person) RETURN p", knowledge_graph_id="kg-01J...")
     """
 
-    # Enforce maximum limits
-    timeout_seconds = min(timeout_seconds, 60)
-    max_rows = min(max_rows, 10000)
+    # Enforce maximum limits (spec: max 60 s timeout, max 10 000 rows)
+    timeout_seconds, max_rows = _clamp_query_params(timeout_seconds, max_rows)
 
     result = service.execute_cypher_query(
         query=cypher,

--- a/src/api/tests/unit/query/test_mcp_query_params.py
+++ b/src/api/tests/unit/query/test_mcp_query_params.py
@@ -1,0 +1,177 @@
+"""Unit tests for the _clamp_query_params helper in the MCP query tool.
+
+Tests the parameter bounds enforcement extracted from the `query_graph` MCP tool.
+
+Spec references:
+  specs/query/mcp-server.spec.md
+
+  - Requirement: Graph Query Tool — Scenario: Query timeout
+    "GIVEN a query that exceeds the timeout (default 30 seconds, max 60 seconds)"
+    "WHEN the query is executed"
+    "THEN it is terminated and returned with error type 'timeout'"
+
+  - Requirement: Graph Query Tool — Scenario: Result limiting
+    "GIVEN a query without a LIMIT clause"
+    "WHEN the query is executed"
+    "THEN a LIMIT is automatically applied (default 1000, max 10000)"
+"""
+
+from __future__ import annotations
+
+
+from query.presentation.mcp import _clamp_query_params
+
+
+class TestClampQueryParamsTimeoutSeconds:
+    """Timeout parameter capped at 60 seconds.
+
+    Spec: Scenario: Query timeout — "max 60 seconds"
+    """
+
+    def test_timeout_seconds_within_bounds_is_unchanged(self) -> None:
+        """timeout_seconds below the max must pass through unchanged.
+
+        Spec: Default is 30 seconds. Requesting 30 s should stay 30 s.
+        """
+        timeout, _ = _clamp_query_params(timeout_seconds=30, max_rows=1000)
+
+        assert timeout == 30
+
+    def test_timeout_seconds_at_max_is_unchanged(self) -> None:
+        """timeout_seconds equal to the max (60) must pass through unchanged."""
+        timeout, _ = _clamp_query_params(timeout_seconds=60, max_rows=1000)
+
+        assert timeout == 60
+
+    def test_timeout_seconds_above_max_is_clamped_to_60(self) -> None:
+        """timeout_seconds = 61 must be clamped to 60."""
+        timeout, _ = _clamp_query_params(timeout_seconds=61, max_rows=1000)
+
+        assert timeout == 60
+
+    def test_timeout_seconds_far_above_max_is_clamped_to_60(self) -> None:
+        """timeout_seconds = 3600 must be clamped to 60."""
+        timeout, _ = _clamp_query_params(timeout_seconds=3600, max_rows=1000)
+
+        assert timeout == 60
+
+    def test_timeout_seconds_999_is_clamped_to_60(self) -> None:
+        """timeout_seconds = 999 must be clamped to 60."""
+        timeout, _ = _clamp_query_params(timeout_seconds=999, max_rows=1000)
+
+        assert timeout == 60
+
+    def test_default_timeout_below_max_is_unchanged(self) -> None:
+        """The default timeout (30 s) is below the max and must pass through unchanged."""
+        timeout, _ = _clamp_query_params(timeout_seconds=30, max_rows=1000)
+
+        # Default (30 s) is well within the 60 s bound
+        assert timeout == 30
+
+
+class TestClampQueryParamsMaxRows:
+    """max_rows parameter capped at 10 000.
+
+    Spec: Scenario: Result limiting — "max 10000"
+    """
+
+    def test_max_rows_within_bounds_is_unchanged(self) -> None:
+        """max_rows = 1000 is within bounds and must pass through unchanged."""
+        _, rows = _clamp_query_params(timeout_seconds=30, max_rows=1000)
+
+        assert rows == 1000
+
+    def test_max_rows_at_max_is_unchanged(self) -> None:
+        """max_rows = 10000 equals the max and must pass through unchanged."""
+        _, rows = _clamp_query_params(timeout_seconds=30, max_rows=10000)
+
+        assert rows == 10000
+
+    def test_max_rows_above_max_is_clamped(self) -> None:
+        """max_rows = 10001 must be clamped to 10000."""
+        _, rows = _clamp_query_params(timeout_seconds=30, max_rows=10001)
+
+        assert rows == 10000
+
+    def test_max_rows_far_above_max_is_clamped(self) -> None:
+        """max_rows = 99999 must be clamped to 10000."""
+        _, rows = _clamp_query_params(timeout_seconds=30, max_rows=99999)
+
+        assert rows == 10000
+
+    def test_default_max_rows_below_max_is_unchanged(self) -> None:
+        """The default max_rows (1000) is below the 10000 bound and must pass through."""
+        _, rows = _clamp_query_params(timeout_seconds=30, max_rows=1000)
+
+        assert rows == 1000
+
+
+class TestClampQueryParamsCombined:
+    """Both parameters are independently clamped.
+
+    Clamping is independent: each parameter is bounded individually. No interaction
+    between timeout_seconds and max_rows.
+    """
+
+    def test_both_params_independently_clamped(self) -> None:
+        """Oversized timeout (120 s) and rows (50000) must each clamp independently.
+
+        Spec: max 60 s for timeout, max 10000 for rows.
+        Result must be (60, 10000) regardless of how far above the cap each input is.
+        """
+        timeout, rows = _clamp_query_params(timeout_seconds=120, max_rows=50000)
+
+        assert timeout == 60
+        assert rows == 10000
+
+    def test_both_params_within_bounds_unchanged(self) -> None:
+        """When both params are within bounds neither should be modified."""
+        timeout, rows = _clamp_query_params(timeout_seconds=15, max_rows=500)
+
+        assert timeout == 15
+        assert rows == 500
+
+    def test_only_timeout_exceeds_max(self) -> None:
+        """When only timeout exceeds max, only timeout is clamped; rows stay unchanged."""
+        timeout, rows = _clamp_query_params(timeout_seconds=120, max_rows=500)
+
+        assert timeout == 60
+        assert rows == 500
+
+    def test_only_max_rows_exceeds_max(self) -> None:
+        """When only max_rows exceeds the limit, only rows are clamped; timeout stays."""
+        timeout, rows = _clamp_query_params(timeout_seconds=15, max_rows=99999)
+
+        assert timeout == 15
+        assert rows == 10000
+
+
+class TestClampQueryParamsCustomLimits:
+    """Custom override limits work correctly.
+
+    The helper exposes max_timeout and max_limit as keyword parameters so that
+    callers (and tests) can inject alternative bounds without monkey-patching.
+    """
+
+    def test_custom_max_timeout_is_respected(self) -> None:
+        """When max_timeout is overridden, the custom limit is enforced."""
+        timeout, _ = _clamp_query_params(
+            timeout_seconds=100, max_rows=1000, max_timeout=90
+        )
+
+        assert timeout == 90
+
+    def test_custom_max_limit_is_respected(self) -> None:
+        """When max_limit is overridden, the custom limit is enforced."""
+        _, rows = _clamp_query_params(timeout_seconds=30, max_rows=5000, max_limit=4000)
+
+        assert rows == 4000
+
+    def test_return_type_is_tuple_of_two_ints(self) -> None:
+        """The return value must be a tuple of exactly two integers."""
+        result = _clamp_query_params(timeout_seconds=30, max_rows=1000)
+
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        assert isinstance(result[0], int)
+        assert isinstance(result[1], int)


### PR DESCRIPTION
## What & Why

`specs/query/mcp-server.spec.md` specifies explicit upper bounds for the
`query_graph` MCP tool parameters:

> "**Scenario: Query timeout**
> GIVEN a query that exceeds the timeout (default 30 seconds, **max 60 seconds**)
> WHEN the query is executed
> THEN it is terminated and returned with error type "timeout""

> "**Scenario: Result limiting**
> GIVEN a query without a LIMIT clause
> WHEN the query is executed
> THEN a LIMIT is automatically applied (default 1000, **max 10000**)"

The `query_graph` tool in `query/presentation/mcp.py` correctly enforces these
bounds with:

```python
timeout_seconds = min(timeout_seconds, 60)
max_rows = min(max_rows, 10000)
```

However, **no test verifies these `min()` operations at the tool layer**. The
repository's `_ensure_limit` (which caps explicit LIMIT clauses at `MAX_LIMIT =
10000`) is tested in `test_query_repository.py`, but that is a different code path.
The tool-layer cap on the `timeout_seconds` and `max_rows` *request parameters*
themselves is untested.

If the two `min()` lines were accidentally deleted, no existing test would catch
the regression. An MCP client sending `max_rows=99999` or `timeout_seconds=3600`
would bypass the intended limit.

## Spec Requirements Satisfied

`specs/query/mcp-server.spec.md`:
- **Requirement: Graph Query Tool** — Scenario: *Query timeout* ("max 60 seconds")
- **Requirement: Graph Query Tool** — Scenario: *Result limiting* ("max 10000")

## What This Change Does

Add unit tests that verify the tool's parameter bounds enforcement. Because
`query_graph` is wrapped by `@mcp.tool` (making direct invocation in unit tests
impractical), the bounds logic should be **extracted into a testable pure function**
and the tool should delegate to it.

### Refactor: Extract `_clamp_query_params`

In `query/presentation/mcp.py`, extract a small pure helper:

```python
def _clamp_query_params(
    timeout_seconds: int,
    max_rows: int,
    max_timeout: int = 60,
    max_limit: int = 10_000,
) -> tuple[int, int]:
    """Clamp query parameters to their spec-defined maximums.

    Spec: mcp-server.spec.md — Scenario: Query timeout (max 60 s)
          mcp-server.spec.md — Scenario: Result limiting (max 10 000)
    """
    return min(timeout_seconds, max_timeout), min(max_rows, max_limit)
```

Replace the inline `min()` calls in `query_graph` with `_clamp_query_params`.

### Tests: `test_mcp_query_params.py`

Add a new test file `src/api/tests/unit/query/test_mcp_query_params.py`:

**`TestClampQueryParams` — timeout_seconds cap at 60:**
- `test_timeout_seconds_within_bounds_is_unchanged`: 30 → 30
- `test_timeout_seconds_at_max_is_unchanged`: 60 → 60
- `test_timeout_seconds_above_max_is_clamped`: 61 → 60, 3600 → 60, 999 → 60
- `test_default_timeout_below_max`: default (30) passes through unchanged

**`TestClampQueryParams` — max_rows cap at 10 000:**
- `test_max_rows_within_bounds_is_unchanged`: 1000 → 1000
- `test_max_rows_at_max_is_unchanged`: 10000 → 10000
- `test_max_rows_above_max_is_clamped`: 10001 → 10000, 99999 → 10000
- `test_default_max_rows_below_max`: default (1000) passes through unchanged

**`TestClampQueryParams` — combined:**
- `test_both_params_independently_clamped`: 120 s / 50000 rows → 60 s / 10000 rows
- `test_both_params_within_bounds_unchanged`: 15 s / 500 rows → 15 s / 500 rows

## Files / Areas Affected

- `src/api/query/presentation/mcp.py` — extract `_clamp_query_params` helper;
  replace inline `min()` calls in `query_graph`
- `src/api/tests/unit/query/test_mcp_query_params.py` (new) — the test cases
  above; import and test `_clamp_query_params` directly

## Tests

The extracted helper tests are pure unit tests (no infrastructure needed):

```bash
cd src/api && uv run pytest tests/unit/query/test_mcp_query_params.py -v
```

## How to Verify

1. `cd src/api && uv run pytest tests/unit/query/test_mcp_query_params.py -v`
2. Confirm all tests pass green
3. Temporarily change `max_timeout=60` to `max_timeout=9999` in `_clamp_query_params`
   and confirm `test_timeout_seconds_above_max_is_clamped` fails — validates the
   tests are not false positives

## Caveats

- The refactor is a behaviour-preserving rename only: the `min()` calls inside
  `query_graph` become a `_clamp_query_params` call. No logic changes.
- The existing `MCPQueryService` and repository-level LIMIT tests are unaffected
  (they test different layers).
- If a mypy or ruff hook complains about the new `_clamp_query_params` public
  exposure, prefix with underscore (it already starts with `_`) and add a
  `__all__` exclusion if needed.

---

**Task:** `task-115`
**Spec:** `specs/query/mcp-server.spec.md@2ac8d03afbf2153e3b569f1289e10b5ad5d21d6e`

### Merge

The orchestrator will squash-merge this PR automatically
once all pipeline steps pass.

---

This PR was created by [hyperloop](https://github.com/jsell-rh/hyperloop),
an AI agent orchestrator.