### PR TITLE
feat(management): add ontology field to DataSource aggregate and API

### DIFF
--- a/src/api/infrastructure/migrations/versions/b3c4d5e6f7a8_add_ontology_json_to_data_sources.py
+++ b/src/api/infrastructure/migrations/versions/b3c4d5e6f7a8_add_ontology_json_to_data_sources.py
@@ -1,0 +1,39 @@
+"""add ontology_json to data_sources
+
+Adds a nullable JSONB column `ontology_json` to the `data_sources` table to
+store the approved ontology (node types, edge types, and their properties)
+for a data source.
+
+An empty/null ontology is valid — data sources will start with NULL and
+gain an ontology after the agent-proposal approval step in the UI.
+
+Revision ID: b3c4d5e6f7a8
+Revises: a2b3c4d5e6f7
+Create Date: 2026-05-03
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+# revision identifiers, used by Alembic.
+revision: str = "b3c4d5e6f7a8"
+down_revision: Union[str, Sequence[str], None] = "a2b3c4d5e6f7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add nullable ontology_json JSONB column to data_sources."""
+    op.add_column(
+        "data_sources",
+        sa.Column("ontology_json", JSONB, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Remove ontology_json column from data_sources."""
+    op.drop_column("data_sources", "ontology_json")

--- a/src/api/management/application/services/data_source_service.py
+++ b/src/api/management/application/services/data_source_service.py
@@ -18,7 +18,7 @@ from management.application.observability import (
 )
 from management.domain.aggregates import DataSource
 from management.domain.entities import DataSourceSyncRun
-from management.domain.value_objects import DataSourceId, KnowledgeGraphId
+from management.domain.value_objects import DataSourceId, KnowledgeGraphId, Ontology
 from management.ports.exceptions import UnauthorizedError
 from management.ports.repositories import (
     IDataSourceRepository,
@@ -122,6 +122,7 @@ class DataSourceService:
         adapter_type: DataSourceAdapterType,
         connection_config: dict[str, str],
         raw_credentials: dict[str, str] | None = None,
+        ontology: Ontology | None = None,
     ) -> DataSource:
         """Create a new data source in a knowledge graph.
 
@@ -171,6 +172,7 @@ class DataSourceService:
                 name=name,
                 adapter_type=adapter_type,
                 connection_config=connection_config,
+                ontology=ontology,
                 created_by=user_id,
             )
 
@@ -395,6 +397,61 @@ class DataSourceService:
             self._probe.data_source_updated(ds_id=ds_id, name=name)
         else:
             self._probe.data_source_updated(ds_id=ds_id, name=ds.name)
+
+        return ds
+
+    async def update_ontology(
+        self,
+        user_id: str,
+        ds_id: str,
+        ontology: Ontology,
+    ) -> DataSource:
+        """Update the approved ontology for a data source.
+
+        Requires EDIT permission on the data source. Replaces the stored
+        ontology with the provided one and persists the change.
+
+        Args:
+            user_id: The user performing the update
+            ds_id: The data source ID
+            ontology: The new approved ontology (may be empty)
+
+        Returns:
+            The updated DataSource aggregate
+
+        Raises:
+            UnauthorizedError: If user lacks EDIT permission on the DS
+            ValueError: If DS not found or belongs to a different tenant
+        """
+        has_edit = await self._check_permission(
+            user_id=user_id,
+            resource_type=ResourceType.DATA_SOURCE,
+            resource_id=ds_id,
+            permission=Permission.EDIT,
+        )
+
+        if not has_edit:
+            self._probe.permission_denied(
+                user_id=user_id,
+                resource_id=ds_id,
+                permission=Permission.EDIT,
+            )
+            raise UnauthorizedError(
+                f"User {user_id} lacks edit permission on data source {ds_id}"
+            )
+
+        ds = await self._ds_repo.get_by_id(DataSourceId(value=ds_id))
+        if ds is None:
+            raise ValueError(f"Data source {ds_id} not found")
+
+        if ds.tenant_id != self._scope_to_tenant:
+            raise ValueError(f"Data source {ds_id} not found")
+
+        async with self._session.begin():
+            ds.update_ontology(ontology=ontology, updated_by=user_id)
+            await self._ds_repo.save(ds)
+
+        self._probe.data_source_updated(ds_id=ds_id, name=ds.name)
 
         return ds
 

--- a/src/api/management/domain/aggregates/data_source.py
+++ b/src/api/management/domain/aggregates/data_source.py
@@ -21,7 +21,12 @@ from management.domain.observability import (
     DataSourceProbe,
     DefaultDataSourceProbe,
 )
-from management.domain.value_objects import DataSourceId, Schedule, ScheduleType
+from management.domain.value_objects import (
+    DataSourceId,
+    Ontology,
+    Schedule,
+    ScheduleType,
+)
 from shared_kernel.datasource_types import DataSourceAdapterType
 
 if TYPE_CHECKING:
@@ -58,6 +63,7 @@ class DataSource:
     last_sync_at: datetime | None
     created_at: datetime
     updated_at: datetime
+    ontology: Ontology | None = None
     _pending_events: list[DomainEvent] = field(default_factory=list, repr=False)
     _probe: DataSourceProbe = field(
         default_factory=DefaultDataSourceProbe,
@@ -110,6 +116,7 @@ class DataSource:
         adapter_type: DataSourceAdapterType,
         connection_config: dict[str, str],
         credentials_path: str | None = None,
+        ontology: Ontology | None = None,
         *,
         created_by: str | None = None,
         probe: DataSourceProbe | None = None,
@@ -143,6 +150,7 @@ class DataSource:
             credentials_path=credentials_path,
             schedule=Schedule(schedule_type=ScheduleType.MANUAL),
             last_sync_at=None,
+            ontology=ontology,
             created_at=now,
             updated_at=now,
             _probe=probe or DefaultDataSourceProbe(),
@@ -234,6 +242,48 @@ class DataSource:
                 "Cannot update schedule on a deleted data source"
             )
         self.schedule = schedule
+        self.updated_at = datetime.now(UTC)
+
+        self._pending_events.append(
+            DataSourceUpdated(
+                data_source_id=self.id.value,
+                knowledge_graph_id=self.knowledge_graph_id,
+                tenant_id=self.tenant_id,
+                name=self.name,
+                occurred_at=self.updated_at,
+                updated_by=updated_by,
+            )
+        )
+        self._probe.updated(
+            data_source_id=self.id.value,
+            knowledge_graph_id=self.knowledge_graph_id,
+            tenant_id=self.tenant_id,
+            name=self.name,
+        )
+
+    def update_ontology(
+        self,
+        ontology: Ontology,
+        *,
+        updated_by: str | None = None,
+    ) -> None:
+        """Update the data source's approved ontology.
+
+        Replaces the stored ontology with the provided one and emits
+        DataSourceUpdated. An empty Ontology (no node or edge types) is valid.
+
+        Args:
+            ontology: The new approved ontology
+            updated_by: The user performing the update (optional)
+
+        Raises:
+            AggregateDeletedError: If the data source has been marked for deletion
+        """
+        if self._deleted:
+            raise AggregateDeletedError(
+                "Cannot update ontology on a deleted data source"
+            )
+        self.ontology = ontology
         self.updated_at = datetime.now(UTC)
 
         self._pending_events.append(

--- a/src/api/management/domain/value_objects.py
+++ b/src/api/management/domain/value_objects.py
@@ -6,9 +6,9 @@ domain semantics for identifiers and domain concepts.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import TypeVar
+from typing import Any, TypeVar
 
 from ulid import ULID
 
@@ -125,3 +125,127 @@ class Schedule:
                 object.__setattr__(self, "value", None)
             else:
                 raise InvalidScheduleError("MANUAL schedule must not have a value")
+
+
+@dataclass(frozen=True)
+class OntologyNodeType:
+    """A node type definition within an ontology.
+
+    Immutable value object representing a single entity class in the graph
+    ontology. Describes what kinds of nodes exist, their labels, and which
+    properties are expected.
+
+    Attributes:
+        label: The type label (e.g. "Repository", "PullRequest")
+        description: Optional human-readable description
+        required_properties: Property names that must be present on nodes of this type
+        optional_properties: Property names that may be present on nodes of this type
+    """
+
+    label: str
+    description: str | None = None
+    required_properties: list[str] = field(default_factory=list)
+    optional_properties: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class OntologyEdgeType:
+    """An edge type definition within an ontology.
+
+    Immutable value object representing a single relationship class in the
+    graph ontology. Describes what kinds of edges exist, their labels, and
+    which node types they connect.
+
+    Attributes:
+        label: The edge label (e.g. "HAS_PR", "CREATED_BY")
+        from_type: The source node type label
+        to_type: The target node type label
+        description: Optional human-readable description
+        required_properties: Property names that must be present on edges of this type
+        optional_properties: Property names that may be present on edges of this type
+    """
+
+    label: str
+    from_type: str
+    to_type: str
+    description: str | None = None
+    required_properties: list[str] = field(default_factory=list)
+    optional_properties: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class Ontology:
+    """An approved ontology for a data source.
+
+    Immutable value object aggregating node type and edge type definitions.
+    An empty Ontology (no types) is valid — it represents a data source
+    that has no approved ontology yet or where all types have been removed.
+
+    Attributes:
+        node_types: List of node type definitions
+        edge_types: List of edge type definitions
+    """
+
+    node_types: list[OntologyNodeType]
+    edge_types: list[OntologyEdgeType]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-serializable dictionary for persistence.
+
+        Returns:
+            Dictionary with node_types and edge_types lists
+        """
+        return {
+            "node_types": [
+                {
+                    "label": nt.label,
+                    "description": nt.description,
+                    "required_properties": list(nt.required_properties),
+                    "optional_properties": list(nt.optional_properties),
+                }
+                for nt in self.node_types
+            ],
+            "edge_types": [
+                {
+                    "label": et.label,
+                    "from_type": et.from_type,
+                    "to_type": et.to_type,
+                    "description": et.description,
+                    "required_properties": list(et.required_properties),
+                    "optional_properties": list(et.optional_properties),
+                }
+                for et in self.edge_types
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Ontology:
+        """Deserialize an Ontology from a dictionary.
+
+        Args:
+            data: Dictionary with node_types and edge_types lists
+
+        Returns:
+            Reconstructed Ontology value object
+        """
+        node_types = [
+            OntologyNodeType(
+                label=nt["label"],
+                description=nt.get("description"),
+                required_properties=list(nt.get("required_properties", [])),
+                optional_properties=list(nt.get("optional_properties", [])),
+            )
+            for nt in data.get("node_types", [])
+        ]
+        edge_types = [
+            OntologyEdgeType(
+                label=et["label"],
+                from_type=et["from_type"],
+                to_type=et["to_type"],
+                description=et.get("description"),
+                required_properties=list(et.get("required_properties", [])),
+                optional_properties=list(et.get("optional_properties", [])),
+            )
+            for et in data.get("edge_types", [])
+        ]
+        return cls(node_types=node_types, edge_types=edge_types)

--- a/src/api/management/infrastructure/models/data_source.py
+++ b/src/api/management/infrastructure/models/data_source.py
@@ -42,6 +42,7 @@ class DataSourceModel(Base, TimestampMixin):
     last_sync_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    ontology_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
     __table_args__ = (
         UniqueConstraint("knowledge_graph_id", "name", name="uq_data_sources_kg_name"),

--- a/src/api/management/infrastructure/repositories/data_source_repository.py
+++ b/src/api/management/infrastructure/repositories/data_source_repository.py
@@ -13,7 +13,12 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from management.domain.aggregates import DataSource
-from management.domain.value_objects import DataSourceId, Schedule, ScheduleType
+from management.domain.value_objects import (
+    DataSourceId,
+    Ontology,
+    Schedule,
+    ScheduleType,
+)
 from management.infrastructure.models import DataSourceModel
 from management.infrastructure.observability import (
     DataSourceRepositoryProbe,
@@ -62,6 +67,12 @@ class DataSourceRepository(IDataSourceRepository):
             result = await self._session.execute(stmt)
             model = result.scalar_one_or_none()
 
+            ontology_json = (
+                data_source.ontology.to_dict()
+                if data_source.ontology is not None
+                else None
+            )
+
             if model:
                 model.name = data_source.name
                 model.connection_config = data_source.connection_config
@@ -70,6 +81,7 @@ class DataSourceRepository(IDataSourceRepository):
                 model.schedule_value = data_source.schedule.value
                 model.last_sync_at = data_source.last_sync_at
                 model.updated_at = data_source.updated_at
+                model.ontology_json = ontology_json
             else:
                 model = DataSourceModel(
                     id=data_source.id.value,
@@ -82,6 +94,7 @@ class DataSourceRepository(IDataSourceRepository):
                     schedule_type=data_source.schedule.schedule_type.value,
                     schedule_value=data_source.schedule.value,
                     last_sync_at=data_source.last_sync_at,
+                    ontology_json=ontology_json,
                     created_at=data_source.created_at,
                     updated_at=data_source.updated_at,
                 )
@@ -174,6 +187,11 @@ class DataSourceRepository(IDataSourceRepository):
 
     def _to_domain(self, model: DataSourceModel) -> DataSource:
         """Reconstitute aggregate from database state without generating events."""
+        ontology = (
+            Ontology.from_dict(model.ontology_json)
+            if model.ontology_json is not None
+            else None
+        )
         return DataSource(
             id=DataSourceId(value=model.id),
             knowledge_graph_id=model.knowledge_graph_id,
@@ -189,4 +207,5 @@ class DataSourceRepository(IDataSourceRepository):
             last_sync_at=model.last_sync_at,
             created_at=model.created_at,
             updated_at=model.updated_at,
+            ontology=ontology,
         )

--- a/src/api/management/presentation/data_sources/models.py
+++ b/src/api/management/presentation/data_sources/models.py
@@ -9,6 +9,113 @@ from pydantic import BaseModel, Field
 from management.application.services.data_source_service import DataSourceWithLatestRun
 from management.domain.aggregates import DataSource
 from management.domain.entities import DataSourceSyncRun
+from management.domain.value_objects import Ontology, OntologyEdgeType, OntologyNodeType
+
+
+class OntologyNodeTypeModel(BaseModel):
+    """Pydantic model for an ontology node type."""
+
+    label: str = Field(..., description="Node type label (e.g. 'Repository')")
+    description: str | None = Field(None, description="Optional description")
+    required_properties: list[str] = Field(
+        default_factory=list,
+        description="Property names that must be present on nodes of this type",
+    )
+    optional_properties: list[str] = Field(
+        default_factory=list,
+        description="Property names that may be present on nodes of this type",
+    )
+
+    @classmethod
+    def from_domain(cls, node_type: OntologyNodeType) -> OntologyNodeTypeModel:
+        """Convert domain OntologyNodeType to API model."""
+        return cls(
+            label=node_type.label,
+            description=node_type.description,
+            required_properties=list(node_type.required_properties),
+            optional_properties=list(node_type.optional_properties),
+        )
+
+    def to_domain(self) -> OntologyNodeType:
+        """Convert API model to domain OntologyNodeType."""
+        return OntologyNodeType(
+            label=self.label,
+            description=self.description,
+            required_properties=list(self.required_properties),
+            optional_properties=list(self.optional_properties),
+        )
+
+
+class OntologyEdgeTypeModel(BaseModel):
+    """Pydantic model for an ontology edge type."""
+
+    label: str = Field(..., description="Edge type label (e.g. 'HAS_PR')")
+    from_type: str = Field(..., description="Source node type label")
+    to_type: str = Field(..., description="Target node type label")
+    description: str | None = Field(None, description="Optional description")
+    required_properties: list[str] = Field(
+        default_factory=list,
+        description="Property names that must be present on edges of this type",
+    )
+    optional_properties: list[str] = Field(
+        default_factory=list,
+        description="Property names that may be present on edges of this type",
+    )
+
+    @classmethod
+    def from_domain(cls, edge_type: OntologyEdgeType) -> OntologyEdgeTypeModel:
+        """Convert domain OntologyEdgeType to API model."""
+        return cls(
+            label=edge_type.label,
+            from_type=edge_type.from_type,
+            to_type=edge_type.to_type,
+            description=edge_type.description,
+            required_properties=list(edge_type.required_properties),
+            optional_properties=list(edge_type.optional_properties),
+        )
+
+    def to_domain(self) -> OntologyEdgeType:
+        """Convert API model to domain OntologyEdgeType."""
+        return OntologyEdgeType(
+            label=self.label,
+            from_type=self.from_type,
+            to_type=self.to_type,
+            description=self.description,
+            required_properties=list(self.required_properties),
+            optional_properties=list(self.optional_properties),
+        )
+
+
+class OntologyModel(BaseModel):
+    """Pydantic model for an ontology."""
+
+    node_types: list[OntologyNodeTypeModel] = Field(
+        default_factory=list,
+        description="Node type definitions",
+    )
+    edge_types: list[OntologyEdgeTypeModel] = Field(
+        default_factory=list,
+        description="Edge type definitions",
+    )
+
+    @classmethod
+    def from_domain(cls, ontology: Ontology) -> OntologyModel:
+        """Convert domain Ontology to API model."""
+        return cls(
+            node_types=[
+                OntologyNodeTypeModel.from_domain(nt) for nt in ontology.node_types
+            ],
+            edge_types=[
+                OntologyEdgeTypeModel.from_domain(et) for et in ontology.edge_types
+            ],
+        )
+
+    def to_domain(self) -> Ontology:
+        """Convert API model to domain Ontology."""
+        return Ontology(
+            node_types=[nt.to_domain() for nt in self.node_types],
+            edge_types=[et.to_domain() for et in self.edge_types],
+        )
 
 
 class CreateDataSourceRequest(BaseModel):
@@ -31,6 +138,10 @@ class CreateDataSourceRequest(BaseModel):
     credentials: dict | None = Field(
         default=None,
         description="Optional credentials to encrypt and store securely",
+    )
+    ontology: OntologyModel | None = Field(
+        default=None,
+        description="Optional initial approved ontology for this data source",
     )
 
 
@@ -56,6 +167,10 @@ class UpdateDataSourceRequest(BaseModel):
         default=None,
         description="New credentials to encrypt and store (replaces existing)",
     )
+    ontology: OntologyModel | None = Field(
+        default=None,
+        description="Updated approved ontology (replaces existing)",
+    )
 
 
 class DataSourceResponse(BaseModel):
@@ -76,6 +191,10 @@ class DataSourceResponse(BaseModel):
     )
     created_at: datetime = Field(..., description="When the DS was created")
     updated_at: datetime = Field(..., description="When the DS was last updated")
+    ontology: OntologyModel | None = Field(
+        None,
+        description="Approved ontology for this data source, or null if not yet set",
+    )
 
     @classmethod
     def from_domain(cls, ds: DataSource) -> DataSourceResponse:
@@ -97,6 +216,11 @@ class DataSourceResponse(BaseModel):
             last_sync_at=ds.last_sync_at,
             created_at=ds.created_at,
             updated_at=ds.updated_at,
+            ontology=(
+                OntologyModel.from_domain(ds.ontology)
+                if ds.ontology is not None
+                else None
+            ),
         )
 
 
@@ -171,6 +295,10 @@ class DataSourceWithSyncResponse(BaseModel):
     )
     created_at: datetime = Field(..., description="When the DS was created")
     updated_at: datetime = Field(..., description="When the DS was last updated")
+    ontology: OntologyModel | None = Field(
+        None,
+        description="Approved ontology for this data source, or null if not yet set",
+    )
     latest_sync_run: SyncRunResponse | None = Field(
         None,
         description="Most recent sync run, or null if the data source has never synced",
@@ -199,6 +327,11 @@ class DataSourceWithSyncResponse(BaseModel):
             last_sync_at=ds.last_sync_at,
             created_at=ds.created_at,
             updated_at=ds.updated_at,
+            ontology=(
+                OntologyModel.from_domain(ds.ontology)
+                if ds.ontology is not None
+                else None
+            ),
             latest_sync_run=(
                 SyncRunResponse.from_domain(pair.latest_sync_run)
                 if pair.latest_sync_run is not None

--- a/src/api/management/presentation/data_sources/routes.py
+++ b/src/api/management/presentation/data_sources/routes.py
@@ -153,6 +153,9 @@ async def create_data_source(
         )
 
     try:
+        ontology = (
+            request.ontology.to_domain() if request.ontology is not None else None
+        )
         ds = await service.create(
             user_id=current_user.user_id.value,
             kg_id=kg_id,
@@ -160,6 +163,7 @@ async def create_data_source(
             adapter_type=adapter_type,
             connection_config=request.connection_config,
             raw_credentials=request.credentials,
+            ontology=ontology,
         )
         return DataSourceResponse.from_domain(ds)
 
@@ -336,6 +340,14 @@ async def update_data_source(
             connection_config=request.connection_config,
             raw_credentials=request.credentials,
         )
+
+        if request.ontology is not None:
+            ds = await service.update_ontology(
+                user_id=current_user.user_id.value,
+                ds_id=ds_id,
+                ontology=request.ontology.to_domain(),
+            )
+
         return DataSourceResponse.from_domain(ds)
 
     except UnauthorizedError:

--- a/src/api/tests/integration/management/test_data_source_repository.py
+++ b/src/api/tests/integration/management/test_data_source_repository.py
@@ -9,7 +9,12 @@ import pytest
 from sqlalchemy import text
 
 from management.domain.aggregates import DataSource, KnowledgeGraph
-from management.domain.value_objects import ScheduleType
+from management.domain.value_objects import (
+    Ontology,
+    OntologyEdgeType,
+    OntologyNodeType,
+    ScheduleType,
+)
 from management.infrastructure.repositories.data_source_repository import (
     DataSourceRepository,
 )
@@ -582,3 +587,155 @@ class TestDeleteRollback:
         assert retrieved is not None, (
             "DataSource must not be deleted when the transaction rolls back"
         )
+
+
+class TestDataSourceOntologyPersistence:
+    """Integration tests for ontology persistence in DataSourceRepository."""
+
+    @pytest.mark.asyncio
+    async def test_saves_and_retrieves_data_source_with_ontology(
+        self,
+        data_source_repository: DataSourceRepository,
+        knowledge_graph_repository: KnowledgeGraphRepository,
+        async_session,
+        test_tenant: str,
+        test_workspace: str,
+        clean_management_data,
+    ) -> None:
+        """save() + get_by_id() should round-trip the ontology field."""
+        kg = KnowledgeGraph.create(
+            tenant_id=test_tenant,
+            workspace_id=test_workspace,
+            name="Ontology Test KG",
+            description="KG for ontology tests",
+        )
+        async with async_session.begin():
+            await knowledge_graph_repository.save(kg)
+
+        ontology = Ontology(
+            node_types=[
+                OntologyNodeType(
+                    label="Repository",
+                    description="A code repository",
+                    required_properties=["url"],
+                    optional_properties=["description"],
+                )
+            ],
+            edge_types=[
+                OntologyEdgeType(
+                    label="HAS_PR",
+                    from_type="Repository",
+                    to_type="PullRequest",
+                )
+            ],
+        )
+
+        ds = DataSource.create(
+            knowledge_graph_id=kg.id.value,
+            tenant_id=test_tenant,
+            name="DS with Ontology",
+            adapter_type=DataSourceAdapterType.GITHUB,
+            connection_config={"repo": "org/repo"},
+            ontology=ontology,
+        )
+
+        async with async_session.begin():
+            await data_source_repository.save(ds)
+
+        retrieved = await data_source_repository.get_by_id(ds.id)
+
+        assert retrieved is not None
+        assert retrieved.ontology is not None
+        assert len(retrieved.ontology.node_types) == 1
+        assert retrieved.ontology.node_types[0].label == "Repository"
+        assert retrieved.ontology.node_types[0].description == "A code repository"
+        assert retrieved.ontology.node_types[0].required_properties == ["url"]
+        assert retrieved.ontology.node_types[0].optional_properties == ["description"]
+        assert len(retrieved.ontology.edge_types) == 1
+        assert retrieved.ontology.edge_types[0].label == "HAS_PR"
+        assert retrieved.ontology.edge_types[0].from_type == "Repository"
+        assert retrieved.ontology.edge_types[0].to_type == "PullRequest"
+
+    @pytest.mark.asyncio
+    async def test_saves_and_retrieves_data_source_with_null_ontology(
+        self,
+        data_source_repository: DataSourceRepository,
+        knowledge_graph_repository: KnowledgeGraphRepository,
+        async_session,
+        test_tenant: str,
+        test_workspace: str,
+        clean_management_data,
+    ) -> None:
+        """DataSource with no ontology should round-trip as None."""
+        kg = KnowledgeGraph.create(
+            tenant_id=test_tenant,
+            workspace_id=test_workspace,
+            name="Null Ontology KG",
+            description="KG for null ontology test",
+        )
+        async with async_session.begin():
+            await knowledge_graph_repository.save(kg)
+
+        ds = DataSource.create(
+            knowledge_graph_id=kg.id.value,
+            tenant_id=test_tenant,
+            name="DS without Ontology",
+            adapter_type=DataSourceAdapterType.GITHUB,
+            connection_config={"repo": "org/repo"},
+        )
+
+        async with async_session.begin():
+            await data_source_repository.save(ds)
+
+        retrieved = await data_source_repository.get_by_id(ds.id)
+
+        assert retrieved is not None
+        assert retrieved.ontology is None
+
+    @pytest.mark.asyncio
+    async def test_update_ontology_persists_change(
+        self,
+        data_source_repository: DataSourceRepository,
+        knowledge_graph_repository: KnowledgeGraphRepository,
+        async_session,
+        test_tenant: str,
+        test_workspace: str,
+        clean_management_data,
+    ) -> None:
+        """update_ontology() followed by save() should persist the new ontology."""
+        kg = KnowledgeGraph.create(
+            tenant_id=test_tenant,
+            workspace_id=test_workspace,
+            name="Update Ontology KG",
+            description="KG for ontology update test",
+        )
+        async with async_session.begin():
+            await knowledge_graph_repository.save(kg)
+
+        ds = DataSource.create(
+            knowledge_graph_id=kg.id.value,
+            tenant_id=test_tenant,
+            name="DS for Update",
+            adapter_type=DataSourceAdapterType.GITHUB,
+            connection_config={"repo": "org/repo"},
+        )
+
+        async with async_session.begin():
+            await data_source_repository.save(ds)
+
+        # Update with a new ontology
+        new_ontology = Ontology(
+            node_types=[OntologyNodeType(label="Issue", required_properties=["title"])],
+            edge_types=[],
+        )
+        ds.update_ontology(new_ontology)
+        async with async_session.begin():
+            await data_source_repository.save(ds)
+
+        retrieved = await data_source_repository.get_by_id(ds.id)
+
+        assert retrieved is not None
+        assert retrieved.ontology is not None
+        assert retrieved.ontology.node_types[0].label == "Issue"
+        assert retrieved.ontology.node_types[0].required_properties == ["title"]
+        assert retrieved.ontology.edge_types == []

--- a/src/api/tests/unit/management/application/test_data_source_service.py
+++ b/src/api/tests/unit/management/application/test_data_source_service.py
@@ -19,13 +19,14 @@ from management.domain.entities import DataSourceSyncRun
 from management.domain.value_objects import (
     DataSourceId,
     KnowledgeGraphId,
+    Ontology,
+    OntologyNodeType,
     Schedule,
     ScheduleType,
 )
 from management.ports.exceptions import UnauthorizedError
 from shared_kernel.authorization.types import Permission
 from shared_kernel.datasource_types import DataSourceAdapterType
-
 
 # ---------------------------------------------------------------------------
 # In-memory fakes
@@ -1148,3 +1149,150 @@ class TestDataSourceServiceListAllForUser:
 
         assert len(result) == 1
         assert result[0].latest_sync_run is None
+
+
+# ---- update_ontology ----
+
+
+class TestDataSourceServiceUpdateOntology:
+    """Tests for DataSourceService.update_ontology."""
+
+    @pytest.mark.asyncio
+    async def test_update_ontology_checks_edit_permission_on_ds(
+        self,
+        service: DataSourceService,
+        authz: _FakeAuthorizationProvider,
+        ds_repo: _FakeDataSourceRepository,
+        user_id: str,
+        tenant_id: str,
+    ) -> None:
+        """update_ontology() must check EDIT permission on the data source."""
+        ds = _make_ds(tenant_id=tenant_id)
+        ds_repo.seed(ds)
+        authz.grant_all()
+
+        ontology = Ontology(node_types=[OntologyNodeType(label="Repo")], edge_types=[])
+        await service.update_ontology(
+            user_id=user_id,
+            ds_id=ds.id.value,
+            ontology=ontology,
+        )
+
+        assert any(
+            call["resource"] == f"data_source:{ds.id.value}"
+            and call["permission"] == Permission.EDIT
+            for call in authz.check_permission_calls
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_ontology_raises_unauthorized_when_permission_denied(
+        self,
+        service: DataSourceService,
+        authz: _FakeAuthorizationProvider,
+        ds_repo: _FakeDataSourceRepository,
+        user_id: str,
+        tenant_id: str,
+    ) -> None:
+        """update_ontology() raises UnauthorizedError when user lacks EDIT permission."""
+        ds = _make_ds(tenant_id=tenant_id)
+        ds_repo.seed(ds)
+        authz.deny_all()
+
+        with pytest.raises(UnauthorizedError):
+            await service.update_ontology(
+                user_id=user_id,
+                ds_id=ds.id.value,
+                ontology=Ontology(node_types=[], edge_types=[]),
+            )
+
+    @pytest.mark.asyncio
+    async def test_update_ontology_raises_value_error_when_ds_not_found(
+        self,
+        service: DataSourceService,
+        authz: _FakeAuthorizationProvider,
+        user_id: str,
+    ) -> None:
+        """update_ontology() raises ValueError when DS not found."""
+        authz.grant_all()
+
+        with pytest.raises(ValueError, match="not found"):
+            await service.update_ontology(
+                user_id=user_id,
+                ds_id="nonexistent-id",
+                ontology=Ontology(node_types=[], edge_types=[]),
+            )
+
+    @pytest.mark.asyncio
+    async def test_update_ontology_raises_value_error_for_wrong_tenant(
+        self,
+        service: DataSourceService,
+        authz: _FakeAuthorizationProvider,
+        ds_repo: _FakeDataSourceRepository,
+        user_id: str,
+    ) -> None:
+        """update_ontology() raises ValueError when DS belongs to a different tenant."""
+        ds = _make_ds(tenant_id="other-tenant")
+        ds_repo.seed(ds)
+        authz.grant_all()
+
+        with pytest.raises(ValueError, match="not found"):
+            await service.update_ontology(
+                user_id=user_id,
+                ds_id=ds.id.value,
+                ontology=Ontology(node_types=[], edge_types=[]),
+            )
+
+    @pytest.mark.asyncio
+    async def test_update_ontology_persists_ontology_to_repository(
+        self,
+        service: DataSourceService,
+        authz: _FakeAuthorizationProvider,
+        ds_repo: _FakeDataSourceRepository,
+        user_id: str,
+        tenant_id: str,
+    ) -> None:
+        """update_ontology() should save the updated DS with ontology to the repo."""
+        ds = _make_ds(tenant_id=tenant_id)
+        ds_repo.seed(ds)
+        authz.grant_all()
+
+        new_ontology = Ontology(
+            node_types=[OntologyNodeType(label="Repository")],
+            edge_types=[],
+        )
+        result = await service.update_ontology(
+            user_id=user_id,
+            ds_id=ds.id.value,
+            ontology=new_ontology,
+        )
+
+        assert result.ontology == new_ontology
+        # Ensure repo has the updated DS
+        saved = await ds_repo.get_by_id(DataSourceId(value=ds.id.value))
+        assert saved is not None
+        assert saved.ontology == new_ontology
+
+    @pytest.mark.asyncio
+    async def test_update_ontology_returns_updated_data_source(
+        self,
+        service: DataSourceService,
+        authz: _FakeAuthorizationProvider,
+        ds_repo: _FakeDataSourceRepository,
+        user_id: str,
+        tenant_id: str,
+    ) -> None:
+        """update_ontology() should return the updated DataSource aggregate."""
+        ds = _make_ds(tenant_id=tenant_id)
+        ds_repo.seed(ds)
+        authz.grant_all()
+
+        ontology = Ontology(node_types=[OntologyNodeType(label="Issue")], edge_types=[])
+        result = await service.update_ontology(
+            user_id=user_id,
+            ds_id=ds.id.value,
+            ontology=ontology,
+        )
+
+        assert result.id == ds.id
+        assert result.ontology is not None
+        assert result.ontology.node_types[0].label == "Issue"

--- a/src/api/tests/unit/management/presentation/test_data_sources_routes.py
+++ b/src/api/tests/unit/management/presentation/test_data_sources_routes.py
@@ -18,7 +18,14 @@ from iam.domain.value_objects import TenantId, UserId
 from management.application.services.data_source_service import DataSourceService
 from management.domain.aggregates import DataSource
 from management.domain.entities import DataSourceSyncRun
-from management.domain.value_objects import DataSourceId, Schedule, ScheduleType
+from management.domain.value_objects import (
+    DataSourceId,
+    Ontology,
+    OntologyEdgeType,
+    OntologyNodeType,
+    Schedule,
+    ScheduleType,
+)
 from management.ports.exceptions import UnauthorizedError
 from management.ports.repositories import IDataSourceSyncRunRepository
 from shared_kernel.datasource_types import DataSourceAdapterType
@@ -215,6 +222,7 @@ class TestCreateDataSourceRoute:
             adapter_type=DataSourceAdapterType("github"),
             connection_config={"repo": "org/repo"},
             raw_credentials=None,
+            ontology=None,
         )
 
     def test_create_data_source_with_credentials(
@@ -245,6 +253,7 @@ class TestCreateDataSourceRoute:
             adapter_type=DataSourceAdapterType("github"),
             connection_config={"repo": "org/repo"},
             raw_credentials={"token": "ghp_secret"},  # gitleaks:allow
+            ontology=None,
         )
 
     def test_create_data_source_returns_403_when_unauthorized(
@@ -896,3 +905,157 @@ class TestDeleteDataSourceRoute:
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestOntologyInDataSourceRoutes:
+    """Tests for ontology field in data source create/update/response."""
+
+    def _make_ds_with_ontology(
+        self,
+        mock_current_user: "CurrentUser",
+        ontology: "Ontology | None",
+    ) -> DataSource:
+        """Create a sample DataSource with an optional ontology."""
+        from datetime import UTC, datetime
+
+        now = datetime.now(UTC)
+        return DataSource(
+            id=DataSourceId(value="01JPQRST1234567890ABCDEFDS"),
+            knowledge_graph_id="01JPQRST1234567890ABCDEFKG",
+            tenant_id=mock_current_user.tenant_id.value,
+            name="My Data Source",
+            adapter_type=DataSourceAdapterType.GITHUB,
+            connection_config={"repo": "org/repo"},
+            credentials_path=None,
+            schedule=Schedule(schedule_type=ScheduleType.MANUAL),
+            last_sync_at=None,
+            ontology=ontology,
+            created_at=now,
+            updated_at=now,
+        )
+
+    def test_response_includes_ontology_when_present(
+        self,
+        test_client: TestClient,
+        mock_ds_service: AsyncMock,
+        mock_current_user: "CurrentUser",
+    ) -> None:
+        """DataSourceResponse should include the ontology when set."""
+        ontology = Ontology(
+            node_types=[
+                OntologyNodeType(
+                    label="Repository",
+                    description="A code repo",
+                    required_properties=["url"],
+                    optional_properties=["description"],
+                )
+            ],
+            edge_types=[
+                OntologyEdgeType(
+                    label="HAS_PR",
+                    from_type="Repository",
+                    to_type="PullRequest",
+                )
+            ],
+        )
+        ds = self._make_ds_with_ontology(mock_current_user, ontology=ontology)
+        kg_id = ds.knowledge_graph_id
+        mock_ds_service.list_for_knowledge_graph.return_value = [ds]
+
+        response = test_client.get(f"/management/knowledge-graphs/{kg_id}/data-sources")
+
+        assert response.status_code == status.HTTP_200_OK
+        result = response.json()
+        assert len(result) == 1
+        assert result[0]["ontology"] is not None
+        assert result[0]["ontology"]["node_types"][0]["label"] == "Repository"
+        assert result[0]["ontology"]["edge_types"][0]["label"] == "HAS_PR"
+
+    def test_response_includes_null_ontology_when_not_set(
+        self,
+        test_client: TestClient,
+        mock_ds_service: AsyncMock,
+        mock_current_user: "CurrentUser",
+    ) -> None:
+        """DataSourceResponse should include ontology=null when not set."""
+        ds = self._make_ds_with_ontology(mock_current_user, ontology=None)
+        kg_id = ds.knowledge_graph_id
+        mock_ds_service.list_for_knowledge_graph.return_value = [ds]
+
+        response = test_client.get(f"/management/knowledge-graphs/{kg_id}/data-sources")
+
+        assert response.status_code == status.HTTP_200_OK
+        result = response.json()
+        assert result[0]["ontology"] is None
+
+    def test_create_with_ontology_passes_ontology_to_service(
+        self,
+        test_client: TestClient,
+        mock_ds_service: AsyncMock,
+        mock_current_user: "CurrentUser",
+    ) -> None:
+        """POST /data-sources with ontology should call service.create() with ontology."""
+        ds = self._make_ds_with_ontology(mock_current_user, ontology=None)
+        mock_ds_service.create.return_value = ds
+
+        kg_id = "01JPQRST1234567890ABCDEFKG"
+        response = test_client.post(
+            f"/management/knowledge-graphs/{kg_id}/data-sources",
+            json={
+                "name": "My Data Source",
+                "adapter_type": "github",
+                "connection_config": {"repo": "org/repo"},
+                "ontology": {
+                    "node_types": [
+                        {
+                            "label": "Repository",
+                            "description": None,
+                            "required_properties": [],
+                            "optional_properties": [],
+                        }
+                    ],
+                    "edge_types": [],
+                },
+            },
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        # Verify the service was called with an ontology kwarg
+        call_kwargs = mock_ds_service.create.call_args.kwargs
+        assert "ontology" in call_kwargs
+        assert call_kwargs["ontology"] is not None
+
+    def test_update_with_ontology_calls_update_ontology_on_service(
+        self,
+        test_client: TestClient,
+        mock_ds_service: AsyncMock,
+        mock_current_user: "CurrentUser",
+    ) -> None:
+        """PATCH /data-sources/{id} with ontology calls service.update_ontology()."""
+        ds = self._make_ds_with_ontology(mock_current_user, ontology=None)
+        mock_ds_service.update.return_value = ds
+        mock_ds_service.update_ontology.return_value = ds
+
+        ds_id = ds.id.value
+        response = test_client.patch(
+            f"/management/data-sources/{ds_id}",
+            json={
+                "ontology": {
+                    "node_types": [
+                        {
+                            "label": "Issue",
+                            "description": "A GitHub issue",
+                            "required_properties": ["title"],
+                            "optional_properties": [],
+                        }
+                    ],
+                    "edge_types": [],
+                }
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_ds_service.update_ontology.assert_called_once()
+        call_kwargs = mock_ds_service.update_ontology.call_args.kwargs
+        assert call_kwargs["ds_id"] == ds_id
+        assert call_kwargs["user_id"] == mock_current_user.user_id.value

--- a/src/api/tests/unit/management/test_data_source.py
+++ b/src/api/tests/unit/management/test_data_source.py
@@ -22,6 +22,8 @@ from management.domain.exceptions import (
 from management.domain.observability import DataSourceProbe
 from management.domain.value_objects import (
     DataSourceId,
+    Ontology,
+    OntologyNodeType,
     Schedule,
     ScheduleType,
 )
@@ -668,3 +670,135 @@ class TestDataSourceValidation:
                 adapter_type=DataSourceAdapterType.GITHUB,
                 connection_config={},
             )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_data_source(ontology: Ontology | None = None) -> DataSource:
+    """Create a DataSource aggregate for testing."""
+    now = datetime.now(UTC)
+    return DataSource(
+        id=DataSourceId.generate(),
+        knowledge_graph_id="kg-test",
+        tenant_id="tenant-test",
+        name="Test Source",
+        adapter_type=DataSourceAdapterType.GITHUB,
+        connection_config={"repo": "org/repo"},
+        credentials_path=None,
+        schedule=Schedule(schedule_type=ScheduleType.MANUAL),
+        last_sync_at=None,
+        ontology=ontology,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class TestDataSourceOntologyField:
+    """Tests for DataSource.ontology field."""
+
+    def test_ontology_defaults_to_none_on_create(self) -> None:
+        """DataSource.create() should produce a DS with ontology=None by default."""
+        ds = DataSource.create(
+            knowledge_graph_id="kg-1",
+            tenant_id="t",
+            name="Source",
+            adapter_type=DataSourceAdapterType.GITHUB,
+            connection_config={},
+        )
+        assert ds.ontology is None
+
+    def test_data_source_stores_ontology(self) -> None:
+        """DataSource with an Ontology should expose it via .ontology."""
+        ontology = Ontology(
+            node_types=[OntologyNodeType(label="Repository")],
+            edge_types=[],
+        )
+        ds = _make_data_source(ontology=ontology)
+        assert ds.ontology is not None
+        assert ds.ontology.node_types[0].label == "Repository"
+
+    def test_data_source_accepts_none_ontology(self) -> None:
+        """DataSource with ontology=None should be valid."""
+        ds = _make_data_source(ontology=None)
+        assert ds.ontology is None
+
+
+class TestDataSourceUpdateOntology:
+    """Tests for DataSource.update_ontology() method."""
+
+    def test_update_ontology_sets_ontology(self) -> None:
+        """update_ontology() should replace the stored ontology."""
+        ds = _make_data_source(ontology=None)
+        new_ontology = Ontology(
+            node_types=[OntologyNodeType(label="Issue")],
+            edge_types=[],
+        )
+        ds.update_ontology(new_ontology)
+        assert ds.ontology == new_ontology
+
+    def test_update_ontology_replaces_existing_ontology(self) -> None:
+        """update_ontology() should replace a previously stored ontology."""
+        initial_ontology = Ontology(
+            node_types=[OntologyNodeType(label="OldType")],
+            edge_types=[],
+        )
+        ds = _make_data_source(ontology=initial_ontology)
+
+        new_ontology = Ontology(
+            node_types=[OntologyNodeType(label="NewType")],
+            edge_types=[],
+        )
+        ds.update_ontology(new_ontology)
+
+        assert ds.ontology is not None
+        assert ds.ontology.node_types[0].label == "NewType"
+
+    def test_update_ontology_bumps_updated_at(self) -> None:
+        """update_ontology() should update updated_at to the current time."""
+        ds = _make_data_source(ontology=None)
+        original_updated_at = ds.updated_at
+        ds.update_ontology(Ontology(node_types=[], edge_types=[]))
+        assert ds.updated_at >= original_updated_at
+
+    def test_update_ontology_emits_data_source_updated_event(self) -> None:
+        """update_ontology() should emit a DataSourceUpdated domain event."""
+        ds = _make_data_source(ontology=None)
+        ds.update_ontology(Ontology(node_types=[], edge_types=[]))
+        events = ds.collect_events()
+        assert any(isinstance(e, DataSourceUpdated) for e in events)
+
+    def test_update_ontology_raises_on_deleted_data_source(self) -> None:
+        """update_ontology() should raise AggregateDeletedError if DS is deleted."""
+        ds = _make_data_source(ontology=None)
+        ds.mark_for_deletion(deleted_by="user-1")
+        ds.collect_events()  # clear events
+
+        with pytest.raises(AggregateDeletedError):
+            ds.update_ontology(Ontology(node_types=[], edge_types=[]))
+
+    def test_update_ontology_with_empty_ontology(self) -> None:
+        """update_ontology() accepts an empty Ontology (no node or edge types)."""
+        ds = _make_data_source(
+            ontology=Ontology(
+                node_types=[OntologyNodeType(label="Existing")],
+                edge_types=[],
+            )
+        )
+        ds.update_ontology(Ontology(node_types=[], edge_types=[]))
+        assert ds.ontology is not None
+        assert ds.ontology.node_types == []
+
+    def test_update_ontology_event_carries_correct_ids(self) -> None:
+        """DataSourceUpdated event emitted by update_ontology should carry correct IDs."""
+        ds = _make_data_source(ontology=None)
+        ds.update_ontology(Ontology(node_types=[], edge_types=[]))
+        events = ds.collect_events()
+        updated_events = [e for e in events if isinstance(e, DataSourceUpdated)]
+        assert len(updated_events) == 1
+        event = updated_events[0]
+        assert event.data_source_id == ds.id.value
+        assert event.knowledge_graph_id == ds.knowledge_graph_id
+        assert event.tenant_id == ds.tenant_id

--- a/src/api/tests/unit/management/test_value_objects.py
+++ b/src/api/tests/unit/management/test_value_objects.py
@@ -10,6 +10,9 @@ from management.domain.value_objects import (
     BaseId,
     DataSourceId,
     KnowledgeGraphId,
+    Ontology,
+    OntologyEdgeType,
+    OntologyNodeType,
     Schedule,
     ScheduleType,
 )
@@ -210,3 +213,249 @@ class TestSchedule:
         s1 = Schedule(schedule_type=ScheduleType.MANUAL)
         s2 = Schedule(schedule_type=ScheduleType.CRON, value="0 * * * *")
         assert s1 != s2
+
+
+class TestOntologyNodeType:
+    """Tests for OntologyNodeType value object."""
+
+    def test_create_with_label_only(self) -> None:
+        """OntologyNodeType with only a label should be valid."""
+        node_type = OntologyNodeType(label="Repository")
+        assert node_type.label == "Repository"
+        assert node_type.description is None
+        assert node_type.required_properties == []
+        assert node_type.optional_properties == []
+
+    def test_create_with_all_fields(self) -> None:
+        """OntologyNodeType with all fields should store them correctly."""
+        node_type = OntologyNodeType(
+            label="PullRequest",
+            description="A GitHub pull request",
+            required_properties=["title", "number"],
+            optional_properties=["body", "merged_at"],
+        )
+        assert node_type.label == "PullRequest"
+        assert node_type.description == "A GitHub pull request"
+        assert node_type.required_properties == ["title", "number"]
+        assert node_type.optional_properties == ["body", "merged_at"]
+
+    def test_equality_by_value(self) -> None:
+        """Two OntologyNodeType instances with same values should be equal."""
+        n1 = OntologyNodeType(
+            label="Issue",
+            required_properties=["title"],
+        )
+        n2 = OntologyNodeType(
+            label="Issue",
+            required_properties=["title"],
+        )
+        assert n1 == n2
+
+    def test_inequality_different_label(self) -> None:
+        """OntologyNodeType instances with different labels should not be equal."""
+        n1 = OntologyNodeType(label="Issue")
+        n2 = OntologyNodeType(label="PullRequest")
+        assert n1 != n2
+
+    def test_is_frozen(self) -> None:
+        """OntologyNodeType should be immutable (frozen dataclass)."""
+        node_type = OntologyNodeType(label="Repo")
+        with pytest.raises((AttributeError, TypeError)):
+            node_type.label = "changed"  # type: ignore[misc]
+
+    def test_required_properties_defaults_to_empty_list(self) -> None:
+        """required_properties should default to empty list, not None."""
+        node_type = OntologyNodeType(label="Commit")
+        assert isinstance(node_type.required_properties, list)
+        assert node_type.required_properties == []
+
+    def test_optional_properties_defaults_to_empty_list(self) -> None:
+        """optional_properties should default to empty list, not None."""
+        node_type = OntologyNodeType(label="Commit")
+        assert isinstance(node_type.optional_properties, list)
+        assert node_type.optional_properties == []
+
+
+class TestOntologyEdgeType:
+    """Tests for OntologyEdgeType value object."""
+
+    def test_create_with_label_from_to(self) -> None:
+        """OntologyEdgeType with label, from_type, to_type should be valid."""
+        edge_type = OntologyEdgeType(
+            label="CREATED_BY",
+            from_type="PullRequest",
+            to_type="User",
+        )
+        assert edge_type.label == "CREATED_BY"
+        assert edge_type.from_type == "PullRequest"
+        assert edge_type.to_type == "User"
+        assert edge_type.description is None
+        assert edge_type.required_properties == []
+        assert edge_type.optional_properties == []
+
+    def test_create_with_all_fields(self) -> None:
+        """OntologyEdgeType with all fields should store them correctly."""
+        edge_type = OntologyEdgeType(
+            label="HAS_ISSUE",
+            from_type="Repository",
+            to_type="Issue",
+            description="A repository contains issues",
+            required_properties=["created_at"],
+            optional_properties=["closed_at"],
+        )
+        assert edge_type.description == "A repository contains issues"
+        assert edge_type.required_properties == ["created_at"]
+        assert edge_type.optional_properties == ["closed_at"]
+
+    def test_equality_by_value(self) -> None:
+        """Two OntologyEdgeType instances with same values should be equal."""
+        e1 = OntologyEdgeType(
+            label="HAS_COMMIT",
+            from_type="PullRequest",
+            to_type="Commit",
+        )
+        e2 = OntologyEdgeType(
+            label="HAS_COMMIT",
+            from_type="PullRequest",
+            to_type="Commit",
+        )
+        assert e1 == e2
+
+    def test_inequality_different_label(self) -> None:
+        """OntologyEdgeType instances with different labels should not be equal."""
+        e1 = OntologyEdgeType(label="CREATED_BY", from_type="PR", to_type="User")
+        e2 = OntologyEdgeType(label="ASSIGNED_TO", from_type="PR", to_type="User")
+        assert e1 != e2
+
+    def test_is_frozen(self) -> None:
+        """OntologyEdgeType should be immutable (frozen dataclass)."""
+        edge_type = OntologyEdgeType(label="HAS", from_type="A", to_type="B")
+        with pytest.raises((AttributeError, TypeError)):
+            edge_type.label = "changed"  # type: ignore[misc]
+
+
+class TestOntology:
+    """Tests for Ontology value object."""
+
+    def test_empty_ontology_is_valid(self) -> None:
+        """Ontology with no types is valid (empty = no approval yet)."""
+        ontology = Ontology(node_types=[], edge_types=[])
+        assert ontology.node_types == []
+        assert ontology.edge_types == []
+
+    def test_ontology_with_node_and_edge_types(self) -> None:
+        """Ontology stores node_types and edge_types correctly."""
+        node_types = [
+            OntologyNodeType(label="Repository"),
+            OntologyNodeType(label="PullRequest"),
+        ]
+        edge_types = [
+            OntologyEdgeType(
+                label="HAS_PR", from_type="Repository", to_type="PullRequest"
+            ),
+        ]
+        ontology = Ontology(node_types=node_types, edge_types=edge_types)
+        assert len(ontology.node_types) == 2
+        assert len(ontology.edge_types) == 1
+        assert ontology.node_types[0].label == "Repository"
+        assert ontology.edge_types[0].label == "HAS_PR"
+
+    def test_equality_by_value(self) -> None:
+        """Two Ontology instances with same contents should be equal."""
+        node = OntologyNodeType(label="Issue")
+        o1 = Ontology(node_types=[node], edge_types=[])
+        o2 = Ontology(node_types=[node], edge_types=[])
+        assert o1 == o2
+
+    def test_inequality_different_node_types(self) -> None:
+        """Ontology instances with different node types should not be equal."""
+        o1 = Ontology(node_types=[OntologyNodeType(label="A")], edge_types=[])
+        o2 = Ontology(node_types=[OntologyNodeType(label="B")], edge_types=[])
+        assert o1 != o2
+
+    def test_is_frozen(self) -> None:
+        """Ontology should be immutable."""
+        ontology = Ontology(node_types=[], edge_types=[])
+        with pytest.raises((AttributeError, TypeError)):
+            ontology.node_types = []  # type: ignore[misc]
+
+    def test_to_dict_serializes_correctly(self) -> None:
+        """to_dict() should produce a JSON-serializable dictionary."""
+        ontology = Ontology(
+            node_types=[
+                OntologyNodeType(
+                    label="Repository",
+                    description="A code repository",
+                    required_properties=["url"],
+                    optional_properties=["description"],
+                )
+            ],
+            edge_types=[
+                OntologyEdgeType(
+                    label="HAS_PR",
+                    from_type="Repository",
+                    to_type="PullRequest",
+                )
+            ],
+        )
+        result = ontology.to_dict()
+        assert isinstance(result, dict)
+        assert "node_types" in result
+        assert "edge_types" in result
+        assert result["node_types"][0]["label"] == "Repository"
+        assert result["node_types"][0]["description"] == "A code repository"
+        assert result["node_types"][0]["required_properties"] == ["url"]
+        assert result["edge_types"][0]["label"] == "HAS_PR"
+        assert result["edge_types"][0]["from_type"] == "Repository"
+
+    def test_from_dict_deserializes_correctly(self) -> None:
+        """from_dict() should reconstruct an Ontology from a dictionary."""
+        data = {
+            "node_types": [
+                {
+                    "label": "Issue",
+                    "description": "A GitHub issue",
+                    "required_properties": ["title"],
+                    "optional_properties": ["body"],
+                }
+            ],
+            "edge_types": [
+                {
+                    "label": "CREATED_BY",
+                    "from_type": "Issue",
+                    "to_type": "User",
+                    "description": None,
+                    "required_properties": [],
+                    "optional_properties": [],
+                }
+            ],
+        }
+        ontology = Ontology.from_dict(data)
+        assert len(ontology.node_types) == 1
+        assert ontology.node_types[0].label == "Issue"
+        assert ontology.node_types[0].description == "A GitHub issue"
+        assert ontology.node_types[0].required_properties == ["title"]
+        assert len(ontology.edge_types) == 1
+        assert ontology.edge_types[0].label == "CREATED_BY"
+
+    def test_roundtrip_serialization(self) -> None:
+        """to_dict() → from_dict() should reconstruct the same Ontology."""
+        original = Ontology(
+            node_types=[
+                OntologyNodeType(
+                    label="Commit",
+                    description="A git commit",
+                    required_properties=["sha"],
+                    optional_properties=["message"],
+                )
+            ],
+            edge_types=[
+                OntologyEdgeType(
+                    label="AUTHORED_BY",
+                    from_type="Commit",
+                    to_type="User",
+                )
+            ],
+        )
+        restored = Ontology.from_dict(original.to_dict())
+        assert restored == original


### PR DESCRIPTION
## Summary

The UI's Ontology Design flow (data-sources page) is fully implemented in the
frontend but has no backend support. When a user:
- Approves a proposed ontology after the agent-scan step, or
- Edits an existing ontology via the ontology editor dialog

…the backend silently discards the `ontology` payload because `DataSource`
has no ontology field in the domain, repository, or API layer. The UI even
comments this explicitly: *"Pre-populate with the GitHub proposal as a
stand-in for the stored ontology. In a real implementation this would load
from the server."*

This PR adds end-to-end ontology storage to the Management bounded context.

## What this change does

### Domain (Management)
- Add `OntologyNodeType` and `OntologyEdgeType` value objects (label,
  description, required_properties, optional_properties; edge type adds
  from_type and to_type).
- Add `Ontology` value object that aggregates a list of node types and edge
  types. An empty `Ontology` (no types defined) is valid.
- Add `ontology: Ontology | None` field to the `DataSource` aggregate
  (None = no ontology approved yet).
- Add `update_ontology(ontology: Ontology)` method on `DataSource` that
  replaces the stored ontology and emits `DataSourceUpdated`.

### Infrastructure (Management)
- Update `DataSourceRepository` to persist and load the `ontology` field.
  Store as JSONB in the existing `data_sources` table (new nullable column
  `ontology_json`).
- Add a database migration for the new column.

### Application (Management)
- Add `update_ontology(user_id, ds_id, ontology)` to `DataSourceService`.
  Authorises via `edit` permission on the data source.

### Presentation (Management)
- Add `OntologyNodeTypeModel`, `OntologyEdgeTypeModel`, and `OntologyModel`
  Pydantic models.
- Add `ontology: OntologyModel | None` to `CreateDataSourceRequest` (so
  the initial approval step can include the proposed ontology).
- Add `ontology: OntologyModel | None` to `UpdateDataSourceRequest`.
- Add `ontology: OntologyModel | None` to `DataSourceResponse`.
- Wire the `PATCH /data-sources/{ds_id}` handler to call
  `service.update_ontology(...)` when the `ontology` field is present.
- Wire the `POST /data-sources` handler to attach the ontology to the new
  data source when `ontology` is provided at creation time.

## Spec requirements satisfied

From `specs/ui/experience.spec.md` — **Requirement: Ontology Design**:

- **Scenario: Ontology review and approval** — `POST /data-sources` now
  accepts the proposed ontology so it is stored when the user approves.
- **Scenario: Individual type editing** — `PATCH /data-sources/{id}` now
  accepts `{ontology: {...}}` and persists the updated types, making the
  existing UI `saveOntology()` call functional.
- **Scenario: Ontology change after initial extraction** — `DataSourceResponse`
  now returns the stored ontology, allowing the UI to populate the editor
  from the server rather than from hardcoded fixture data.

Note: **Scenario: Agent-proposed ontology** and **Scenario: Intent
description** (the AI-driven scan + proposal backend) remain out of scope;
they depend on Extraction context work blocked by AIHCM-174.

## Key design decisions

- **JSONB column**: Ontology is schema-flexible (arbitrary property names)
  and read back as a whole; JSONB is the right fit over normalised tables.
- **Nullable at domain level**: An empty/null ontology is valid — most data
  sources will start without one and gain it after the agent-proposal step.
- **No new endpoint**: Ontology updates flow through the existing PATCH
  endpoint to keep the API surface minimal; the new field is purely additive.
- **No extraction trigger here**: Triggering re-extraction when ontology
  changes is Extraction-context responsibility and is deferred to AIHCM-174.

## Files / areas affected

- `management/domain/value_objects.py` — new value objects
- `management/domain/aggregates/data_source.py` — new field + method
- `management/infrastructure/repositories/data_source_repository.py`
- `migrations/versions/<new_migration>.py`
- `management/application/services/data_source_service.py`
- `management/presentation/data_sources/models.py`
- `management/presentation/data_sources/routes.py`
- `tests/unit/management/**` — new TDD unit tests for each layer
- `tests/integration/management/**` — integration test covering the full
  create-with-ontology and patch-ontology round-trips

## How to verify

1. `make test-unit` passes with new domain and service tests.
2. `make test-integration` passes — specifically:
   - `POST /data-sources` with `ontology` stores and returns it.
   - `GET /data-sources/{id}` returns the stored ontology.
   - `PATCH /data-sources/{id}` with `{ontology: {...}}` updates and
     returns the new ontology.
3. Open the dev UI, add a GitHub data source, complete the ontology-proposal
   step, approve — then view the data source and click "Edit ontology". The
   editor should populate from the server, not from fixture data.

## Caveats / follow-up

- Re-extraction trigger on ontology change deferred to AIHCM-174 (Extraction
  context spike).
- The simulated agent scan in the frontend (GITHUB_PROPOSAL_NODES/EDGES)
  will be replaced by a real backend scan endpoint in a future task, also
  gated on AIHCM-174.

---

**Task:** `task-130`
**Spec:** `specs/ui/experience.spec.md@e77913c2cc6d8b719291e2dbb6870519a94d50da`

### Merge

The orchestrator will squash-merge this PR automatically
once all pipeline steps pass.

---

This PR was created by [hyperloop](https://github.com/jsell-rh/hyperloop),
an AI agent orchestrator.