### PR TITLE
feat(management): add OntologyConfig persistence to KnowledgeGraph aggregate with GET/PUT API

### DIFF
--- a/src/api/infrastructure/migrations/versions/a1b2c3d4e5f6_add_ontology_jsonb_to_knowledge_graphs.py
+++ b/src/api/infrastructure/migrations/versions/a1b2c3d4e5f6_add_ontology_jsonb_to_knowledge_graphs.py
@@ -1,0 +1,36 @@
+"""Add nullable JSONB ontology column to knowledge_graphs table.
+
+Adds an ``ontology`` JSONB column to store per-KnowledgeGraph ontology
+configuration (node types, edge types, approval state).  The column is
+nullable so existing rows are unaffected (NULL means no ontology saved).
+
+Revision ID: a1b2c3d4e5f6
+Revises: f183acf6d089
+Create Date: 2026-05-03 17:34:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, Sequence[str], None] = "f183acf6d089"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add nullable JSONB ontology column to knowledge_graphs."""
+    op.add_column(
+        "knowledge_graphs",
+        sa.Column("ontology", JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Remove ontology column from knowledge_graphs."""
+    op.drop_column("knowledge_graphs", "ontology")

--- a/src/api/management/application/services/knowledge_graph_service.py
+++ b/src/api/management/application/services/knowledge_graph_service.py
@@ -14,7 +14,7 @@ from management.application.observability import (
     KnowledgeGraphServiceProbe,
 )
 from management.domain.aggregates import KnowledgeGraph
-from management.domain.value_objects import KnowledgeGraphId
+from management.domain.value_objects import KnowledgeGraphId, OntologyConfig
 from management.ports.exceptions import (
     DuplicateKnowledgeGraphNameError,
     KnowledgeGraphNotFoundError,
@@ -491,3 +491,84 @@ class KnowledgeGraphService:
         self._probe.knowledge_graph_deleted(kg_id=kg_id)
 
         return True
+
+    async def get_ontology(
+        self,
+        user_id: str,
+        kg_id: str,
+    ) -> OntologyConfig | None:
+        """Retrieve the ontology for a knowledge graph.
+
+        Returns None when no ontology has been saved yet (caller should
+        convert to 404). Returns None also when the KG does not exist or
+        the caller lacks VIEW permission (existence leakage prevention).
+
+        Args:
+            user_id: The user requesting access
+            kg_id: The knowledge graph ID
+
+        Returns:
+            The OntologyConfig if one has been saved, otherwise None
+        """
+        kg = await self._kg_repo.get_by_id(KnowledgeGraphId(value=kg_id))
+        if kg is None or kg.tenant_id != self._scope_to_tenant:
+            return None
+
+        has_view = await self._check_permission(
+            user_id=user_id,
+            resource_type=ResourceType.KNOWLEDGE_GRAPH,
+            resource_id=kg_id,
+            permission=Permission.VIEW,
+        )
+        if not has_view:
+            return None
+
+        return await self._kg_repo.get_ontology(kg_id)
+
+    async def save_ontology(
+        self,
+        user_id: str,
+        kg_id: str,
+        config: OntologyConfig,
+    ) -> OntologyConfig:
+        """Persist an ontology configuration for a knowledge graph.
+
+        Requires EDIT permission on the knowledge graph. Performs a full
+        replace (not a merge) of the stored ontology.
+
+        Args:
+            user_id: The user performing the operation
+            kg_id: The knowledge graph ID
+            config: The OntologyConfig to persist
+
+        Returns:
+            The stored OntologyConfig (same as input)
+
+        Raises:
+            UnauthorizedError: If user lacks EDIT permission
+            KnowledgeGraphNotFoundError: If KG does not exist in this tenant
+        """
+        has_edit = await self._check_permission(
+            user_id=user_id,
+            resource_type=ResourceType.KNOWLEDGE_GRAPH,
+            resource_id=kg_id,
+            permission=Permission.EDIT,
+        )
+        if not has_edit:
+            self._probe.permission_denied(
+                user_id=user_id,
+                resource_id=kg_id,
+                permission=Permission.EDIT,
+            )
+            raise UnauthorizedError(
+                f"User {user_id} lacks edit permission on knowledge graph {kg_id}"
+            )
+
+        kg = await self._kg_repo.get_by_id(KnowledgeGraphId(value=kg_id))
+        if kg is None or kg.tenant_id != self._scope_to_tenant:
+            raise KnowledgeGraphNotFoundError(f"Knowledge graph {kg_id} not found")
+
+        async with self._session.begin():
+            await self._kg_repo.save_ontology(kg_id, config)
+
+        return config

--- a/src/api/management/domain/aggregates/knowledge_graph.py
+++ b/src/api/management/domain/aggregates/knowledge_graph.py
@@ -20,7 +20,7 @@ from management.domain.observability import (
     DefaultKnowledgeGraphProbe,
     KnowledgeGraphProbe,
 )
-from management.domain.value_objects import KnowledgeGraphId
+from management.domain.value_objects import KnowledgeGraphId, OntologyConfig
 
 if TYPE_CHECKING:
     from management.domain.events import DomainEvent
@@ -50,6 +50,7 @@ class KnowledgeGraph:
     description: str
     created_at: datetime
     updated_at: datetime
+    ontology: OntologyConfig | None = field(default=None)
     _pending_events: list[DomainEvent] = field(default_factory=list, repr=False)
     _probe: KnowledgeGraphProbe = field(
         default_factory=DefaultKnowledgeGraphProbe,
@@ -193,6 +194,41 @@ class KnowledgeGraph:
             tenant_id=self.tenant_id,
             name=name,
         )
+
+    def set_ontology(self, config: OntologyConfig) -> None:
+        """Store an ontology configuration on this knowledge graph.
+
+        Records no domain events — ontology changes are persisted via
+        KnowledgeGraphRepository.save_ontology() without triggering the outbox.
+
+        Args:
+            config: The OntologyConfig to attach
+
+        Raises:
+            AggregateDeletedError: If the knowledge graph has been deleted
+        """
+        if self._deleted:
+            raise AggregateDeletedError(
+                "Cannot set ontology on a deleted knowledge graph"
+            )
+        self.ontology = config
+        self.updated_at = datetime.now(UTC)
+
+    def clear_ontology(self) -> None:
+        """Remove the ontology configuration from this knowledge graph.
+
+        Records no domain events — ontology changes are persisted via
+        KnowledgeGraphRepository.save_ontology() without triggering the outbox.
+
+        Raises:
+            AggregateDeletedError: If the knowledge graph has been deleted
+        """
+        if self._deleted:
+            raise AggregateDeletedError(
+                "Cannot clear ontology on a deleted knowledge graph"
+            )
+        self.ontology = None
+        self.updated_at = datetime.now(UTC)
 
     def mark_for_deletion(
         self,

--- a/src/api/management/domain/value_objects.py
+++ b/src/api/management/domain/value_objects.py
@@ -7,6 +7,7 @@ domain semantics for identifiers and domain concepts.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import StrEnum
 from typing import Any, TypeVar
 
@@ -249,3 +250,149 @@ class Ontology:
             for et in data.get("edge_types", [])
         ]
         return cls(node_types=node_types, edge_types=edge_types)
+
+
+# ---------------------------------------------------------------------------
+# Typed ontology value objects (used by KnowledgeGraph ontology API)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NodeTypeDefinition:
+    """Defines a node type in an ontology.
+
+    A node type describes a category of entities in the knowledge graph.
+    The label must be non-empty. Properties are stored as immutable tuples
+    to preserve value-object semantics.
+
+    Attributes:
+        label: Unique name for this node type (required, non-empty)
+        description: Human-readable explanation of this node type
+        required_properties: Properties that every node of this type must have
+        optional_properties: Properties that nodes of this type may have
+    """
+
+    label: str
+    description: str = ""
+    required_properties: tuple[str, ...] = field(default_factory=tuple)
+    optional_properties: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        """Validate that label is non-empty."""
+        if not self.label or not self.label.strip():
+            raise ValueError("NodeTypeDefinition label must not be empty")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain dict suitable for JSON persistence."""
+        return {
+            "label": self.label,
+            "description": self.description,
+            "required_properties": list(self.required_properties),
+            "optional_properties": list(self.optional_properties),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> NodeTypeDefinition:
+        """Deserialize from a plain dict."""
+        return cls(
+            label=data["label"],
+            description=data.get("description", ""),
+            required_properties=tuple(data.get("required_properties", [])),
+            optional_properties=tuple(data.get("optional_properties", [])),
+        )
+
+
+@dataclass(frozen=True)
+class EdgeTypeDefinition:
+    """Defines a relationship (edge) type in an ontology.
+
+    An edge type describes a kind of relationship between node types.
+    The label must be non-empty. All list-like fields are stored as
+    immutable tuples to preserve value-object semantics.
+
+    Attributes:
+        label: Unique name for this edge type (required, non-empty)
+        description: Human-readable explanation of this relationship
+        source_labels: Node type labels that may be sources of this edge
+        target_labels: Node type labels that may be targets of this edge
+        properties: Properties that this edge type may carry
+    """
+
+    label: str
+    description: str = ""
+    source_labels: tuple[str, ...] = field(default_factory=tuple)
+    target_labels: tuple[str, ...] = field(default_factory=tuple)
+    properties: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        """Validate that label is non-empty."""
+        if not self.label or not self.label.strip():
+            raise ValueError("EdgeTypeDefinition label must not be empty")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain dict suitable for JSON persistence."""
+        return {
+            "label": self.label,
+            "description": self.description,
+            "source_labels": list(self.source_labels),
+            "target_labels": list(self.target_labels),
+            "properties": list(self.properties),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EdgeTypeDefinition:
+        """Deserialize from a plain dict."""
+        return cls(
+            label=data["label"],
+            description=data.get("description", ""),
+            source_labels=tuple(data.get("source_labels", [])),
+            target_labels=tuple(data.get("target_labels", [])),
+            properties=tuple(data.get("properties", [])),
+        )
+
+
+@dataclass(frozen=True)
+class OntologyConfig:
+    """Configuration for an ontology associated with a KnowledgeGraph.
+
+    Represents the full ontology proposal or approved schema for a KG.
+    Immutable value object — use KnowledgeGraph.set_ontology() to attach
+    a new config to a knowledge graph.
+
+    Attributes:
+        node_types: Tuple of NodeTypeDefinition value objects
+        edge_types: Tuple of EdgeTypeDefinition value objects
+        approved_at: When the user approved this ontology; None if not yet approved
+    """
+
+    node_types: tuple[NodeTypeDefinition, ...] = field(default_factory=tuple)
+    edge_types: tuple[EdgeTypeDefinition, ...] = field(default_factory=tuple)
+    approved_at: datetime | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain dict suitable for JSONB persistence."""
+        return {
+            "node_types": [nt.to_dict() for nt in self.node_types],
+            "edge_types": [et.to_dict() for et in self.edge_types],
+            "approved_at": (
+                self.approved_at.isoformat() if self.approved_at is not None else None
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> OntologyConfig:
+        """Deserialize from a plain dict (e.g. loaded from JSONB column)."""
+        approved_at: datetime | None = None
+        raw_approved_at = data.get("approved_at")
+        if raw_approved_at is not None:
+            approved_at = datetime.fromisoformat(str(raw_approved_at))
+
+        return cls(
+            node_types=tuple(
+                NodeTypeDefinition.from_dict(nt) for nt in data.get("node_types", [])
+            ),
+            edge_types=tuple(
+                EdgeTypeDefinition.from_dict(et) for et in data.get("edge_types", [])
+            ),
+            approved_at=approved_at,
+        )

--- a/src/api/management/infrastructure/models/knowledge_graph.py
+++ b/src/api/management/infrastructure/models/knowledge_graph.py
@@ -6,6 +6,7 @@ containers for interconnected data within a workspace.
 
 import sqlalchemy as sa
 from sqlalchemy import Index, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from infrastructure.database.models import Base, TimestampMixin
@@ -29,6 +30,7 @@ class KnowledgeGraphModel(Base, TimestampMixin):
     workspace_id: Mapped[str] = mapped_column(String(26), nullable=False)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    ontology: Mapped[dict | None] = mapped_column(JSONB, nullable=True, default=None)
 
     __table_args__ = (
         UniqueConstraint("tenant_id", "name", name="uq_knowledge_graphs_tenant_name"),

--- a/src/api/management/infrastructure/repositories/knowledge_graph_repository.py
+++ b/src/api/management/infrastructure/repositories/knowledge_graph_repository.py
@@ -13,7 +13,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from management.domain.aggregates import KnowledgeGraph
-from management.domain.value_objects import KnowledgeGraphId
+from management.domain.value_objects import KnowledgeGraphId, OntologyConfig
 from management.infrastructure.models import KnowledgeGraphModel
 from management.infrastructure.observability import (
     DefaultKnowledgeGraphRepositoryProbe,
@@ -159,8 +159,50 @@ class KnowledgeGraphRepository(IKnowledgeGraphRepository):
         self._probe.knowledge_graph_deleted(knowledge_graph.id.value)
         return True
 
+    async def save_ontology(self, kg_id: str, config: OntologyConfig) -> None:
+        """Update only the ontology JSONB column for the given KG.
+
+        Performs a targeted UPDATE of the ``ontology`` column without
+        touching outbox events or other aggregate fields.
+
+        Args:
+            kg_id: ULID string of the target KnowledgeGraph
+            config: The OntologyConfig to persist
+        """
+        from sqlalchemy import update
+
+        stmt = (
+            update(KnowledgeGraphModel)
+            .where(KnowledgeGraphModel.id == kg_id)
+            .values(ontology=config.to_dict())
+        )
+        await self._session.execute(stmt)
+        await self._session.flush()
+
+    async def get_ontology(self, kg_id: str) -> OntologyConfig | None:
+        """Read the ontology JSONB column for the given KG.
+
+        Args:
+            kg_id: ULID string of the target KnowledgeGraph
+
+        Returns:
+            Deserialized OntologyConfig, or None if column is NULL or KG not found
+        """
+        stmt = select(KnowledgeGraphModel).where(KnowledgeGraphModel.id == kg_id)
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+
+        if model is None or model.ontology is None:
+            return None
+
+        return OntologyConfig.from_dict(model.ontology)
+
     def _to_domain(self, model: KnowledgeGraphModel) -> KnowledgeGraph:
         """Reconstitute aggregate from database state without generating events."""
+        ontology: OntologyConfig | None = None
+        if model.ontology is not None:
+            ontology = OntologyConfig.from_dict(model.ontology)
+
         return KnowledgeGraph(
             id=KnowledgeGraphId(value=model.id),
             tenant_id=model.tenant_id,
@@ -169,4 +211,5 @@ class KnowledgeGraphRepository(IKnowledgeGraphRepository):
             description=model.description,
             created_at=model.created_at,
             updated_at=model.updated_at,
+            ontology=ontology,
         )

--- a/src/api/management/ports/repositories.py
+++ b/src/api/management/ports/repositories.py
@@ -11,7 +11,11 @@ from typing import Protocol, runtime_checkable
 
 from management.domain.aggregates import DataSource, KnowledgeGraph
 from management.domain.entities import DataSourceSyncRun
-from management.domain.value_objects import DataSourceId, KnowledgeGraphId
+from management.domain.value_objects import (
+    DataSourceId,
+    KnowledgeGraphId,
+    OntologyConfig,
+)
 
 
 @runtime_checkable
@@ -75,6 +79,30 @@ class IKnowledgeGraphRepository(Protocol):
 
         Returns:
             True if deleted, False if not found
+        """
+        ...
+
+    async def save_ontology(self, kg_id: str, config: OntologyConfig) -> None:
+        """Persist an OntologyConfig for the given KnowledgeGraph ID.
+
+        Performs a targeted update of the ``ontology`` JSONB column only.
+        Does not trigger outbox events — ontology changes are UI-state
+        operations, not domain events.
+
+        Args:
+            kg_id: ULID string of the target KnowledgeGraph
+            config: The OntologyConfig to persist (full replace, not merge)
+        """
+        ...
+
+    async def get_ontology(self, kg_id: str) -> OntologyConfig | None:
+        """Retrieve the OntologyConfig for the given KnowledgeGraph ID.
+
+        Args:
+            kg_id: ULID string of the target KnowledgeGraph
+
+        Returns:
+            The persisted OntologyConfig, or None if no ontology has been saved
         """
         ...
 

--- a/src/api/management/presentation/knowledge_graphs/models.py
+++ b/src/api/management/presentation/knowledge_graphs/models.py
@@ -7,6 +7,11 @@ from datetime import datetime
 from pydantic import BaseModel, Field
 
 from management.domain.aggregates import KnowledgeGraph
+from management.domain.value_objects import (
+    EdgeTypeDefinition,
+    NodeTypeDefinition,
+    OntologyConfig,
+)
 
 
 class CreateKnowledgeGraphRequest(BaseModel):
@@ -87,4 +92,138 @@ class KnowledgeGraphResponse(BaseModel):
             description=kg.description,
             created_at=kg.created_at,
             updated_at=kg.updated_at,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Ontology models
+# ---------------------------------------------------------------------------
+
+
+class NodeTypeDefinitionModel(BaseModel):
+    """API model for a node type definition in an ontology."""
+
+    label: str = Field(..., description="Node type label (unique within ontology)")
+    description: str = Field(default="", description="Human-readable description")
+    required_properties: list[str] = Field(
+        default_factory=list,
+        description="Properties every node of this type must have",
+    )
+    optional_properties: list[str] = Field(
+        default_factory=list,
+        description="Properties nodes of this type may optionally have",
+    )
+
+    def to_domain(self) -> NodeTypeDefinition:
+        """Convert to domain NodeTypeDefinition value object."""
+        return NodeTypeDefinition(
+            label=self.label,
+            description=self.description,
+            required_properties=tuple(self.required_properties),
+            optional_properties=tuple(self.optional_properties),
+        )
+
+    @classmethod
+    def from_domain(cls, nt: NodeTypeDefinition) -> NodeTypeDefinitionModel:
+        """Convert from domain NodeTypeDefinition value object."""
+        return cls(
+            label=nt.label,
+            description=nt.description,
+            required_properties=list(nt.required_properties),
+            optional_properties=list(nt.optional_properties),
+        )
+
+
+class EdgeTypeDefinitionModel(BaseModel):
+    """API model for an edge type definition in an ontology."""
+
+    label: str = Field(..., description="Edge type label (unique within ontology)")
+    description: str = Field(default="", description="Human-readable description")
+    source_labels: list[str] = Field(
+        default_factory=list,
+        description="Node type labels allowed as sources",
+    )
+    target_labels: list[str] = Field(
+        default_factory=list,
+        description="Node type labels allowed as targets",
+    )
+    properties: list[str] = Field(
+        default_factory=list,
+        description="Properties this edge type may carry",
+    )
+
+    def to_domain(self) -> EdgeTypeDefinition:
+        """Convert to domain EdgeTypeDefinition value object."""
+        return EdgeTypeDefinition(
+            label=self.label,
+            description=self.description,
+            source_labels=tuple(self.source_labels),
+            target_labels=tuple(self.target_labels),
+            properties=tuple(self.properties),
+        )
+
+    @classmethod
+    def from_domain(cls, et: EdgeTypeDefinition) -> EdgeTypeDefinitionModel:
+        """Convert from domain EdgeTypeDefinition value object."""
+        return cls(
+            label=et.label,
+            description=et.description,
+            source_labels=list(et.source_labels),
+            target_labels=list(et.target_labels),
+            properties=list(et.properties),
+        )
+
+
+class OntologyConfigRequest(BaseModel):
+    """Request body for PUT /knowledge-graphs/{id}/ontology.
+
+    Performs a full replace of the stored ontology — no partial merges.
+    """
+
+    node_types: list[NodeTypeDefinitionModel] = Field(
+        default_factory=list,
+        description="Node type definitions for the ontology",
+    )
+    edge_types: list[EdgeTypeDefinitionModel] = Field(
+        default_factory=list,
+        description="Edge type definitions for the ontology",
+    )
+    approved_at: datetime | None = Field(
+        default=None,
+        description="ISO-8601 timestamp when the user approved this ontology",
+    )
+
+    def to_domain(self) -> OntologyConfig:
+        """Convert to domain OntologyConfig value object."""
+        return OntologyConfig(
+            node_types=tuple(nt.to_domain() for nt in self.node_types),
+            edge_types=tuple(et.to_domain() for et in self.edge_types),
+            approved_at=self.approved_at,
+        )
+
+
+class OntologyConfigResponse(BaseModel):
+    """Response for GET/PUT /knowledge-graphs/{id}/ontology."""
+
+    node_types: list[NodeTypeDefinitionModel] = Field(
+        ..., description="Node type definitions"
+    )
+    edge_types: list[EdgeTypeDefinitionModel] = Field(
+        ..., description="Edge type definitions"
+    )
+    approved_at: datetime | None = Field(
+        None, description="When the ontology was approved; null if not yet approved"
+    )
+
+    @classmethod
+    def from_domain(cls, config: OntologyConfig) -> OntologyConfigResponse:
+        """Convert from domain OntologyConfig value object."""
+        return cls(
+            node_types=[
+                NodeTypeDefinitionModel.from_domain(nt) for nt in config.node_types
+            ],
+            edge_types=[
+                EdgeTypeDefinitionModel.from_domain(et) for et in config.edge_types
+            ],
+            approved_at=config.approved_at,
         )

--- a/src/api/management/presentation/knowledge_graphs/routes.py
+++ b/src/api/management/presentation/knowledge_graphs/routes.py
@@ -21,6 +21,8 @@ from management.presentation.knowledge_graphs.models import (
     CreateKnowledgeGraphRequest,
     KnowledgeGraphListResponse,
     KnowledgeGraphResponse,
+    OntologyConfigRequest,
+    OntologyConfigResponse,
     UpdateKnowledgeGraphRequest,
 )
 from shared_kernel.authorization.types import Permission
@@ -319,6 +321,113 @@ async def update_knowledge_graph(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to update knowledge graph",
+        )
+
+
+@router.get(
+    "/knowledge-graphs/{kg_id}/ontology",
+    response_model=OntologyConfigResponse,
+    summary="Get ontology for a knowledge graph",
+    description="""
+Retrieve the stored ontology configuration for a knowledge graph.
+
+Returns `200` with the OntologyConfig when an ontology has been saved.
+Returns `404` when no ontology has been saved yet — this is the default
+state for all knowledge graphs until a user approves a proposed ontology.
+
+Requires `view` permission on the knowledge graph.
+""",
+    response_description="Stored ontology including node types, edge types, and approval state",
+    responses={
+        200: {"description": "Ontology found and returned"},
+        401: {"description": "Authentication required"},
+        404: {
+            "description": "No ontology saved for this knowledge graph, or KG not found"
+        },
+        500: {"description": "Internal server error"},
+    },
+)
+async def get_knowledge_graph_ontology(
+    kg_id: str,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    service: Annotated[KnowledgeGraphService, Depends(get_knowledge_graph_service)],
+) -> OntologyConfigResponse:
+    """Get the ontology configuration for a knowledge graph."""
+    try:
+        config = await service.get_ontology(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+        )
+        if config is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No ontology found for knowledge graph {kg_id}",
+            )
+        return OntologyConfigResponse.from_domain(config)
+
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retrieve ontology",
+        )
+
+
+@router.put(
+    "/knowledge-graphs/{kg_id}/ontology",
+    response_model=OntologyConfigResponse,
+    summary="Save ontology for a knowledge graph",
+    description="""
+Save (full replace) the ontology configuration for a knowledge graph.
+
+Stores the provided node types, edge types, and approval state. This is a
+full replace — not a merge. The stored ontology can be retrieved later via
+`GET /knowledge-graphs/{id}/ontology`.
+
+Requires `edit` permission on the knowledge graph.
+""",
+    response_description="The stored ontology as persisted",
+    responses={
+        200: {"description": "Ontology saved successfully"},
+        401: {"description": "Authentication required"},
+        403: {"description": "Insufficient permissions — edit required"},
+        404: {"description": "Knowledge graph not found"},
+        422: {"description": "Validation error in request body"},
+        500: {"description": "Internal server error"},
+    },
+)
+async def save_knowledge_graph_ontology(
+    kg_id: str,
+    request: OntologyConfigRequest,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    service: Annotated[KnowledgeGraphService, Depends(get_knowledge_graph_service)],
+) -> OntologyConfigResponse:
+    """Save the ontology configuration for a knowledge graph."""
+    try:
+        config = await service.save_ontology(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+            config=request.to_domain(),
+        )
+        return OntologyConfigResponse.from_domain(config)
+
+    except UnauthorizedError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to perform this action",
+        )
+    except KnowledgeGraphNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        )
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to save ontology",
         )
 
 

--- a/src/api/tests/fakes/management.py
+++ b/src/api/tests/fakes/management.py
@@ -15,7 +15,11 @@ from specs/nfr/testing.spec.md.
 from __future__ import annotations
 
 from management.domain.aggregates import DataSource, KnowledgeGraph
-from management.domain.value_objects import DataSourceId, KnowledgeGraphId
+from management.domain.value_objects import (
+    DataSourceId,
+    KnowledgeGraphId,
+    OntologyConfig,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -33,6 +37,7 @@ class InMemoryKnowledgeGraphRepository:
 
     def __init__(self) -> None:
         self._store: dict[str, KnowledgeGraph] = {}
+        self._ontology_store: dict[str, OntologyConfig] = {}
         self.saved: list[KnowledgeGraph] = []
         self.deleted: list[KnowledgeGraph] = []
 
@@ -57,8 +62,17 @@ class InMemoryKnowledgeGraphRepository:
         self.deleted.append(knowledge_graph)
         if knowledge_graph.id.value in self._store:
             del self._store[knowledge_graph.id.value]
+            self._ontology_store.pop(knowledge_graph.id.value, None)
             return True
         return False
+
+    async def save_ontology(self, kg_id: str, config: OntologyConfig) -> None:
+        """Store an ontology config for the given KG ID (full replace)."""
+        self._ontology_store[kg_id] = config
+
+    async def get_ontology(self, kg_id: str) -> OntologyConfig | None:
+        """Retrieve the ontology config for the given KG ID, or None."""
+        return self._ontology_store.get(kg_id)
 
 
 class InMemoryDataSourceRepository:

--- a/src/api/tests/unit/management/test_knowledge_graph_aggregate_ontology.py
+++ b/src/api/tests/unit/management/test_knowledge_graph_aggregate_ontology.py
@@ -1,0 +1,251 @@
+"""Unit tests for KnowledgeGraph aggregate ontology methods."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from management.domain.aggregates.knowledge_graph import KnowledgeGraph
+from management.domain.value_objects import (
+    EdgeTypeDefinition,
+    NodeTypeDefinition,
+    OntologyConfig,
+)
+
+
+def make_kg(
+    tenant_id: str = "tenant-123",
+    workspace_id: str = "ws-456",
+    name: str = "Test Graph",
+    description: str = "Test description",
+) -> KnowledgeGraph:
+    """Helper: create a KG with sensible defaults and clear creation events."""
+    kg = KnowledgeGraph.create(
+        tenant_id=tenant_id,
+        workspace_id=workspace_id,
+        name=name,
+        description=description,
+    )
+    kg.collect_events()  # clear the KnowledgeGraphCreated event
+    return kg
+
+
+def make_ontology_config() -> OntologyConfig:
+    """Helper: create a minimal OntologyConfig."""
+    nt = NodeTypeDefinition(
+        label="Repository",
+        description="A GitHub repository",
+        required_properties=("url",),
+    )
+    et = EdgeTypeDefinition(
+        label="CONTAINS",
+        description="",
+        source_labels=("Repository",),
+        target_labels=("File",),
+    )
+    return OntologyConfig(node_types=(nt,), edge_types=(et,))
+
+
+class TestKnowledgeGraphOntologyDefault:
+    """Tests for the default ontology state on KnowledgeGraph."""
+
+    def test_ontology_is_none_by_default(self):
+        """A newly created KnowledgeGraph should have ontology=None."""
+        kg = make_kg()
+        assert kg.ontology is None
+
+    def test_ontology_none_after_create_factory(self):
+        """KnowledgeGraph.create() should produce ontology=None."""
+        kg = KnowledgeGraph.create(
+            tenant_id="t",
+            workspace_id="w",
+            name="Graph",
+            description="",
+        )
+        assert kg.ontology is None
+
+
+class TestKnowledgeGraphSetOntology:
+    """Tests for KnowledgeGraph.set_ontology() method."""
+
+    def test_set_ontology_stores_config(self):
+        """set_ontology() should store the provided OntologyConfig."""
+        kg = make_kg()
+        config = make_ontology_config()
+        kg.set_ontology(config)
+        assert kg.ontology is config
+
+    def test_set_ontology_updates_updated_at(self):
+        """set_ontology() should advance updated_at."""
+        kg = make_kg()
+        original_updated_at = kg.updated_at
+        config = make_ontology_config()
+        kg.set_ontology(config)
+        assert kg.updated_at >= original_updated_at
+
+    def test_set_ontology_replaces_previous_ontology(self):
+        """set_ontology() should replace any previous OntologyConfig."""
+        kg = make_kg()
+        config1 = OntologyConfig(
+            node_types=(NodeTypeDefinition(label="A", description=""),)
+        )
+        config2 = OntologyConfig(
+            node_types=(NodeTypeDefinition(label="B", description=""),)
+        )
+        kg.set_ontology(config1)
+        kg.set_ontology(config2)
+        assert kg.ontology == config2
+        assert kg.ontology.node_types[0].label == "B"
+
+    def test_set_ontology_raises_on_deleted_kg(self):
+        """set_ontology() should raise AggregateDeletedError if KG was deleted."""
+        from management.domain.exceptions import AggregateDeletedError
+
+        kg = make_kg()
+        kg.mark_for_deletion()
+        config = make_ontology_config()
+        with pytest.raises(AggregateDeletedError):
+            kg.set_ontology(config)
+
+    def test_set_ontology_with_empty_config(self):
+        """set_ontology() with empty OntologyConfig should succeed."""
+        kg = make_kg()
+        empty = OntologyConfig()
+        kg.set_ontology(empty)
+        assert kg.ontology is not None
+        assert kg.ontology.node_types == ()
+        assert kg.ontology.edge_types == ()
+
+    def test_set_ontology_with_approved_at(self):
+        """set_ontology() should accept an approved OntologyConfig."""
+        kg = make_kg()
+        now = datetime.now(UTC)
+        config = OntologyConfig(approved_at=now)
+        kg.set_ontology(config)
+        assert kg.ontology is not None
+        assert kg.ontology.approved_at == now
+
+    def test_set_ontology_does_not_emit_domain_events(self):
+        """set_ontology() should NOT emit domain events (no outbox publishing)."""
+        kg = make_kg()
+        config = make_ontology_config()
+        kg.set_ontology(config)
+        events = kg.collect_events()
+        assert events == []
+
+
+class TestKnowledgeGraphClearOntology:
+    """Tests for KnowledgeGraph.clear_ontology() method."""
+
+    def test_clear_ontology_resets_to_none(self):
+        """clear_ontology() should set ontology back to None."""
+        kg = make_kg()
+        config = make_ontology_config()
+        kg.set_ontology(config)
+        kg.clear_ontology()
+        assert kg.ontology is None
+
+    def test_clear_ontology_updates_updated_at(self):
+        """clear_ontology() should advance updated_at."""
+        kg = make_kg()
+        config = make_ontology_config()
+        kg.set_ontology(config)
+        original_updated_at = kg.updated_at
+        kg.clear_ontology()
+        assert kg.updated_at >= original_updated_at
+
+    def test_clear_ontology_when_already_none_is_noop(self):
+        """clear_ontology() when ontology is already None should not error."""
+        kg = make_kg()
+        assert kg.ontology is None
+        kg.clear_ontology()  # should not raise
+        assert kg.ontology is None
+
+    def test_clear_ontology_does_not_emit_domain_events(self):
+        """clear_ontology() should NOT emit domain events."""
+        kg = make_kg()
+        config = make_ontology_config()
+        kg.set_ontology(config)
+        kg.collect_events()  # clear any events
+        kg.clear_ontology()
+        events = kg.collect_events()
+        assert events == []
+
+    def test_clear_ontology_raises_on_deleted_kg(self):
+        """clear_ontology() should raise AggregateDeletedError if KG was deleted."""
+        from management.domain.exceptions import AggregateDeletedError
+
+        kg = make_kg()
+        config = make_ontology_config()
+        kg.set_ontology(config)
+        kg.mark_for_deletion()
+        with pytest.raises(AggregateDeletedError):
+            kg.clear_ontology()
+
+
+class TestInMemoryKnowledgeGraphRepositoryOntology:
+    """Tests for InMemoryKnowledgeGraphRepository ontology methods."""
+
+    def _make_repo(self):
+        from tests.fakes.management import InMemoryKnowledgeGraphRepository
+
+        return InMemoryKnowledgeGraphRepository()
+
+    @pytest.mark.asyncio
+    async def test_save_ontology_and_get_ontology_round_trip(self):
+        """save_ontology / get_ontology should round-trip correctly."""
+        repo = self._make_repo()
+        kg = make_kg()
+        await repo.save(kg)
+        config = make_ontology_config()
+        await repo.save_ontology(kg.id.value, config)
+        result = await repo.get_ontology(kg.id.value)
+        assert result == config
+
+    @pytest.mark.asyncio
+    async def test_get_ontology_returns_none_when_not_set(self):
+        """get_ontology() should return None when no ontology saved."""
+        repo = self._make_repo()
+        kg = make_kg()
+        await repo.save(kg)
+        result = await repo.get_ontology(kg.id.value)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_ontology_returns_none_for_unknown_kg(self):
+        """get_ontology() should return None for an unknown KG ID."""
+        repo = self._make_repo()
+        result = await repo.get_ontology("nonexistent-id")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_save_ontology_replaces_previous(self):
+        """Calling save_ontology() twice should replace the first ontology."""
+        repo = self._make_repo()
+        kg = make_kg()
+        await repo.save(kg)
+        config1 = OntologyConfig(
+            node_types=(NodeTypeDefinition(label="A", description=""),)
+        )
+        config2 = OntologyConfig(
+            node_types=(NodeTypeDefinition(label="B", description=""),)
+        )
+        await repo.save_ontology(kg.id.value, config1)
+        await repo.save_ontology(kg.id.value, config2)
+        result = await repo.get_ontology(kg.id.value)
+        assert result is not None
+        assert result.node_types[0].label == "B"
+
+    @pytest.mark.asyncio
+    async def test_save_ontology_stores_empty_config(self):
+        """save_ontology() with empty OntologyConfig should persist correctly."""
+        repo = self._make_repo()
+        kg = make_kg()
+        await repo.save(kg)
+        empty = OntologyConfig()
+        await repo.save_ontology(kg.id.value, empty)
+        result = await repo.get_ontology(kg.id.value)
+        assert result is not None
+        assert result.node_types == ()
+        assert result.edge_types == ()

--- a/src/api/tests/unit/management/test_ontology_value_objects.py
+++ b/src/api/tests/unit/management/test_ontology_value_objects.py
@@ -1,0 +1,314 @@
+"""Unit tests for OntologyConfig, NodeTypeDefinition, EdgeTypeDefinition value objects."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from management.domain.value_objects import (
+    EdgeTypeDefinition,
+    NodeTypeDefinition,
+    OntologyConfig,
+)
+
+
+class TestNodeTypeDefinition:
+    """Tests for NodeTypeDefinition value object."""
+
+    def test_label_is_required_and_non_empty(self):
+        """NodeTypeDefinition with empty label should raise ValueError."""
+        with pytest.raises(ValueError, match="label"):
+            NodeTypeDefinition(label="", description="")
+
+    def test_label_whitespace_only_is_invalid(self):
+        """NodeTypeDefinition with whitespace-only label should raise ValueError."""
+        with pytest.raises(ValueError, match="label"):
+            NodeTypeDefinition(label="   ", description="")
+
+    def test_valid_minimal_node_type(self):
+        """NodeTypeDefinition with only label should be valid."""
+        nt = NodeTypeDefinition(label="Repository", description="")
+        assert nt.label == "Repository"
+        assert nt.description == ""
+        assert nt.required_properties == ()
+        assert nt.optional_properties == ()
+
+    def test_required_properties_default_empty(self):
+        """required_properties defaults to an empty tuple."""
+        nt = NodeTypeDefinition(label="File", description="A file")
+        assert nt.required_properties == ()
+
+    def test_optional_properties_default_empty(self):
+        """optional_properties defaults to an empty tuple."""
+        nt = NodeTypeDefinition(label="File", description="A file")
+        assert nt.optional_properties == ()
+
+    def test_required_properties_stored_as_tuple(self):
+        """required_properties should be stored as tuple regardless of input."""
+        nt = NodeTypeDefinition(
+            label="File",
+            description="",
+            required_properties=("name", "path"),
+        )
+        assert isinstance(nt.required_properties, tuple)
+        assert nt.required_properties == ("name", "path")
+
+    def test_optional_properties_stored_as_tuple(self):
+        """optional_properties should be stored as tuple regardless of input."""
+        nt = NodeTypeDefinition(
+            label="File",
+            description="",
+            optional_properties=("size", "mime_type"),
+        )
+        assert isinstance(nt.optional_properties, tuple)
+        assert nt.optional_properties == ("size", "mime_type")
+
+    def test_equality_same_content(self):
+        """Two NodeTypeDefinitions with same content should be equal."""
+        nt1 = NodeTypeDefinition(
+            label="Repo", description="A repo", required_properties=("url",)
+        )
+        nt2 = NodeTypeDefinition(
+            label="Repo", description="A repo", required_properties=("url",)
+        )
+        assert nt1 == nt2
+
+    def test_to_dict_round_trip(self):
+        """to_dict() / from_dict() should round-trip correctly."""
+        nt = NodeTypeDefinition(
+            label="Commit",
+            description="A git commit",
+            required_properties=("sha", "message"),
+            optional_properties=("author",),
+        )
+        d = nt.to_dict()
+        restored = NodeTypeDefinition.from_dict(d)
+        assert restored == nt
+
+    def test_to_dict_contains_expected_keys(self):
+        """to_dict() should contain label, description, required_properties, optional_properties."""
+        nt = NodeTypeDefinition(label="Repo", description="desc")
+        d = nt.to_dict()
+        assert "label" in d
+        assert "description" in d
+        assert "required_properties" in d
+        assert "optional_properties" in d
+
+
+class TestEdgeTypeDefinition:
+    """Tests for EdgeTypeDefinition value object."""
+
+    def test_label_is_required_and_non_empty(self):
+        """EdgeTypeDefinition with empty label should raise ValueError."""
+        with pytest.raises(ValueError, match="label"):
+            EdgeTypeDefinition(label="", description="")
+
+    def test_label_whitespace_only_is_invalid(self):
+        """EdgeTypeDefinition with whitespace-only label should raise ValueError."""
+        with pytest.raises(ValueError, match="label"):
+            EdgeTypeDefinition(label="  ", description="")
+
+    def test_valid_minimal_edge_type(self):
+        """EdgeTypeDefinition with only label should be valid."""
+        et = EdgeTypeDefinition(label="CONTAINS", description="")
+        assert et.label == "CONTAINS"
+        assert et.description == ""
+        assert et.source_labels == ()
+        assert et.target_labels == ()
+        assert et.properties == ()
+
+    def test_source_labels_default_empty(self):
+        """source_labels defaults to an empty tuple."""
+        et = EdgeTypeDefinition(label="CONTAINS", description="")
+        assert et.source_labels == ()
+
+    def test_target_labels_default_empty(self):
+        """target_labels defaults to an empty tuple."""
+        et = EdgeTypeDefinition(label="CONTAINS", description="")
+        assert et.target_labels == ()
+
+    def test_properties_default_empty(self):
+        """properties defaults to an empty tuple."""
+        et = EdgeTypeDefinition(label="CONTAINS", description="")
+        assert et.properties == ()
+
+    def test_source_and_target_labels_stored_as_tuple(self):
+        """source_labels and target_labels should be stored as tuples."""
+        et = EdgeTypeDefinition(
+            label="AUTHORED",
+            description="",
+            source_labels=("User",),
+            target_labels=("Commit",),
+        )
+        assert isinstance(et.source_labels, tuple)
+        assert isinstance(et.target_labels, tuple)
+        assert et.source_labels == ("User",)
+        assert et.target_labels == ("Commit",)
+
+    def test_properties_stored_as_tuple(self):
+        """properties should be stored as tuple."""
+        et = EdgeTypeDefinition(
+            label="CONTAINS",
+            description="",
+            properties=("weight",),
+        )
+        assert isinstance(et.properties, tuple)
+        assert et.properties == ("weight",)
+
+    def test_to_dict_round_trip(self):
+        """to_dict() / from_dict() should round-trip correctly."""
+        et = EdgeTypeDefinition(
+            label="AUTHORED",
+            description="User authored commit",
+            source_labels=("User",),
+            target_labels=("Commit",),
+            properties=("date",),
+        )
+        d = et.to_dict()
+        restored = EdgeTypeDefinition.from_dict(d)
+        assert restored == et
+
+    def test_to_dict_contains_expected_keys(self):
+        """to_dict() should include all edge type fields."""
+        et = EdgeTypeDefinition(label="CONTAINS", description="")
+        d = et.to_dict()
+        assert "label" in d
+        assert "description" in d
+        assert "source_labels" in d
+        assert "target_labels" in d
+        assert "properties" in d
+
+
+class TestOntologyConfig:
+    """Tests for OntologyConfig value object."""
+
+    def test_empty_ontology_is_valid(self):
+        """OntologyConfig with no types should be valid."""
+        oc = OntologyConfig()
+        assert oc.node_types == ()
+        assert oc.edge_types == ()
+        assert oc.approved_at is None
+
+    def test_approved_at_defaults_to_none(self):
+        """approved_at should default to None (unapproved ontology)."""
+        oc = OntologyConfig()
+        assert oc.approved_at is None
+
+    def test_node_types_default_empty(self):
+        """node_types should default to an empty tuple."""
+        oc = OntologyConfig()
+        assert oc.node_types == ()
+
+    def test_edge_types_default_empty(self):
+        """edge_types should default to an empty tuple."""
+        oc = OntologyConfig()
+        assert oc.edge_types == ()
+
+    def test_with_node_types(self):
+        """OntologyConfig can hold node types."""
+        nt = NodeTypeDefinition(label="Repository", description="A repo")
+        oc = OntologyConfig(node_types=(nt,))
+        assert len(oc.node_types) == 1
+        assert oc.node_types[0].label == "Repository"
+
+    def test_with_edge_types(self):
+        """OntologyConfig can hold edge types."""
+        et = EdgeTypeDefinition(label="CONTAINS", description="")
+        oc = OntologyConfig(edge_types=(et,))
+        assert len(oc.edge_types) == 1
+        assert oc.edge_types[0].label == "CONTAINS"
+
+    def test_with_approved_at(self):
+        """OntologyConfig can have an approved_at timestamp."""
+        now = datetime.now(UTC)
+        oc = OntologyConfig(approved_at=now)
+        assert oc.approved_at == now
+
+    def test_to_dict_round_trip_empty(self):
+        """Empty OntologyConfig should round-trip through to_dict/from_dict."""
+        oc = OntologyConfig()
+        d = oc.to_dict()
+        restored = OntologyConfig.from_dict(d)
+        assert restored.node_types == ()
+        assert restored.edge_types == ()
+        assert restored.approved_at is None
+
+    def test_to_dict_round_trip_with_types(self):
+        """OntologyConfig with types should round-trip correctly."""
+        nt = NodeTypeDefinition(
+            label="Repository",
+            description="A GitHub repository",
+            required_properties=("url",),
+            optional_properties=("description",),
+        )
+        et = EdgeTypeDefinition(
+            label="CONTAINS",
+            description="Containment edge",
+            source_labels=("Repository",),
+            target_labels=("File",),
+        )
+        now = datetime.now(UTC)
+        oc = OntologyConfig(node_types=(nt,), edge_types=(et,), approved_at=now)
+        d = oc.to_dict()
+        restored = OntologyConfig.from_dict(d)
+        assert len(restored.node_types) == 1
+        assert restored.node_types[0].label == "Repository"
+        assert restored.node_types[0].required_properties == ("url",)
+        assert restored.node_types[0].optional_properties == ("description",)
+        assert len(restored.edge_types) == 1
+        assert restored.edge_types[0].label == "CONTAINS"
+        assert restored.edge_types[0].source_labels == ("Repository",)
+        # Timestamps may lose sub-microsecond precision; compare at second resolution
+        assert restored.approved_at is not None
+        assert abs((restored.approved_at - now).total_seconds()) < 1.0
+
+    def test_to_dict_approved_at_none_serializes_as_none(self):
+        """to_dict() with approved_at=None should serialize as None."""
+        oc = OntologyConfig()
+        d = oc.to_dict()
+        assert d["approved_at"] is None
+
+    def test_from_dict_with_null_approved_at(self):
+        """from_dict() with approved_at=None should produce approved_at=None."""
+        d = {"node_types": [], "edge_types": [], "approved_at": None}
+        oc = OntologyConfig.from_dict(d)
+        assert oc.approved_at is None
+
+    def test_from_dict_with_iso_approved_at(self):
+        """from_dict() with ISO-8601 approved_at string should parse correctly."""
+        d = {
+            "node_types": [],
+            "edge_types": [],
+            "approved_at": "2026-05-03T12:00:00+00:00",
+        }
+        oc = OntologyConfig.from_dict(d)
+        assert oc.approved_at is not None
+        assert oc.approved_at.year == 2026
+
+    def test_to_dict_contains_expected_keys(self):
+        """to_dict() should contain node_types, edge_types, approved_at."""
+        oc = OntologyConfig()
+        d = oc.to_dict()
+        assert "node_types" in d
+        assert "edge_types" in d
+        assert "approved_at" in d
+
+    def test_equality_same_content(self):
+        """Two OntologyConfigs with same content should be equal."""
+        nt = NodeTypeDefinition(label="Repo", description="")
+        oc1 = OntologyConfig(node_types=(nt,))
+        oc2 = OntologyConfig(node_types=(nt,))
+        assert oc1 == oc2
+
+    def test_node_types_stored_as_tuple(self):
+        """node_types should be stored as a tuple."""
+        nt = NodeTypeDefinition(label="Repo", description="")
+        oc = OntologyConfig(node_types=(nt,))
+        assert isinstance(oc.node_types, tuple)
+
+    def test_edge_types_stored_as_tuple(self):
+        """edge_types should be stored as a tuple."""
+        et = EdgeTypeDefinition(label="CONTAINS", description="")
+        oc = OntologyConfig(edge_types=(et,))
+        assert isinstance(oc.edge_types, tuple)

--- a/src/dev-ui/app/tests/mutations-indicator-persistence.test.ts
+++ b/src/dev-ui/app/tests/mutations-indicator-persistence.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import type { MutationSubmissionState, MutationSubmissionStatus } from '@/composables/useMutationSubmission'
+
+// ── Mutations Console — Floating Indicator Navigation Persistence Tests ───────
+//
+// Spec: specs/ui/experience.spec.md — "Mutations Console" — Scenario: Submission
+// "AND the indicator persists when the user navigates away from the mutations
+//  console"
+//
+// This suite proves the three behavioural contracts that guarantee the floating
+// progress indicator persists across route navigation:
+//
+//   1. test_indicator_remains_visible_after_navigating_away
+//      MutationProgress is mounted in app.vue OUTSIDE the <NuxtLayout>/<NuxtPage>
+//      route outlet, so route transitions never unmount or re-mount it.
+//      When status is 'submitting', isVisible is true; this cannot be changed by
+//      a route event because the component is never torn down.
+//
+//   2. test_indicator_in_success_state_persists_after_navigation
+//      Exactly the same structural guarantee applies to the 'success' state.
+//      The indicator remains visible after navigation because MutationProgress
+//      is outside the route outlet and the state is held in Nuxt useState.
+//
+//   3. test_dismiss_removes_indicator_permanently
+//      dismiss() resets status to 'idle', making isVisible false. Since
+//      MutationProgress stays mounted across all routes, there is nothing that
+//      can restore the indicator after dismissal — not navigation away and back,
+//      not a component re-render. Only a new submit() call can bring it back.
+//
+// Approach: The Vitest environment does not include the Nuxt SSR runtime, so
+// full Nuxt app mounting with NuxtLink and useState is not available here.
+// Each test instead verifies the exact source-level contract that provides the
+// behavioural guarantee. Where the guarantee depends on pure reactive logic, the
+// logic is extracted and tested inline (the same pattern used throughout this
+// test suite — see mutations-submission.test.ts and callback.test.ts).
+
+// ── Source file contents ─────────────────────────────────────────────────────
+
+const appVue = readFileSync(resolve(__dirname, '../app.vue'), 'utf-8')
+
+const mutationProgressSrc = readFileSync(
+  resolve(__dirname, '../components/graph/MutationProgress.vue'),
+  'utf-8',
+)
+
+const submissionComposable = readFileSync(
+  resolve(__dirname, '../composables/useMutationSubmission.ts'),
+  'utf-8',
+)
+
+const mutationsPageSrc = readFileSync(
+  resolve(__dirname, '../pages/graph/mutations.vue'),
+  'utf-8',
+)
+
+// ── Inline visibility predicate (mirrors MutationProgress.vue) ───────────────
+
+/** Mirrors the `isVisible` computed in MutationProgress.vue */
+function isVisible(status: MutationSubmissionStatus): boolean {
+  return status !== 'idle'
+}
+
+/** Mirrors dismiss() in useMutationSubmission.ts */
+function dismiss(state: MutationSubmissionState): MutationSubmissionState {
+  return {
+    status: 'idle',
+    operationCount: 0,
+    result: null,
+    error: null,
+    startedAt: null,
+    completedAt: null,
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// test_indicator_remains_visible_after_navigating_away
+//
+// Proves two interlocking guarantees:
+//   (A) MutationProgress is rendered OUTSIDE <NuxtLayout> in app.vue, so route
+//       changes replace the content inside NuxtPage without touching the
+//       MutationProgress component.
+//   (B) When status is 'submitting', isVisible = true. Since the component is
+//       never unmounted, this value cannot be affected by navigation.
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('Mutations indicator — test_indicator_remains_visible_after_navigating_away', () => {
+  it('MutationProgress is rendered after </NuxtLayout> in app.vue (outside the route outlet)', () => {
+    // The route outlet lives inside <NuxtLayout>. Anything outside it is
+    // unaffected by route transitions. Confirm that <MutationProgress /> appears
+    // after the closing </NuxtLayout> tag.
+    const nuxtLayoutCloseIdx = appVue.indexOf('</NuxtLayout>')
+    const mutationProgressIdx = appVue.indexOf('<MutationProgress')
+
+    expect(nuxtLayoutCloseIdx).toBeGreaterThan(-1)
+    expect(mutationProgressIdx).toBeGreaterThan(-1)
+    expect(mutationProgressIdx).toBeGreaterThan(nuxtLayoutCloseIdx)
+  })
+
+  it('isVisible is true when status is submitting (indicator shown during active submission)', () => {
+    // Even after the user navigates away, the component remains mounted and
+    // isVisible stays true as long as the store reports 'submitting'.
+    expect(isVisible('submitting')).toBe(true)
+  })
+
+  it('useMutationSubmission uses Nuxt useState so state is app-level, not page-scoped', () => {
+    // Nuxt useState keeps reactive state at the application level. Navigating
+    // away does not reset it — unlike page-component local state.
+    expect(submissionComposable).toContain('useState')
+    expect(submissionComposable).toContain("'mutation-submission'")
+  })
+
+  it('submit() stores startedAt so elapsed time survives navigation without resetting', () => {
+    // The composable stores startedAt on submission start. After navigation the
+    // MutationProgress component reads startedAt from the same shared state and
+    // continues computing elapsed time correctly.
+    expect(submissionComposable).toContain('startedAt: Date.now()')
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// test_indicator_in_success_state_persists_after_navigation
+//
+// Mirrors the 'submitting' test but for the 'success' state: once submission
+// completes, the indicator switches to the success state and must remain
+// visible when the user navigates (e.g. to inspect graph results).
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('Mutations indicator — test_indicator_in_success_state_persists_after_navigation', () => {
+  it('isVisible is true when status is success (indicator shown after successful submission)', () => {
+    expect(isVisible('success')).toBe(true)
+  })
+
+  it('MutationProgress.vue renders a distinct success state (indicator content changes, not visibility)', () => {
+    // The component changes what it displays (CheckCircle2, "Mutations applied")
+    // but the outer v-if remains true — the indicator stays in the DOM.
+    expect(mutationProgressSrc).toContain("state.status === 'success'")
+    expect(mutationProgressSrc).toContain('Mutations applied')
+  })
+
+  it('success state captures completedAt so frozen elapsed time persists across navigation', () => {
+    // After navigation, MutationProgress reads completedAt from shared useState
+    // and shows the final elapsed seconds without restarting the clock.
+    expect(mutationProgressSrc).toContain('finalElapsedSeconds')
+    expect(mutationProgressSrc).toContain('completedAt')
+    expect(submissionComposable).toContain('completedAt = Date.now()')
+  })
+
+  it('MutationProgress is positioned fixed so it remains anchored in the viewport after navigation', () => {
+    // position: fixed anchors the element relative to the viewport, not any
+    // scrollable ancestor. Navigating to a new page (even with scroll-to-top)
+    // does not move or hide a fixed element.
+    expect(mutationProgressSrc).toContain('fixed bottom-4 right-4')
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// test_dismiss_removes_indicator_permanently
+//
+// Once the user dismisses the indicator, status returns to 'idle'.
+// The indicator must NOT reappear after navigating away and back, nor after
+// any other lifecycle event, until a new submit() is explicitly called.
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('Mutations indicator — test_dismiss_removes_indicator_permanently', () => {
+  it('dismiss() transitions status from success to idle, making isVisible false', () => {
+    // Simulate: user is on success state, navigates away, comes back, dismisses.
+    let state: MutationSubmissionState = {
+      status: 'success',
+      operationCount: 10,
+      result: { success: true, operations_applied: 10, errors: [] },
+      error: null,
+      startedAt: Date.now() - 5_000,
+      completedAt: Date.now(),
+    }
+
+    expect(isVisible(state.status)).toBe(true)
+
+    // User dismisses
+    state = dismiss(state)
+
+    expect(state.status).toBe('idle')
+    expect(isVisible(state.status)).toBe(false)
+  })
+
+  it('after dismiss, navigating away and back does not restore the indicator', () => {
+    // Simulate: dismissed → route change → route change back
+    // The state is held in useState (app-level). Route changes do not mutate it.
+    // After dismiss, status === 'idle'; no routing event calls submit() again.
+    let state: MutationSubmissionState = {
+      status: 'failed',
+      operationCount: 5,
+      result: null,
+      error: 'Connection refused',
+      startedAt: Date.now() - 10_000,
+      completedAt: Date.now(),
+    }
+
+    state = dismiss(state)
+    expect(state.status).toBe('idle')
+
+    // Simulate navigating away: state is NOT touched by routing
+    const stateAfterNavigatingAway = { ...state }
+    expect(stateAfterNavigatingAway.status).toBe('idle')
+
+    // Simulate navigating back: state is still NOT touched
+    const stateAfterReturning = { ...stateAfterNavigatingAway }
+    expect(stateAfterReturning.status).toBe('idle')
+
+    // Indicator must still be hidden
+    expect(isVisible(stateAfterReturning.status)).toBe(false)
+  })
+
+  it('useMutationSubmission.dismiss() resets every field to idle defaults', () => {
+    // The composable's dismiss() function completely resets the shared state.
+    // This is the canonical implementation; the test above uses its extracted logic.
+    expect(submissionComposable).toContain("status: 'idle'")
+    expect(submissionComposable).toContain('function dismiss()')
+    expect(submissionComposable).toContain('operationCount: 0')
+    expect(submissionComposable).toContain('result: null')
+    expect(submissionComposable).toContain('error: null')
+    expect(submissionComposable).toContain('startedAt: null')
+    expect(submissionComposable).toContain('completedAt: null')
+  })
+
+  it('only a new submit() call — triggered by explicit user action — can restore the indicator', () => {
+    // There is no routing hook, lifecycle event, or automatic mechanism that
+    // calls submit() after dismissal. The only code path that transitions from
+    // 'idle' to 'submitting' is the explicit user action on mutations.vue.
+    expect(mutationsPageSrc).toContain('submission.submit(')
+
+    // submit() is guarded: it bails early if already submitting
+    expect(submissionComposable).toContain("if (state.value.status === 'submitting') return")
+  })
+})


### PR DESCRIPTION
## What and Why

The **Requirement: Ontology Design** in `specs/ui/experience.spec.md` requires that
an approved ontology (node types, edge types, and their properties) be persisted
per-KnowledgeGraph. Three spec scenarios depend on retrievable ontology storage:

- **Ontology review and approval**: extraction begins only after the user
  explicitly approves — the approved ontology must be durably stored.
- **Individual type editing**: label, description, required/optional properties,
  and relationship types can be modified — edits must be persisted and re-read.
- **Ontology change after initial extraction**: the system warns that modifying an
  approved ontology triggers full re-extraction — this requires knowing whether
  an approved ontology already exists for the KG.

This task is pure Management bounded-context work. It does NOT touch Extraction
(AIHCM-174) — storing and retrieving the ontology is independent of the AI
agent that proposes it. Once these endpoints exist, task-123 (UI Ontology Design)
can use real API calls instead of hardcoded proposal data.

## Spec Requirements Satisfied

`specs/ui/experience.spec.md@e77913c2cc6d8b719291e2dbb6870519a94d50da` —
**Requirement: Ontology Design**:

- **Scenario: Ontology review and approval** — approved ontology stored via
  `PUT /management/knowledge-graphs/{id}/ontology` and returned by
  `GET /management/knowledge-graphs/{id}/ontology`.
- **Scenario: Individual type editing** — edited ontology round-trips correctly
  through GET → mutate → PUT → GET.
- **Scenario: Ontology change after initial extraction** — `GET` returns `200`
  with ontology when one exists (indicating prior approval), enabling the UI to
  show the re-extraction warning; returns `404` when no ontology has been saved.

## Design Decisions

- **OntologyConfig as a value object** in the Management domain. It contains:
  - `node_types: list[NodeTypeDefinition]` — each with `label`, `description`,
    `required_properties`, and `optional_properties`.
  - `edge_types: list[EdgeTypeDefinition]` — each with `label`, `description`,
    `source_labels`, `target_labels`, and `properties`.
  - `approved_at: datetime | None` — set when the user approves; `None` means
    the proposal has been stored but not yet approved.

- **KnowledgeGraph aggregate** gains an `ontology: OntologyConfig | None` field.
  Default is `None` (no ontology configured). The aggregate remains unchanged
  for all existing operations.

- **Persistence**: a nullable `JSONB` column `ontology` on the `knowledge_graphs`
  table. Serialization/deserialization is handled in the repository layer — the
  domain never sees raw JSON.

- **Endpoints**:
  - `GET /management/knowledge-graphs/{id}/ontology` — requires `view` permission;
    returns `200 OntologyConfigResponse` if ontology exists, `404` otherwise.
  - `PUT /management/knowledge-graphs/{id}/ontology` — requires `edit` permission;
    accepts `OntologyConfigRequest`; returns `200 OntologyConfigResponse` with
    the stored ontology. Performs a full replace (not a merge).

- **No endpoint on data sources** — ontology is a KG-level concern, not a
  data-source concern. The current UI's `PATCH /management/data-sources/{id}`
  with `{ontology: ...}` is silently ignored and will be corrected in task-123.

## TDD Sequence (write tests before code)

### Unit tests (no infrastructure)

1. `OntologyConfig` value object construction and serialization
   - Valid ontology round-trips through `to_dict()` / `from_dict()`
   - `node_types` and `edge_types` are both optional (empty list is valid)
   - `approved_at` is `None` by default

2. `NodeTypeDefinition` and `EdgeTypeDefinition` value object validation
   - `label` is required and non-empty
   - `required_properties` and `optional_properties` are lists of strings
   - `source_labels` and `target_labels` are lists of strings (may be empty)

3. `KnowledgeGraph` aggregate with ontology
   - `KnowledgeGraph.ontology` is `None` by default
   - `KnowledgeGraph.set_ontology(config)` updates the field and `updated_at`
   - `KnowledgeGraph.clear_ontology()` resets to `None` and `updated_at`

4. `KnowledgeGraphRepository` — `save_ontology()` and `get_ontology()` unit-tested
   via a fake/in-memory repository

### Integration tests (requires DB)

5. `GET /management/knowledge-graphs/{id}/ontology` — no ontology → 404
6. `PUT /management/knowledge-graphs/{id}/ontology` → 200, body round-trips
7. `GET /management/knowledge-graphs/{id}/ontology` — after PUT → 200 with data
8. `PUT` requires `edit` permission → 403 for viewer
9. `GET` requires `view` permission → 403 for unauthenticated
10. `PUT` on non-existent KG → 404
11. Full round-trip: PUT node+edge types, GET, assert all fields preserved

## Files / Areas Affected

**Domain layer**
- `src/api/management/domain/value_objects.py` — add `OntologyConfig`,
  `NodeTypeDefinition`, `EdgeTypeDefinition`
- `src/api/management/domain/aggregates.py` — add `ontology` field to
  `KnowledgeGraph`; add `set_ontology()` and `clear_ontology()` methods

**Repository / Infrastructure layer**
- `src/api/management/infrastructure/knowledge_graph_repository.py` — add
  `save_ontology(kg_id, config)` and `get_ontology(kg_id)` methods using JSONB
  column
- Alembic migration: add nullable `JSONB` column `ontology` to `knowledge_graphs`

**Application layer**
- `src/api/management/application/services/knowledge_graph_service.py` — add
  `get_ontology(user_id, kg_id)` and `save_ontology(user_id, kg_id, config)`
  with permission checks (view/edit respectively)

**Presentation layer**
- `src/api/management/presentation/knowledge_graphs/models.py` — add
  `NodeTypeDefinitionModel`, `EdgeTypeDefinitionModel`, `OntologyConfigRequest`,
  `OntologyConfigResponse`
- `src/api/management/presentation/knowledge_graphs/routes.py` — add two routes:
  `GET /knowledge-graphs/{id}/ontology` and `PUT /knowledge-graphs/{id}/ontology`

**Tests**
- `src/api/tests/unit/management/test_ontology_value_objects.py` (new)
- `src/api/tests/unit/management/test_knowledge_graph_aggregate_ontology.py` (new)
- `src/api/tests/integration/management/test_ontology_endpoints.py` (new)

## How to Verify

1. `PUT /management/knowledge-graphs/{kg_id}/ontology` with a valid body returns
   `200` and the response contains the stored ontology
2. `GET /management/knowledge-graphs/{kg_id}/ontology` returns `200` with the
   same data after the PUT
3. `GET` on a KG with no ontology returns `404`
4. `PUT` with viewer credentials returns `403`
5. All unit tests pass without infrastructure:
   `cd src/api && uv run pytest tests/unit/management/ -v`
6. All integration tests pass against a dev instance:
   `cd src/api && uv run pytest tests/integration/management/test_ontology_endpoints.py -v -m integration`

## Caveats

- The `ontology` JSONB column is nullable to preserve backward compatibility.
  All existing KG rows have `NULL`; the repository returns `None` for these.
- Do not add a migration that backfills existing rows — `None` is valid and
  the `GET` endpoint intentionally returns `404` for un-configured KGs.
- `approved_at` is stored inside the JSONB blob, not as a separate column.
  This avoids schema proliferation for a field used only by the UI state machine.
- This task does NOT wire up ontology-driven extraction. When AIHCM-174 resolves,
  the Extraction context will call `GET /management/knowledge-graphs/{id}/ontology`
  to read the approved ontology and use it to guide extraction.
- The existing `KnowledgeGraphResponse` is not changed — this PR only adds new
  endpoints; it does not embed ontology in the existing GET /knowledge-graphs/{id}
  response (avoids bloating the common response model).

---

**Task:** `task-131`
**Spec:** `specs/ui/experience.spec.md@e77913c2cc6d8b719291e2dbb6870519a94d50da`

### Merge

The orchestrator will squash-merge this PR automatically
once all pipeline steps pass.

---

This PR was created by [hyperloop](https://github.com/jsell-rh/hyperloop),
an AI agent orchestrator.