### PR TITLE
fix(ingestion): wire GitHub adapter, credential reader, sync run logs, and UI polling

### DIFF
--- a/src/api/ingestion/application/services/ingestion_service.py
+++ b/src/api/ingestion/application/services/ingestion_service.py
@@ -86,7 +86,13 @@ class IngestionService:
             )
 
         credentials: dict[str, str] = {}
-        if credentials_path and tenant_id and self._credential_reader:
+        if credentials_path:
+            if not tenant_id:
+                raise ValueError(
+                    "tenant_id is required when credentials_path is provided"
+                )
+            if self._credential_reader is None:
+                raise RuntimeError("credential_reader is not configured")
             credentials = await self._credential_reader.retrieve(
                 credentials_path, tenant_id
             )

--- a/src/api/ingestion/application/services/ingestion_service.py
+++ b/src/api/ingestion/application/services/ingestion_service.py
@@ -7,8 +7,12 @@ The service is stateless; all context flows via method parameters.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from ingestion.ports.adapters import IDatasourceAdapter
+
+if TYPE_CHECKING:
+    from shared_kernel.credential_reader import ICredentialReader
 from shared_kernel.job_package.builder import JobPackageBuilder
 from shared_kernel.job_package.value_objects import (
     JobPackageId,
@@ -39,9 +43,11 @@ class IngestionService:
         self,
         adapter_registry: dict[str, IDatasourceAdapter],
         work_dir: Path,
+        credential_reader: "ICredentialReader | None" = None,
     ) -> None:
         self._adapter_registry = adapter_registry
         self._work_dir = work_dir
+        self._credential_reader = credential_reader
 
     async def run(
         self,
@@ -51,6 +57,7 @@ class IngestionService:
         adapter_type: str,
         connection_config: dict[str, str],
         credentials_path: str | None,
+        tenant_id: str | None = None,
     ) -> JobPackageId:
         """Run the ingestion pipeline for a data source sync.
 
@@ -60,8 +67,8 @@ class IngestionService:
             knowledge_graph_id: The knowledge graph this feeds
             adapter_type: The adapter type string (e.g. "github")
             connection_config: Key-value adapter configuration
-            credentials_path: Vault path for credentials (currently unused;
-                future implementations will decrypt and pass credentials)
+            credentials_path: Path for encrypted credentials
+            tenant_id: Tenant ID for credential decryption scoping
 
         Returns:
             The JobPackageId of the produced ZIP archive
@@ -78,9 +85,11 @@ class IngestionService:
                 f"Registered adapters: {list(self._adapter_registry.keys())}"
             )
 
-        # TODO: decrypt credentials from credentials_path when secret store
-        # is injected. Currently an empty dict is passed as placeholder.
         credentials: dict[str, str] = {}
+        if credentials_path and tenant_id and self._credential_reader:
+            credentials = await self._credential_reader.retrieve(
+                credentials_path, tenant_id
+            )
 
         # Extract raw items from the adapter using the new ExtractionResult API
         result = await adapter.extract(

--- a/src/api/ingestion/infrastructure/event_handler.py
+++ b/src/api/ingestion/infrastructure/event_handler.py
@@ -82,6 +82,7 @@ class IngestionEventHandler:
                 adapter_type=payload["adapter_type"],
                 connection_config=payload.get("connection_config", {}),
                 credentials_path=payload.get("credentials_path"),
+                tenant_id=payload.get("tenant_id"),
             )
         except asyncio.CancelledError:
             # Propagate task cancellation so the event loop can shut down

--- a/src/api/ingestion/ports/services.py
+++ b/src/api/ingestion/ports/services.py
@@ -22,6 +22,7 @@ class IIngestionService(Protocol):
         adapter_type: str,
         connection_config: dict[str, str],
         credentials_path: str | None,
+        tenant_id: str | None = None,
     ) -> JobPackageId:
         """Run the ingestion pipeline.
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -148,7 +148,15 @@ class _SessionedIngestionEventHandler:
             )
 
             mgmt_settings = get_management_settings()
-            encryption_keys = mgmt_settings.encryption_key.get_secret_value().split(",")
+            encryption_keys = [
+                key.strip()
+                for key in mgmt_settings.encryption_key.get_secret_value().split(",")
+                if key.strip()
+            ]
+            if not encryption_keys:
+                raise RuntimeError(
+                    "No valid encryption keys configured for FernetSecretStore"
+                )
             credential_reader = FernetSecretStore(
                 session=session,
                 encryption_keys=encryption_keys,

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -142,10 +142,22 @@ class _SessionedIngestionEventHandler:
         async with self._session_factory() as session:
             outbox = OutboxRepository(session=session)
             from ingestion.infrastructure.adapters.github import GitHubAdapter
+            from infrastructure.settings import get_management_settings
+            from management.infrastructure.repositories.fernet_secret_store import (
+                FernetSecretStore,
+            )
+
+            mgmt_settings = get_management_settings()
+            encryption_keys = mgmt_settings.encryption_key.get_secret_value().split(",")
+            credential_reader = FernetSecretStore(
+                session=session,
+                encryption_keys=encryption_keys,
+            )
 
             ingestion_service = IngestionService(
                 adapter_registry={"github": GitHubAdapter()},
                 work_dir=_JOB_PACKAGE_WORK_DIR,
+                credential_reader=credential_reader,
             )
             ingestion_handler = IngestionEventHandler(
                 ingestion_service=ingestion_service,

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -147,20 +147,24 @@ class _SessionedIngestionEventHandler:
                 FernetSecretStore,
             )
 
-            mgmt_settings = get_management_settings()
-            encryption_keys = [
-                key.strip()
-                for key in mgmt_settings.encryption_key.get_secret_value().split(",")
-                if key.strip()
-            ]
-            if not encryption_keys:
-                raise RuntimeError(
-                    "No valid encryption keys configured for FernetSecretStore"
+            credential_reader = None
+            if payload.get("credentials_path"):
+                mgmt_settings = get_management_settings()
+                encryption_keys = [
+                    key.strip()
+                    for key in mgmt_settings.encryption_key.get_secret_value().split(
+                        ","
+                    )
+                    if key.strip()
+                ]
+                if not encryption_keys:
+                    raise RuntimeError(
+                        "No valid encryption keys configured for FernetSecretStore"
+                    )
+                credential_reader = FernetSecretStore(
+                    session=session,
+                    encryption_keys=encryption_keys,
                 )
-            credential_reader = FernetSecretStore(
-                session=session,
-                encryption_keys=encryption_keys,
-            )
 
             ingestion_service = IngestionService(
                 adapter_registry={"github": GitHubAdapter()},

--- a/src/api/tests/unit/ingestion/infrastructure/test_ingestion_event_handler.py
+++ b/src/api/tests/unit/ingestion/infrastructure/test_ingestion_event_handler.py
@@ -66,6 +66,7 @@ class _FakeIngestionService:
         adapter_type: str,
         connection_config: dict[str, str],
         credentials_path: str | None,
+        tenant_id: str | None = None,
     ) -> JobPackageId:
         self.calls.append(
             {
@@ -294,6 +295,7 @@ class TestIngestionEventHandlerOutboxIsolation:
                 adapter_type: str,
                 connection_config: dict[str, str],
                 credentials_path: str | None,
+                tenant_id: str | None = None,
             ) -> JobPackageId:
                 raise asyncio.CancelledError()
 

--- a/src/dev-ui/app/pages/data-sources/index.vue
+++ b/src/dev-ui/app/pages/data-sources/index.vue
@@ -676,7 +676,7 @@ function startPolling() {
     if (!hasActiveSyncs.value) {
       stopPolling()
     }
-  }, 5000)
+  }, 3000)
 }
 
 onMounted(async () => {
@@ -931,6 +931,7 @@ async function viewLogs(ds: DataSourceItem, run: SyncRun) {
   logsError.value = null
   logSheetOpen.value = true
   await fetchRunLogs(ds.id, run.id)
+  await loadDataSources()
 }
 
 async function fetchRunLogs(dsId: string, runId: string) {


### PR DESCRIPTION
## Summary

Fixes the ingestion pipeline from end to end — data source syncs were failing at every step:

1. **Register GitHub adapter** — `adapter_registry` was empty `{}`, now registers `GitHubAdapter`
2. **Parse repo_url** — adapter expected `{owner, repo, branch}` but UI sends `{repo_url}`. Added `_parse_connection_config()` that handles both URL and explicit param formats
3. **Accept flexible credentials** — adapter now accepts either `token` or `access_token` key
4. **Wire credential reader** — `IngestionService` had a TODO for credential decryption. Now injects `FernetSecretStore` as `ICredentialReader` and passes `tenant_id` from the event payload
5. **Add sync run logs** — `SyncLifecycleHandler` now appends timestamped log entries for all status transitions and failures
6. **Refresh UI after viewing logs** — data source card showed stale "Ingesting" status; now refreshes after log view. Poll interval reduced from 5s to 3s
7. **Spec update** — added adapter config normalization and sync run logging requirements to `data-sources.spec.md`

## Test plan

- [ ] `cd src/api && uv run pytest tests/unit/ -v` (3003 tests pass)
- [ ] Deploy to stage, create a GitHub data source with repo URL and PAT
- [ ] Trigger sync — verify ingestion progresses through to `ai_extracting` (then fails on stub)
- [ ] Verify sync run logs show timestamped lifecycle entries
- [ ] Verify card status updates to "Failed" within 3 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)