### PR TITLE
feat(management): add workspace mode lifecycle (#643)

### DIFF
--- a/skills/subagent-delivery/SKILL.md
+++ b/skills/subagent-delivery/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: subagent-delivery
+description: >
+  Executes a GitHub issue end-to-end with consistent branch, test, PR, and merge behavior.
+  Use when implementing units of work with sub-agents, preparing pull requests, resolving merge
+  conflicts, or when the user asks to run issue-by-issue delivery into feature/manage-knowledge-graph.
+---
+
+# Subagent Delivery Protocol
+
+Follow this protocol for every assigned issue.
+
+## Scope and Inputs
+
+Before coding, gather:
+
+1. Issue number and acceptance criteria.
+2. Target branch: `feature/manage-knowledge-graph`.
+3. Current repository state (`git status`, `git branch -vv`).
+
+If acceptance criteria are ambiguous, ask one focused question before implementation.
+
+## Git Workflow
+
+1. Ensure local target branch is up to date:
+   - `git checkout feature/manage-knowledge-graph`
+   - `git pull --ff-only`
+2. Create a dedicated branch per issue:
+   - `feat/issue-<id>-<short-scope>` for features
+   - `fix/issue-<id>-<short-scope>` for fixes
+3. Never mix multiple issues in one branch.
+4. Keep commits atomic and conventional (`feat:`, `fix:`, `refactor:`, `test:`).
+
+## Implementation Workflow (TDD Required)
+
+1. Read relevant spec(s) and affected bounded context code first.
+2. Write/adjust tests for expected behavior before implementation.
+3. Implement minimal code to satisfy tests.
+4. Run focused tests first, then broader suite for touched context.
+5. Run lints/type checks for changed files when applicable.
+6. If behavior depends on configuration, use settings/DI instead of hardcoding.
+
+## PR Workflow
+
+1. Push branch to origin with upstream tracking.
+2. Open PR against `feature/manage-knowledge-graph`.
+3. Use this body structure:
+
+```markdown
+## Summary
+- <what changed and why>
+- <important architectural/security note>
+
+## Testing
+- [x] <unit tests run>
+- [x] <integration tests run if applicable>
+- [ ] <manual verification if pending>
+
+## Risks
+- <none> or <known risk + mitigation>
+```
+
+4. Link the issue in PR body using `Closes #<id>` when appropriate.
+
+## Merge and Conflict Handling
+
+1. Before merge, ensure CI checks are green.
+2. If branch is stale, rebase or merge target branch cleanly.
+3. Resolve conflicts preserving:
+   - Spec-required behavior
+   - Existing user changes
+   - Authorization and tenancy boundaries
+4. Re-run tests after conflict resolution.
+5. Merge into `feature/manage-knowledge-graph` only after verification.
+
+## Non-Negotiables
+
+- Do not use destructive git commands.
+- Do not skip tests.
+- Do not disable hooks.
+- Do not commit secrets or credentials.
+- Prefer fakes over mocks in unit tests when testing domain/application behavior.
+

--- a/src/api/infrastructure/migrations/versions/f4a5b6c7d8e9_add_workspace_mode_to_knowledge_graphs.py
+++ b/src/api/infrastructure/migrations/versions/f4a5b6c7d8e9_add_workspace_mode_to_knowledge_graphs.py
@@ -1,0 +1,39 @@
+"""add workspace_mode to knowledge_graphs
+
+Adds lifecycle mode tracking to KnowledgeGraph records with a non-null
+default of ``schema_bootstrap``.
+
+Revision ID: f4a5b6c7d8e9
+Revises: e2f3a4b5c6d7
+Create Date: 2026-05-14 12:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f4a5b6c7d8e9"
+down_revision: Union[str, Sequence[str], None] = "e2f3a4b5c6d7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add workspace_mode with bootstrap default for existing rows."""
+    op.add_column(
+        "knowledge_graphs",
+        sa.Column(
+            "workspace_mode",
+            sa.String(length=64),
+            nullable=False,
+            server_default="schema_bootstrap",
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop workspace_mode from knowledge_graphs."""
+    op.drop_column("knowledge_graphs", "workspace_mode")

--- a/src/api/management/domain/aggregates/knowledge_graph.py
+++ b/src/api/management/domain/aggregates/knowledge_graph.py
@@ -15,12 +15,17 @@ from management.domain.exceptions import (
     AggregateDeletedError,
     InvalidIdentifierError,
     InvalidKnowledgeGraphNameError,
+    InvalidWorkspaceModeTransitionError,
 )
 from management.domain.observability import (
     DefaultKnowledgeGraphProbe,
     KnowledgeGraphProbe,
 )
-from management.domain.value_objects import KnowledgeGraphId, OntologyConfig
+from management.domain.value_objects import (
+    KnowledgeGraphId,
+    OntologyConfig,
+    WorkspaceMode,
+)
 
 if TYPE_CHECKING:
     from management.domain.events import DomainEvent
@@ -51,6 +56,7 @@ class KnowledgeGraph:
     created_at: datetime
     updated_at: datetime
     ontology: OntologyConfig | None = field(default=None)
+    workspace_mode: WorkspaceMode = field(default=WorkspaceMode.SCHEMA_BOOTSTRAP)
     _pending_events: list[DomainEvent] = field(default_factory=list, repr=False)
     _probe: KnowledgeGraphProbe = field(
         default_factory=DefaultKnowledgeGraphProbe,
@@ -63,6 +69,7 @@ class KnowledgeGraph:
         self._validate_name(self.name)
         self._validate_identifier(self.tenant_id, "tenant_id")
         self._validate_identifier(self.workspace_id, "workspace_id")
+        self.workspace_mode = WorkspaceMode(self.workspace_mode)
 
     def _validate_name(self, name: str) -> None:
         """Validate knowledge graph name length.
@@ -228,6 +235,15 @@ class KnowledgeGraph:
                 "Cannot clear ontology on a deleted knowledge graph"
             )
         self.ontology = None
+        self.updated_at = datetime.now(UTC)
+
+    def transition_to_extraction_operations(self) -> None:
+        """Transition workspace mode from bootstrap to extraction operations."""
+        if self.workspace_mode == WorkspaceMode.EXTRACTION_OPERATIONS:
+            raise InvalidWorkspaceModeTransitionError(
+                "Workspace mode is already extraction_operations"
+            )
+        self.workspace_mode = WorkspaceMode.EXTRACTION_OPERATIONS
         self.updated_at = datetime.now(UTC)
 
     def mark_for_deletion(

--- a/src/api/management/domain/exceptions.py
+++ b/src/api/management/domain/exceptions.py
@@ -29,3 +29,9 @@ class InvalidIdentifierError(Exception):
     """Raised when a cross-context identifier (tenant_id, workspace_id, etc.) is empty or whitespace."""
 
     pass
+
+
+class InvalidWorkspaceModeTransitionError(Exception):
+    """Raised when a workspace mode transition is invalid."""
+
+    pass

--- a/src/api/management/domain/value_objects.py
+++ b/src/api/management/domain/value_objects.py
@@ -94,6 +94,13 @@ class ScheduleType(StrEnum):
     INTERVAL = "interval"
 
 
+class WorkspaceMode(StrEnum):
+    """Lifecycle mode of a knowledge-graph workspace."""
+
+    SCHEMA_BOOTSTRAP = "schema_bootstrap"
+    EXTRACTION_OPERATIONS = "extraction_operations"
+
+
 @dataclass(frozen=True)
 class Schedule:
     """Schedule configuration for data source synchronization.

--- a/src/api/management/infrastructure/models/knowledge_graph.py
+++ b/src/api/management/infrastructure/models/knowledge_graph.py
@@ -10,6 +10,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from infrastructure.database.models import Base, TimestampMixin
+from management.domain.value_objects import WorkspaceMode
 
 
 class KnowledgeGraphModel(Base, TimestampMixin):
@@ -30,6 +31,12 @@ class KnowledgeGraphModel(Base, TimestampMixin):
     workspace_id: Mapped[str] = mapped_column(String(26), nullable=False)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    workspace_mode: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        default=WorkspaceMode.SCHEMA_BOOTSTRAP.value,
+        server_default=WorkspaceMode.SCHEMA_BOOTSTRAP.value,
+    )
     ontology: Mapped[dict | None] = mapped_column(JSONB, nullable=True, default=None)
 
     __table_args__ = (

--- a/src/api/management/infrastructure/repositories/knowledge_graph_repository.py
+++ b/src/api/management/infrastructure/repositories/knowledge_graph_repository.py
@@ -13,7 +13,11 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from management.domain.aggregates import KnowledgeGraph
-from management.domain.value_objects import KnowledgeGraphId, OntologyConfig
+from management.domain.value_objects import (
+    KnowledgeGraphId,
+    OntologyConfig,
+    WorkspaceMode,
+)
 from management.infrastructure.models import KnowledgeGraphModel
 from management.infrastructure.observability import (
     DefaultKnowledgeGraphRepositoryProbe,
@@ -67,6 +71,7 @@ class KnowledgeGraphRepository(IKnowledgeGraphRepository):
             if model:
                 model.name = knowledge_graph.name
                 model.description = knowledge_graph.description
+                model.workspace_mode = knowledge_graph.workspace_mode.value
                 model.updated_at = knowledge_graph.updated_at
             else:
                 model = KnowledgeGraphModel(
@@ -75,6 +80,7 @@ class KnowledgeGraphRepository(IKnowledgeGraphRepository):
                     workspace_id=knowledge_graph.workspace_id,
                     name=knowledge_graph.name,
                     description=knowledge_graph.description,
+                    workspace_mode=knowledge_graph.workspace_mode.value,
                     created_at=knowledge_graph.created_at,
                     updated_at=knowledge_graph.updated_at,
                 )
@@ -219,4 +225,5 @@ class KnowledgeGraphRepository(IKnowledgeGraphRepository):
             created_at=model.created_at,
             updated_at=model.updated_at,
             ontology=ontology,
+            workspace_mode=WorkspaceMode(model.workspace_mode),
         )

--- a/src/api/management/presentation/knowledge_graphs/models.py
+++ b/src/api/management/presentation/knowledge_graphs/models.py
@@ -11,6 +11,7 @@ from management.domain.value_objects import (
     EdgeTypeDefinition,
     NodeTypeDefinition,
     OntologyConfig,
+    WorkspaceMode,
 )
 
 
@@ -71,6 +72,10 @@ class KnowledgeGraphResponse(BaseModel):
     workspace_id: str = Field(..., description="Workspace ID this KG belongs to")
     name: str = Field(..., description="Knowledge graph name")
     description: str = Field(..., description="Knowledge graph description")
+    workspace_mode: WorkspaceMode = Field(
+        ...,
+        description="Workspace lifecycle mode for this knowledge graph",
+    )
     created_at: datetime = Field(..., description="When the KG was created")
     updated_at: datetime = Field(..., description="When the KG was last updated")
 
@@ -90,6 +95,7 @@ class KnowledgeGraphResponse(BaseModel):
             workspace_id=kg.workspace_id,
             name=kg.name,
             description=kg.description,
+            workspace_mode=kg.workspace_mode,
             created_at=kg.created_at,
             updated_at=kg.updated_at,
         )

--- a/src/api/tests/integration/management/test_knowledge_graph_repository.py
+++ b/src/api/tests/integration/management/test_knowledge_graph_repository.py
@@ -22,6 +22,7 @@ from management.infrastructure.repositories.knowledge_graph_repository import (
     KnowledgeGraphRepository,
 )
 from management.ports.exceptions import DuplicateKnowledgeGraphNameError
+from management.domain.value_objects import WorkspaceMode
 from shared_kernel.datasource_types import DataSourceAdapterType
 
 pytestmark = pytest.mark.integration
@@ -83,6 +84,32 @@ class TestKnowledgeGraphRoundTrip:
 
         assert retrieved is not None
         assert retrieved.description == ""
+
+    @pytest.mark.asyncio
+    async def test_saves_and_retrieves_workspace_mode(
+        self,
+        knowledge_graph_repository: KnowledgeGraphRepository,
+        async_session,
+        test_tenant: str,
+        test_workspace: str,
+        clean_management_data,
+    ):
+        """Should persist workspace mode transition state."""
+        kg = KnowledgeGraph.create(
+            tenant_id=test_tenant,
+            workspace_id=test_workspace,
+            name="Workspace Mode KG",
+            description="Tracks mode lifecycle",
+        )
+        kg.transition_to_extraction_operations()
+
+        async with async_session.begin():
+            await knowledge_graph_repository.save(kg)
+
+        retrieved = await knowledge_graph_repository.get_by_id(kg.id)
+
+        assert retrieved is not None
+        assert retrieved.workspace_mode == WorkspaceMode.EXTRACTION_OPERATIONS
 
 
 class TestKnowledgeGraphUpdate:

--- a/src/api/tests/unit/management/presentation/test_knowledge_graphs_routes.py
+++ b/src/api/tests/unit/management/presentation/test_knowledge_graphs_routes.py
@@ -19,7 +19,7 @@ from management.application.services.knowledge_graph_service import (
     KnowledgeGraphService,
 )
 from management.domain.aggregates import KnowledgeGraph
-from management.domain.value_objects import KnowledgeGraphId
+from management.domain.value_objects import KnowledgeGraphId, WorkspaceMode
 from management.ports.exceptions import (
     DuplicateKnowledgeGraphNameError,
     KnowledgeGraphNotFoundError,
@@ -100,6 +100,10 @@ class TestListKnowledgeGraphsRoute:
         assert len(result["knowledge_graphs"]) == 1
         assert result["knowledge_graphs"][0]["id"] == sample_knowledge_graph.id.value
         assert result["knowledge_graphs"][0]["name"] == sample_knowledge_graph.name
+        assert (
+            result["knowledge_graphs"][0]["workspace_mode"]
+            == WorkspaceMode.SCHEMA_BOOTSTRAP.value
+        )
 
     def test_list_knowledge_graphs_calls_list_all_with_view_permission_by_default(
         self,
@@ -254,6 +258,7 @@ class TestGetKnowledgeGraphRoute:
         assert result["description"] == sample_knowledge_graph.description
         assert result["tenant_id"] == sample_knowledge_graph.tenant_id
         assert result["workspace_id"] == sample_knowledge_graph.workspace_id
+        assert result["workspace_mode"] == WorkspaceMode.SCHEMA_BOOTSTRAP.value
 
     def test_get_knowledge_graph_calls_service_with_user_id(
         self,

--- a/src/api/tests/unit/management/test_knowledge_graph.py
+++ b/src/api/tests/unit/management/test_knowledge_graph.py
@@ -17,11 +17,12 @@ from management.domain.exceptions import (
     AggregateDeletedError,
     InvalidIdentifierError,
     InvalidKnowledgeGraphNameError,
+    InvalidWorkspaceModeTransitionError,
 )
 from management.domain.observability import (
     KnowledgeGraphProbe,
 )
-from management.domain.value_objects import KnowledgeGraphId
+from management.domain.value_objects import KnowledgeGraphId, WorkspaceMode
 
 
 class TestKnowledgeGraphCreate:
@@ -43,6 +44,7 @@ class TestKnowledgeGraphCreate:
         assert isinstance(kg.created_at, datetime)
         assert isinstance(kg.updated_at, datetime)
         assert kg.created_at == kg.updated_at
+        assert kg.workspace_mode == WorkspaceMode.SCHEMA_BOOTSTRAP
 
     def test_create_generates_unique_id(self):
         """Each create() call should generate a unique ID."""
@@ -217,6 +219,38 @@ class TestKnowledgeGraphUpdate:
         kg.mark_for_deletion()
         with pytest.raises(AggregateDeletedError):
             kg.update(name="Should fail", description="")
+
+
+class TestKnowledgeGraphWorkspaceMode:
+    """Tests for workspace mode lifecycle transitions."""
+
+    def _create_kg(self, **kwargs):
+        defaults = {
+            "tenant_id": "t",
+            "workspace_id": "w",
+            "name": "Original",
+            "description": "Original desc",
+        }
+        defaults.update(kwargs)
+        kg = KnowledgeGraph.create(**defaults)
+        kg.collect_events()
+        return kg
+
+    def test_transition_to_extraction_operations(self):
+        """Transition should move mode to extraction_operations."""
+        kg = self._create_kg()
+
+        kg.transition_to_extraction_operations()
+
+        assert kg.workspace_mode == WorkspaceMode.EXTRACTION_OPERATIONS
+
+    def test_transition_is_irreversible(self):
+        """Transitioning after extraction_operations should fail."""
+        kg = self._create_kg()
+        kg.transition_to_extraction_operations()
+
+        with pytest.raises(InvalidWorkspaceModeTransitionError):
+            kg.transition_to_extraction_operations()
 
 
 class TestKnowledgeGraphMarkForDeletion:


### PR DESCRIPTION
## Summary
- add `workspace_mode` lifecycle support to knowledge graphs with default `schema_bootstrap`
- enforce irreversible domain transition to `extraction_operations` and persist state via repository/model/migration
- add a reusable `skills/subagent-delivery/SKILL.md` protocol to keep sub-agent git/test/PR behavior consistent

## Testing
- [x] `uv run pytest tests/unit/management/test_knowledge_graph.py tests/unit/management/presentation/test_knowledge_graphs_routes.py tests/unit/management/application/test_knowledge_graph_service.py -q`

## Risks
- migration adds a non-null defaulted column; low risk due to server default and backward-compatible API serialization

Closes #643

Made with [Cursor](https://cursor.com)