### PR TITLE
feat(management): add workspace status projection API (#644)

### DIFF
--- a/src/api/management/application/services/knowledge_graph_service.py
+++ b/src/api/management/application/services/knowledge_graph_service.py
@@ -14,7 +14,14 @@ from management.application.observability import (
     KnowledgeGraphServiceProbe,
 )
 from management.domain.aggregates import KnowledgeGraph
-from management.domain.value_objects import KnowledgeGraphId, OntologyConfig
+from management.domain.value_objects import (
+    KnowledgeGraphId,
+    KnowledgeGraphWorkspaceStatus,
+    OntologyConfig,
+    WorkspaceMode,
+    WorkspaceReadinessStatus,
+    WorkspaceSessionPointers,
+)
 from management.ports.exceptions import (
     DuplicateKnowledgeGraphNameError,
     KnowledgeGraphNotFoundError,
@@ -580,3 +587,49 @@ class KnowledgeGraphService:
         await self._session.commit()
 
         return config
+
+    def _evaluate_workspace_readiness(
+        self, kg: KnowledgeGraph
+    ) -> WorkspaceReadinessStatus:
+        """Evaluate transition readiness flags for workspace status projection."""
+        node_type_count = len(kg.ontology.node_types) if kg.ontology else 0
+        edge_type_count = len(kg.ontology.edge_types) if kg.ontology else 0
+
+        # Prepopulated-instance validation is delivered by later units of work.
+        return WorkspaceReadinessStatus(
+            has_minimum_entity_types=node_type_count >= 1,
+            has_minimum_relationship_types=edge_type_count >= 1,
+            prepopulated_types_ready=True,
+        )
+
+    async def get_workspace_status(
+        self,
+        user_id: str,
+        kg_id: str,
+    ) -> KnowledgeGraphWorkspaceStatus | None:
+        """Get mode/readiness/session projection for a knowledge graph workspace."""
+        kg = await self._kg_repo.get_by_id(KnowledgeGraphId(value=kg_id))
+        if kg is None or kg.tenant_id != self._scope_to_tenant:
+            return None
+
+        has_view = await self._check_permission(
+            user_id=user_id,
+            resource_type=ResourceType.KNOWLEDGE_GRAPH,
+            resource_id=kg_id,
+            permission=Permission.VIEW,
+        )
+        if not has_view:
+            return None
+
+        readiness = self._evaluate_workspace_readiness(kg)
+        transition_eligible = (
+            kg.workspace_mode == WorkspaceMode.SCHEMA_BOOTSTRAP and readiness.is_ready
+        )
+
+        return KnowledgeGraphWorkspaceStatus(
+            knowledge_graph_id=kg.id.value,
+            workspace_mode=kg.workspace_mode,
+            readiness=readiness,
+            transition_eligible=transition_eligible,
+            session_pointers=WorkspaceSessionPointers(),
+        )

--- a/src/api/management/domain/value_objects.py
+++ b/src/api/management/domain/value_objects.py
@@ -102,6 +102,44 @@ class WorkspaceMode(StrEnum):
 
 
 @dataclass(frozen=True)
+class WorkspaceReadinessStatus:
+    """Readiness flags used to determine bootstrap transition eligibility."""
+
+    has_minimum_entity_types: bool
+    has_minimum_relationship_types: bool
+    prepopulated_types_ready: bool
+
+    @property
+    def is_ready(self) -> bool:
+        """Return true when all readiness checks pass."""
+        return (
+            self.has_minimum_entity_types
+            and self.has_minimum_relationship_types
+            and self.prepopulated_types_ready
+        )
+
+
+@dataclass(frozen=True)
+class WorkspaceSessionPointers:
+    """Session pointers projected for workspace status UIs."""
+
+    active_schema_bootstrap_session_id: str | None = None
+    active_extraction_operations_session_id: str | None = None
+    most_recent_completed_session_id: str | None = None
+
+
+@dataclass(frozen=True)
+class KnowledgeGraphWorkspaceStatus:
+    """Workspace status projection for a knowledge graph."""
+
+    knowledge_graph_id: str
+    workspace_mode: WorkspaceMode
+    readiness: WorkspaceReadinessStatus
+    transition_eligible: bool
+    session_pointers: WorkspaceSessionPointers
+
+
+@dataclass(frozen=True)
 class Schedule:
     """Schedule configuration for data source synchronization.
 

--- a/src/api/management/presentation/knowledge_graphs/models.py
+++ b/src/api/management/presentation/knowledge_graphs/models.py
@@ -9,8 +9,11 @@ from pydantic import BaseModel, Field
 from management.domain.aggregates import KnowledgeGraph
 from management.domain.value_objects import (
     EdgeTypeDefinition,
+    KnowledgeGraphWorkspaceStatus,
     NodeTypeDefinition,
     OntologyConfig,
+    WorkspaceReadinessStatus,
+    WorkspaceSessionPointers,
     WorkspaceMode,
 )
 
@@ -98,6 +101,66 @@ class KnowledgeGraphResponse(BaseModel):
             workspace_mode=kg.workspace_mode,
             created_at=kg.created_at,
             updated_at=kg.updated_at,
+        )
+
+
+class WorkspaceReadinessResponse(BaseModel):
+    """Workspace readiness flags for bootstrap transition."""
+
+    has_minimum_entity_types: bool
+    has_minimum_relationship_types: bool
+    prepopulated_types_ready: bool
+
+    @classmethod
+    def from_domain(cls, readiness: WorkspaceReadinessStatus) -> "WorkspaceReadinessResponse":
+        return cls(
+            has_minimum_entity_types=readiness.has_minimum_entity_types,
+            has_minimum_relationship_types=readiness.has_minimum_relationship_types,
+            prepopulated_types_ready=readiness.prepopulated_types_ready,
+        )
+
+
+class WorkspaceSessionPointersResponse(BaseModel):
+    """Session pointer projection for workspace status UI."""
+
+    active_schema_bootstrap_session_id: str | None = None
+    active_extraction_operations_session_id: str | None = None
+    most_recent_completed_session_id: str | None = None
+
+    @classmethod
+    def from_domain(
+        cls, pointers: WorkspaceSessionPointers
+    ) -> "WorkspaceSessionPointersResponse":
+        return cls(
+            active_schema_bootstrap_session_id=pointers.active_schema_bootstrap_session_id,
+            active_extraction_operations_session_id=(
+                pointers.active_extraction_operations_session_id
+            ),
+            most_recent_completed_session_id=pointers.most_recent_completed_session_id,
+        )
+
+
+class KnowledgeGraphWorkspaceStatusResponse(BaseModel):
+    """Mode/readiness/session status projection for a knowledge graph workspace."""
+
+    knowledge_graph_id: str
+    workspace_mode: WorkspaceMode
+    readiness: WorkspaceReadinessResponse
+    transition_eligible: bool
+    session_pointers: WorkspaceSessionPointersResponse
+
+    @classmethod
+    def from_domain(
+        cls, status: KnowledgeGraphWorkspaceStatus
+    ) -> "KnowledgeGraphWorkspaceStatusResponse":
+        return cls(
+            knowledge_graph_id=status.knowledge_graph_id,
+            workspace_mode=status.workspace_mode,
+            readiness=WorkspaceReadinessResponse.from_domain(status.readiness),
+            transition_eligible=status.transition_eligible,
+            session_pointers=WorkspaceSessionPointersResponse.from_domain(
+                status.session_pointers
+            ),
         )
 
 

--- a/src/api/management/presentation/knowledge_graphs/routes.py
+++ b/src/api/management/presentation/knowledge_graphs/routes.py
@@ -21,6 +21,7 @@ from management.presentation.knowledge_graphs.models import (
     CreateKnowledgeGraphRequest,
     KnowledgeGraphListResponse,
     KnowledgeGraphResponse,
+    KnowledgeGraphWorkspaceStatusResponse,
     OntologyConfigRequest,
     OntologyConfigResponse,
     UpdateKnowledgeGraphRequest,
@@ -153,6 +154,43 @@ async def get_knowledge_graph(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve knowledge graph",
+        )
+
+
+@router.get(
+    "/knowledge-graphs/{kg_id}/workspace-status",
+    response_model=KnowledgeGraphWorkspaceStatusResponse,
+    summary="Get knowledge graph workspace status projection",
+    description="""
+Return mode/readiness/session status used by the knowledge graph Manage workspace UI.
+
+Returns 404 when the knowledge graph does not exist or the caller lacks `view`
+permission on the knowledge graph.
+""",
+)
+async def get_knowledge_graph_workspace_status(
+    kg_id: str,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    service: Annotated[KnowledgeGraphService, Depends(get_knowledge_graph_service)],
+) -> KnowledgeGraphWorkspaceStatusResponse:
+    """Get workspace status projection for a knowledge graph."""
+    try:
+        status_projection = await service.get_workspace_status(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+        )
+        if status_projection is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Knowledge graph {kg_id} not found",
+            )
+        return KnowledgeGraphWorkspaceStatusResponse.from_domain(status_projection)
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retrieve workspace status",
         )
 
 

--- a/src/api/tests/unit/management/application/test_knowledge_graph_service.py
+++ b/src/api/tests/unit/management/application/test_knowledge_graph_service.py
@@ -21,9 +21,14 @@ from management.application.services.knowledge_graph_service import (
 from management.domain.aggregates import DataSource, KnowledgeGraph
 from management.domain.value_objects import (
     DataSourceId,
+    EdgeTypeDefinition,
+    KnowledgeGraphWorkspaceStatus,
     KnowledgeGraphId,
+    NodeTypeDefinition,
+    OntologyConfig,
     Schedule,
     ScheduleType,
+    WorkspaceMode,
 )
 from shared_kernel.datasource_types import DataSourceAdapterType
 from management.ports.exceptions import (
@@ -408,6 +413,76 @@ class TestKnowledgeGraphServiceGet:
         assert result is kg
         assert len(probe.knowledge_graph_retrieved_calls) == 1
         assert probe.knowledge_graph_retrieved_calls[0]["kg_id"] == kg.id.value
+
+
+class TestKnowledgeGraphServiceWorkspaceStatus:
+    """Tests for KnowledgeGraphService.get_workspace_status."""
+
+    @pytest.mark.asyncio
+    async def test_workspace_status_returns_none_when_not_found(self, service, user_id):
+        """Should return None if KG does not exist."""
+        result = await service.get_workspace_status(user_id=user_id, kg_id="missing")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_workspace_status_returns_none_when_view_denied(
+        self, service, kg_repo, user_id
+    ):
+        """Should return None if caller lacks VIEW on KG."""
+        kg = _make_kg()
+        kg_repo.seed(kg)
+
+        result = await service.get_workspace_status(user_id=user_id, kg_id=kg.id.value)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_workspace_status_includes_mode_readiness_and_session_pointers(
+        self, service, authz, kg_repo, user_id
+    ):
+        """Should project mode/readiness flags and default null session pointers."""
+        kg = _make_kg()
+        kg.set_ontology(
+            OntologyConfig(
+                node_types=(NodeTypeDefinition(label="Repository"),),
+                edge_types=(
+                    EdgeTypeDefinition(
+                        label="CONTAINS",
+                        source_labels=("Repository",),
+                        target_labels=("Repository",),
+                    ),
+                ),
+            )
+        )
+        kg_repo.seed(kg)
+        await _grant_kg_view(authz, kg.id.value, user_id)
+
+        result = await service.get_workspace_status(user_id=user_id, kg_id=kg.id.value)
+
+        assert isinstance(result, KnowledgeGraphWorkspaceStatus)
+        assert result.workspace_mode == WorkspaceMode.SCHEMA_BOOTSTRAP
+        assert result.readiness.has_minimum_entity_types is True
+        assert result.readiness.has_minimum_relationship_types is True
+        assert result.readiness.prepopulated_types_ready is True
+        assert result.transition_eligible is True
+        assert result.session_pointers.active_schema_bootstrap_session_id is None
+        assert result.session_pointers.active_extraction_operations_session_id is None
+        assert result.session_pointers.most_recent_completed_session_id is None
+
+    @pytest.mark.asyncio
+    async def test_workspace_status_transition_not_eligible_without_schema_readiness(
+        self, service, authz, kg_repo, user_id
+    ):
+        """Should report transition_eligible false when readiness checks fail."""
+        kg = _make_kg()
+        kg_repo.seed(kg)
+        await _grant_kg_view(authz, kg.id.value, user_id)
+
+        result = await service.get_workspace_status(user_id=user_id, kg_id=kg.id.value)
+
+        assert result is not None
+        assert result.readiness.has_minimum_entity_types is False
+        assert result.readiness.has_minimum_relationship_types is False
+        assert result.transition_eligible is False
 
 
 # ---- list_for_workspace ----

--- a/src/api/tests/unit/management/presentation/test_knowledge_graphs_routes.py
+++ b/src/api/tests/unit/management/presentation/test_knowledge_graphs_routes.py
@@ -19,7 +19,13 @@ from management.application.services.knowledge_graph_service import (
     KnowledgeGraphService,
 )
 from management.domain.aggregates import KnowledgeGraph
-from management.domain.value_objects import KnowledgeGraphId, WorkspaceMode
+from management.domain.value_objects import (
+    KnowledgeGraphId,
+    KnowledgeGraphWorkspaceStatus,
+    WorkspaceMode,
+    WorkspaceReadinessStatus,
+    WorkspaceSessionPointers,
+)
 from management.ports.exceptions import (
     DuplicateKnowledgeGraphNameError,
     KnowledgeGraphNotFoundError,
@@ -289,6 +295,64 @@ class TestGetKnowledgeGraphRoute:
 
         response = test_client.get(
             "/management/knowledge-graphs/01JPQRST1234567890ABCDEFKG"
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestGetKnowledgeGraphWorkspaceStatusRoute:
+    """Tests for GET /management/knowledge-graphs/{kg_id}/workspace-status."""
+
+    def test_workspace_status_returns_200_with_projection(
+        self,
+        test_client: TestClient,
+        mock_kg_service: AsyncMock,
+        sample_knowledge_graph: KnowledgeGraph,
+        mock_current_user: CurrentUser,
+    ) -> None:
+        """Should return mode/readiness/session projection when authorized."""
+        mock_kg_service.get_workspace_status.return_value = KnowledgeGraphWorkspaceStatus(
+            knowledge_graph_id=sample_knowledge_graph.id.value,
+            workspace_mode=WorkspaceMode.SCHEMA_BOOTSTRAP,
+            readiness=WorkspaceReadinessStatus(
+                has_minimum_entity_types=True,
+                has_minimum_relationship_types=False,
+                prepopulated_types_ready=True,
+            ),
+            transition_eligible=False,
+            session_pointers=WorkspaceSessionPointers(),
+        )
+
+        response = test_client.get(
+            f"/management/knowledge-graphs/{sample_knowledge_graph.id.value}/workspace-status"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        payload = response.json()
+        assert payload["knowledge_graph_id"] == sample_knowledge_graph.id.value
+        assert payload["workspace_mode"] == WorkspaceMode.SCHEMA_BOOTSTRAP.value
+        assert payload["readiness"]["has_minimum_entity_types"] is True
+        assert payload["readiness"]["has_minimum_relationship_types"] is False
+        assert payload["readiness"]["prepopulated_types_ready"] is True
+        assert payload["transition_eligible"] is False
+        assert payload["session_pointers"]["active_schema_bootstrap_session_id"] is None
+
+        mock_kg_service.get_workspace_status.assert_called_once_with(
+            user_id=mock_current_user.user_id.value,
+            kg_id=sample_knowledge_graph.id.value,
+        )
+
+    def test_workspace_status_returns_404_when_missing_or_unauthorized(
+        self,
+        test_client: TestClient,
+        mock_kg_service: AsyncMock,
+        sample_knowledge_graph: KnowledgeGraph,
+    ) -> None:
+        """Should return 404 when service returns None."""
+        mock_kg_service.get_workspace_status.return_value = None
+
+        response = test_client.get(
+            f"/management/knowledge-graphs/{sample_knowledge_graph.id.value}/workspace-status"
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
## Summary
- add `get_workspace_status` service projection with mode, readiness flags, transition eligibility, and session pointers
- expose `GET /management/knowledge-graphs/{kg_id}/workspace-status` with non-leaking auth behavior
- add unit tests for service and presentation route coverage

## Testing
- [x] `uv run pytest tests/unit/management/application/test_knowledge_graph_service.py tests/unit/management/presentation/test_knowledge_graphs_routes.py tests/unit/management/test_knowledge_graph.py -q`

## Risks
- prepopulated-type readiness is currently a placeholder (`true`) and will be hardened by follow-up readiness issue work

Closes #644

Made with [Cursor](https://cursor.com)