### PR TITLE
feat(management): implement bootstrap readiness validation (#645)

### DIFF
--- a/src/api/management/application/services/knowledge_graph_service.py
+++ b/src/api/management/application/services/knowledge_graph_service.py
@@ -594,12 +594,35 @@ class KnowledgeGraphService:
         """Evaluate transition readiness flags for workspace status projection."""
         node_type_count = len(kg.ontology.node_types) if kg.ontology else 0
         edge_type_count = len(kg.ontology.edge_types) if kg.ontology else 0
+        prepopulated_without_instances: tuple[str, ...] = ()
+        if kg.ontology is not None:
+            prepopulated_without_instances = tuple(
+                node_type.label
+                for node_type in kg.ontology.node_types
+                if node_type.prepopulated and node_type.prepopulated_instance_count <= 0
+            )
 
-        # Prepopulated-instance validation is delivered by later units of work.
+        has_min_entities = node_type_count >= 1
+        has_min_relationships = edge_type_count >= 1
+        prepopulated_ready = len(prepopulated_without_instances) == 0
+
+        blocking_reasons: list[str] = []
+        if not has_min_entities:
+            blocking_reasons.append("At least one entity type is required")
+        if not has_min_relationships:
+            blocking_reasons.append("At least one relationship type is required")
+        if not prepopulated_ready:
+            labels = ", ".join(prepopulated_without_instances)
+            blocking_reasons.append(
+                f"Prepopulated types require instances before transition: {labels}"
+            )
+
         return WorkspaceReadinessStatus(
-            has_minimum_entity_types=node_type_count >= 1,
-            has_minimum_relationship_types=edge_type_count >= 1,
-            prepopulated_types_ready=True,
+            has_minimum_entity_types=has_min_entities,
+            has_minimum_relationship_types=has_min_relationships,
+            prepopulated_types_ready=prepopulated_ready,
+            prepopulated_types_without_instances=prepopulated_without_instances,
+            blocking_reasons=tuple(blocking_reasons),
         )
 
     async def get_workspace_status(

--- a/src/api/management/domain/value_objects.py
+++ b/src/api/management/domain/value_objects.py
@@ -108,6 +108,8 @@ class WorkspaceReadinessStatus:
     has_minimum_entity_types: bool
     has_minimum_relationship_types: bool
     prepopulated_types_ready: bool
+    prepopulated_types_without_instances: tuple[str, ...] = field(default_factory=tuple)
+    blocking_reasons: tuple[str, ...] = field(default_factory=tuple)
 
     @property
     def is_ready(self) -> bool:
@@ -116,6 +118,7 @@ class WorkspaceReadinessStatus:
             self.has_minimum_entity_types
             and self.has_minimum_relationship_types
             and self.prepopulated_types_ready
+            and not self.prepopulated_types_without_instances
         )
 
 
@@ -321,11 +324,15 @@ class NodeTypeDefinition:
     description: str = ""
     required_properties: tuple[str, ...] = field(default_factory=tuple)
     optional_properties: tuple[str, ...] = field(default_factory=tuple)
+    prepopulated: bool = False
+    prepopulated_instance_count: int = 0
 
     def __post_init__(self) -> None:
         """Validate that label is non-empty."""
         if not self.label or not self.label.strip():
             raise ValueError("NodeTypeDefinition label must not be empty")
+        if self.prepopulated_instance_count < 0:
+            raise ValueError("prepopulated_instance_count must be >= 0")
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a plain dict suitable for JSON persistence."""
@@ -334,6 +341,8 @@ class NodeTypeDefinition:
             "description": self.description,
             "required_properties": list(self.required_properties),
             "optional_properties": list(self.optional_properties),
+            "prepopulated": self.prepopulated,
+            "prepopulated_instance_count": self.prepopulated_instance_count,
         }
 
     @classmethod
@@ -344,6 +353,8 @@ class NodeTypeDefinition:
             description=data.get("description", ""),
             required_properties=tuple(data.get("required_properties", [])),
             optional_properties=tuple(data.get("optional_properties", [])),
+            prepopulated=bool(data.get("prepopulated", False)),
+            prepopulated_instance_count=int(data.get("prepopulated_instance_count", 0)),
         )
 
 

--- a/src/api/management/presentation/knowledge_graphs/models.py
+++ b/src/api/management/presentation/knowledge_graphs/models.py
@@ -110,6 +110,8 @@ class WorkspaceReadinessResponse(BaseModel):
     has_minimum_entity_types: bool
     has_minimum_relationship_types: bool
     prepopulated_types_ready: bool
+    prepopulated_types_without_instances: list[str] = Field(default_factory=list)
+    blocking_reasons: list[str] = Field(default_factory=list)
 
     @classmethod
     def from_domain(cls, readiness: WorkspaceReadinessStatus) -> "WorkspaceReadinessResponse":
@@ -117,6 +119,10 @@ class WorkspaceReadinessResponse(BaseModel):
             has_minimum_entity_types=readiness.has_minimum_entity_types,
             has_minimum_relationship_types=readiness.has_minimum_relationship_types,
             prepopulated_types_ready=readiness.prepopulated_types_ready,
+            prepopulated_types_without_instances=list(
+                readiness.prepopulated_types_without_instances
+            ),
+            blocking_reasons=list(readiness.blocking_reasons),
         )
 
 
@@ -182,6 +188,15 @@ class NodeTypeDefinitionModel(BaseModel):
         default_factory=list,
         description="Properties nodes of this type may optionally have",
     )
+    prepopulated: bool = Field(
+        default=False,
+        description="Whether this type must have at least one instance before transition",
+    )
+    prepopulated_instance_count: int = Field(
+        default=0,
+        ge=0,
+        description="Current known instance count used for readiness evaluation",
+    )
 
     def to_domain(self) -> NodeTypeDefinition:
         """Convert to domain NodeTypeDefinition value object."""
@@ -190,6 +205,8 @@ class NodeTypeDefinitionModel(BaseModel):
             description=self.description,
             required_properties=tuple(self.required_properties),
             optional_properties=tuple(self.optional_properties),
+            prepopulated=self.prepopulated,
+            prepopulated_instance_count=self.prepopulated_instance_count,
         )
 
     @classmethod
@@ -200,6 +217,8 @@ class NodeTypeDefinitionModel(BaseModel):
             description=nt.description,
             required_properties=list(nt.required_properties),
             optional_properties=list(nt.optional_properties),
+            prepopulated=nt.prepopulated,
+            prepopulated_instance_count=nt.prepopulated_instance_count,
         )
 
 

--- a/src/api/tests/unit/management/application/test_knowledge_graph_service.py
+++ b/src/api/tests/unit/management/application/test_knowledge_graph_service.py
@@ -463,6 +463,8 @@ class TestKnowledgeGraphServiceWorkspaceStatus:
         assert result.readiness.has_minimum_entity_types is True
         assert result.readiness.has_minimum_relationship_types is True
         assert result.readiness.prepopulated_types_ready is True
+        assert result.readiness.prepopulated_types_without_instances == ()
+        assert result.readiness.blocking_reasons == ()
         assert result.transition_eligible is True
         assert result.session_pointers.active_schema_bootstrap_session_id is None
         assert result.session_pointers.active_extraction_operations_session_id is None
@@ -482,6 +484,45 @@ class TestKnowledgeGraphServiceWorkspaceStatus:
         assert result is not None
         assert result.readiness.has_minimum_entity_types is False
         assert result.readiness.has_minimum_relationship_types is False
+        assert "At least one entity type is required" in result.readiness.blocking_reasons
+        assert (
+            "At least one relationship type is required"
+            in result.readiness.blocking_reasons
+        )
+        assert result.transition_eligible is False
+
+    @pytest.mark.asyncio
+    async def test_workspace_status_fails_for_prepopulated_type_without_instances(
+        self, service, authz, kg_repo, user_id
+    ):
+        """Should block transition when prepopulated type has zero instances."""
+        kg = _make_kg()
+        kg.set_ontology(
+            OntologyConfig(
+                node_types=(
+                    NodeTypeDefinition(
+                        label="Repository",
+                        prepopulated=True,
+                        prepopulated_instance_count=0,
+                    ),
+                ),
+                edge_types=(
+                    EdgeTypeDefinition(
+                        label="CONTAINS",
+                        source_labels=("Repository",),
+                        target_labels=("Repository",),
+                    ),
+                ),
+            )
+        )
+        kg_repo.seed(kg)
+        await _grant_kg_view(authz, kg.id.value, user_id)
+
+        result = await service.get_workspace_status(user_id=user_id, kg_id=kg.id.value)
+
+        assert result is not None
+        assert result.readiness.prepopulated_types_ready is False
+        assert result.readiness.prepopulated_types_without_instances == ("Repository",)
         assert result.transition_eligible is False
 
 

--- a/src/api/tests/unit/management/presentation/test_knowledge_graphs_routes.py
+++ b/src/api/tests/unit/management/presentation/test_knowledge_graphs_routes.py
@@ -334,6 +334,8 @@ class TestGetKnowledgeGraphWorkspaceStatusRoute:
         assert payload["readiness"]["has_minimum_entity_types"] is True
         assert payload["readiness"]["has_minimum_relationship_types"] is False
         assert payload["readiness"]["prepopulated_types_ready"] is True
+        assert payload["readiness"]["prepopulated_types_without_instances"] == []
+        assert payload["readiness"]["blocking_reasons"] == []
         assert payload["transition_eligible"] is False
         assert payload["session_pointers"]["active_schema_bootstrap_session_id"] is None
 

--- a/src/api/tests/unit/management/test_ontology_value_objects.py
+++ b/src/api/tests/unit/management/test_ontology_value_objects.py
@@ -33,6 +33,8 @@ class TestNodeTypeDefinition:
         assert nt.description == ""
         assert nt.required_properties == ()
         assert nt.optional_properties == ()
+        assert nt.prepopulated is False
+        assert nt.prepopulated_instance_count == 0
 
     def test_required_properties_default_empty(self):
         """required_properties defaults to an empty tuple."""
@@ -94,6 +96,17 @@ class TestNodeTypeDefinition:
         assert "description" in d
         assert "required_properties" in d
         assert "optional_properties" in d
+        assert "prepopulated" in d
+        assert "prepopulated_instance_count" in d
+
+    def test_prepopulated_instance_count_must_be_non_negative(self):
+        """NodeTypeDefinition should reject negative prepopulated instance counts."""
+        with pytest.raises(ValueError, match="prepopulated_instance_count"):
+            NodeTypeDefinition(
+                label="Repo",
+                prepopulated=True,
+                prepopulated_instance_count=-1,
+            )
 
 
 class TestEdgeTypeDefinition:


### PR DESCRIPTION
## Summary
- implement actionable bootstrap readiness validation for workspace status projection
- enforce minimum schema checks (entity and relationship types) and prepopulated-type instance checks
- return explicit blocking reasons and failing prepopulated type labels for UI diagnostics

## Testing
- [x] `uv run pytest tests/unit/management/test_ontology_value_objects.py tests/unit/management/application/test_knowledge_graph_service.py tests/unit/management/presentation/test_knowledge_graphs_routes.py -q`

## Risks
- prepopulated instance count currently uses ontology-provided counts until graph-native instance counting is wired

Closes #645

Made with [Cursor](https://cursor.com)