### PR TITLE
feat(management): add workspace validate/transition commands (#646)

### DIFF
--- a/src/api/infrastructure/migrations/versions/f5b6c7d8e9f0_add_workspace_session_pointer_columns.py
+++ b/src/api/infrastructure/migrations/versions/f5b6c7d8e9f0_add_workspace_session_pointer_columns.py
@@ -1,0 +1,46 @@
+"""add workspace session pointer columns to knowledge_graphs
+
+Adds nullable session pointer fields used by workspace status projection
+and bootstrap-to-extraction transition commands.
+
+Revision ID: f5b6c7d8e9f0
+Revises: f4a5b6c7d8e9
+Create Date: 2026-05-14 13:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f5b6c7d8e9f0"
+down_revision: Union[str, Sequence[str], None] = "f4a5b6c7d8e9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add workspace session pointer columns."""
+    op.add_column(
+        "knowledge_graphs",
+        sa.Column("active_schema_bootstrap_session_id", sa.String(length=26), nullable=True),
+    )
+    op.add_column(
+        "knowledge_graphs",
+        sa.Column(
+            "active_extraction_operations_session_id", sa.String(length=26), nullable=True
+        ),
+    )
+    op.add_column(
+        "knowledge_graphs",
+        sa.Column("most_recent_completed_session_id", sa.String(length=26), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop workspace session pointer columns."""
+    op.drop_column("knowledge_graphs", "most_recent_completed_session_id")
+    op.drop_column("knowledge_graphs", "active_extraction_operations_session_id")
+    op.drop_column("knowledge_graphs", "active_schema_bootstrap_session_id")

--- a/src/api/management/application/services/knowledge_graph_service.py
+++ b/src/api/management/application/services/knowledge_graph_service.py
@@ -654,5 +654,92 @@ class KnowledgeGraphService:
             workspace_mode=kg.workspace_mode,
             readiness=readiness,
             transition_eligible=transition_eligible,
-            session_pointers=WorkspaceSessionPointers(),
+            session_pointers=WorkspaceSessionPointers(
+                active_schema_bootstrap_session_id=kg.active_schema_bootstrap_session_id,
+                active_extraction_operations_session_id=(
+                    kg.active_extraction_operations_session_id
+                ),
+                most_recent_completed_session_id=kg.most_recent_completed_session_id,
+            ),
+        )
+
+    async def validate_workspace(
+        self,
+        user_id: str,
+        kg_id: str,
+    ) -> KnowledgeGraphWorkspaceStatus:
+        """Validate bootstrap readiness with KG edit authorization."""
+        has_edit = await self._check_permission(
+            user_id=user_id,
+            resource_type=ResourceType.KNOWLEDGE_GRAPH,
+            resource_id=kg_id,
+            permission=Permission.EDIT,
+        )
+        if not has_edit:
+            self._probe.permission_denied(
+                user_id=user_id,
+                resource_id=kg_id,
+                permission=Permission.EDIT,
+            )
+            raise UnauthorizedError(
+                f"User {user_id} lacks edit permission on knowledge graph {kg_id}"
+            )
+
+        kg = await self._kg_repo.get_by_id(KnowledgeGraphId(value=kg_id))
+        if kg is None or kg.tenant_id != self._scope_to_tenant:
+            raise KnowledgeGraphNotFoundError(f"Knowledge graph {kg_id} not found")
+
+        readiness = self._evaluate_workspace_readiness(kg)
+        transition_eligible = (
+            kg.workspace_mode == WorkspaceMode.SCHEMA_BOOTSTRAP and readiness.is_ready
+        )
+        return KnowledgeGraphWorkspaceStatus(
+            knowledge_graph_id=kg.id.value,
+            workspace_mode=kg.workspace_mode,
+            readiness=readiness,
+            transition_eligible=transition_eligible,
+            session_pointers=WorkspaceSessionPointers(
+                active_schema_bootstrap_session_id=kg.active_schema_bootstrap_session_id,
+                active_extraction_operations_session_id=(
+                    kg.active_extraction_operations_session_id
+                ),
+                most_recent_completed_session_id=kg.most_recent_completed_session_id,
+            ),
+        )
+
+    async def transition_workspace_to_extraction(
+        self,
+        user_id: str,
+        kg_id: str,
+    ) -> KnowledgeGraphWorkspaceStatus:
+        """Transition a knowledge graph workspace to extraction_operations mode."""
+        _ = await self.validate_workspace(user_id=user_id, kg_id=kg_id)
+
+        kg = await self._kg_repo.get_by_id(KnowledgeGraphId(value=kg_id))
+        if kg is None or kg.tenant_id != self._scope_to_tenant:
+            raise KnowledgeGraphNotFoundError(f"Knowledge graph {kg_id} not found")
+
+        readiness = self._evaluate_workspace_readiness(kg)
+        if not readiness.is_ready:
+            joined_reasons = "; ".join(readiness.blocking_reasons)
+            raise ValueError(
+                f"Knowledge graph {kg_id} is not ready for transition: {joined_reasons}"
+            )
+
+        kg.transition_to_extraction_operations()
+        await self._kg_repo.save(kg)
+        await self._session.commit()
+
+        return KnowledgeGraphWorkspaceStatus(
+            knowledge_graph_id=kg.id.value,
+            workspace_mode=kg.workspace_mode,
+            readiness=readiness,
+            transition_eligible=False,
+            session_pointers=WorkspaceSessionPointers(
+                active_schema_bootstrap_session_id=kg.active_schema_bootstrap_session_id,
+                active_extraction_operations_session_id=(
+                    kg.active_extraction_operations_session_id
+                ),
+                most_recent_completed_session_id=kg.most_recent_completed_session_id,
+            ),
         )

--- a/src/api/management/domain/aggregates/knowledge_graph.py
+++ b/src/api/management/domain/aggregates/knowledge_graph.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from ulid import ULID
+
 from management.domain.events import (
     KnowledgeGraphCreated,
     KnowledgeGraphDeleted,
@@ -57,6 +59,9 @@ class KnowledgeGraph:
     updated_at: datetime
     ontology: OntologyConfig | None = field(default=None)
     workspace_mode: WorkspaceMode = field(default=WorkspaceMode.SCHEMA_BOOTSTRAP)
+    active_schema_bootstrap_session_id: str | None = field(default=None)
+    active_extraction_operations_session_id: str | None = field(default=None)
+    most_recent_completed_session_id: str | None = field(default=None)
     _pending_events: list[DomainEvent] = field(default_factory=list, repr=False)
     _probe: KnowledgeGraphProbe = field(
         default_factory=DefaultKnowledgeGraphProbe,
@@ -237,14 +242,16 @@ class KnowledgeGraph:
         self.ontology = None
         self.updated_at = datetime.now(UTC)
 
-    def transition_to_extraction_operations(self) -> None:
+    def transition_to_extraction_operations(self) -> str:
         """Transition workspace mode from bootstrap to extraction operations."""
         if self.workspace_mode == WorkspaceMode.EXTRACTION_OPERATIONS:
             raise InvalidWorkspaceModeTransitionError(
                 "Workspace mode is already extraction_operations"
             )
         self.workspace_mode = WorkspaceMode.EXTRACTION_OPERATIONS
+        self.active_extraction_operations_session_id = str(ULID())
         self.updated_at = datetime.now(UTC)
+        return self.active_extraction_operations_session_id
 
     def mark_for_deletion(
         self,

--- a/src/api/management/infrastructure/models/knowledge_graph.py
+++ b/src/api/management/infrastructure/models/knowledge_graph.py
@@ -37,6 +37,15 @@ class KnowledgeGraphModel(Base, TimestampMixin):
         default=WorkspaceMode.SCHEMA_BOOTSTRAP.value,
         server_default=WorkspaceMode.SCHEMA_BOOTSTRAP.value,
     )
+    active_schema_bootstrap_session_id: Mapped[str | None] = mapped_column(
+        String(26), nullable=True
+    )
+    active_extraction_operations_session_id: Mapped[str | None] = mapped_column(
+        String(26), nullable=True
+    )
+    most_recent_completed_session_id: Mapped[str | None] = mapped_column(
+        String(26), nullable=True
+    )
     ontology: Mapped[dict | None] = mapped_column(JSONB, nullable=True, default=None)
 
     __table_args__ = (

--- a/src/api/management/infrastructure/repositories/knowledge_graph_repository.py
+++ b/src/api/management/infrastructure/repositories/knowledge_graph_repository.py
@@ -72,6 +72,15 @@ class KnowledgeGraphRepository(IKnowledgeGraphRepository):
                 model.name = knowledge_graph.name
                 model.description = knowledge_graph.description
                 model.workspace_mode = knowledge_graph.workspace_mode.value
+                model.active_schema_bootstrap_session_id = (
+                    knowledge_graph.active_schema_bootstrap_session_id
+                )
+                model.active_extraction_operations_session_id = (
+                    knowledge_graph.active_extraction_operations_session_id
+                )
+                model.most_recent_completed_session_id = (
+                    knowledge_graph.most_recent_completed_session_id
+                )
                 model.updated_at = knowledge_graph.updated_at
             else:
                 model = KnowledgeGraphModel(
@@ -81,6 +90,15 @@ class KnowledgeGraphRepository(IKnowledgeGraphRepository):
                     name=knowledge_graph.name,
                     description=knowledge_graph.description,
                     workspace_mode=knowledge_graph.workspace_mode.value,
+                    active_schema_bootstrap_session_id=(
+                        knowledge_graph.active_schema_bootstrap_session_id
+                    ),
+                    active_extraction_operations_session_id=(
+                        knowledge_graph.active_extraction_operations_session_id
+                    ),
+                    most_recent_completed_session_id=(
+                        knowledge_graph.most_recent_completed_session_id
+                    ),
                     created_at=knowledge_graph.created_at,
                     updated_at=knowledge_graph.updated_at,
                 )
@@ -226,4 +244,9 @@ class KnowledgeGraphRepository(IKnowledgeGraphRepository):
             updated_at=model.updated_at,
             ontology=ontology,
             workspace_mode=WorkspaceMode(model.workspace_mode),
+            active_schema_bootstrap_session_id=model.active_schema_bootstrap_session_id,
+            active_extraction_operations_session_id=(
+                model.active_extraction_operations_session_id
+            ),
+            most_recent_completed_session_id=model.most_recent_completed_session_id,
         )

--- a/src/api/management/presentation/knowledge_graphs/routes.py
+++ b/src/api/management/presentation/knowledge_graphs/routes.py
@@ -195,6 +195,79 @@ async def get_knowledge_graph_workspace_status(
 
 
 @router.post(
+    "/knowledge-graphs/{kg_id}/workspace/validate",
+    response_model=KnowledgeGraphWorkspaceStatusResponse,
+    summary="Validate bootstrap readiness for workspace transition",
+)
+async def validate_knowledge_graph_workspace(
+    kg_id: str,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    service: Annotated[KnowledgeGraphService, Depends(get_knowledge_graph_service)],
+) -> KnowledgeGraphWorkspaceStatusResponse:
+    """Validate workspace readiness with edit authorization."""
+    try:
+        status_projection = await service.validate_workspace(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+        )
+        return KnowledgeGraphWorkspaceStatusResponse.from_domain(status_projection)
+    except UnauthorizedError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to perform this action",
+        )
+    except KnowledgeGraphNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        )
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to validate workspace status",
+        )
+
+
+@router.post(
+    "/knowledge-graphs/{kg_id}/workspace/transition-to-extraction",
+    response_model=KnowledgeGraphWorkspaceStatusResponse,
+    summary="Transition workspace from bootstrap to extraction operations",
+)
+async def transition_workspace_to_extraction(
+    kg_id: str,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    service: Annotated[KnowledgeGraphService, Depends(get_knowledge_graph_service)],
+) -> KnowledgeGraphWorkspaceStatusResponse:
+    """Transition workspace mode after successful validation."""
+    try:
+        status_projection = await service.transition_workspace_to_extraction(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+        )
+        return KnowledgeGraphWorkspaceStatusResponse.from_domain(status_projection)
+    except UnauthorizedError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to perform this action",
+        )
+    except KnowledgeGraphNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(e),
+        )
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to transition workspace mode",
+        )
+
+
+@router.post(
     "/workspaces/{workspace_id}/knowledge-graphs",
     status_code=status.HTTP_201_CREATED,
 )

--- a/src/api/tests/integration/management/test_knowledge_graph_repository.py
+++ b/src/api/tests/integration/management/test_knowledge_graph_repository.py
@@ -110,6 +110,7 @@ class TestKnowledgeGraphRoundTrip:
 
         assert retrieved is not None
         assert retrieved.workspace_mode == WorkspaceMode.EXTRACTION_OPERATIONS
+        assert retrieved.active_extraction_operations_session_id is not None
 
 
 class TestKnowledgeGraphUpdate:

--- a/src/api/tests/unit/management/application/test_knowledge_graph_service.py
+++ b/src/api/tests/unit/management/application/test_knowledge_graph_service.py
@@ -526,6 +526,103 @@ class TestKnowledgeGraphServiceWorkspaceStatus:
         assert result.transition_eligible is False
 
 
+class TestKnowledgeGraphServiceWorkspaceCommands:
+    """Tests for validate_workspace and transition_workspace_to_extraction."""
+
+    @pytest.mark.asyncio
+    async def test_validate_workspace_requires_edit_permission(
+        self, service, authz, kg_repo, user_id
+    ):
+        kg = _make_kg()
+        kg_repo.seed(kg)
+        await _grant_kg_view(authz, kg.id.value, user_id)
+
+        with pytest.raises(UnauthorizedError):
+            await service.validate_workspace(user_id=user_id, kg_id=kg.id.value)
+
+    @pytest.mark.asyncio
+    async def test_validate_workspace_returns_projection_when_authorized(
+        self, service, authz, kg_repo, user_id
+    ):
+        kg = _make_kg()
+        kg_repo.seed(kg)
+        await _grant_kg_edit(authz, kg.id.value, user_id)
+
+        result = await service.validate_workspace(user_id=user_id, kg_id=kg.id.value)
+
+        assert result.knowledge_graph_id == kg.id.value
+        assert result.workspace_mode == WorkspaceMode.SCHEMA_BOOTSTRAP
+
+    @pytest.mark.asyncio
+    async def test_transition_workspace_requires_edit_permission(
+        self, service, authz, kg_repo, user_id
+    ):
+        kg = _make_kg()
+        kg.set_ontology(
+            OntologyConfig(
+                node_types=(NodeTypeDefinition(label="Repository"),),
+                edge_types=(
+                    EdgeTypeDefinition(
+                        label="CONTAINS",
+                        source_labels=("Repository",),
+                        target_labels=("Repository",),
+                    ),
+                ),
+            )
+        )
+        kg_repo.seed(kg)
+        await _grant_kg_view(authz, kg.id.value, user_id)
+
+        with pytest.raises(UnauthorizedError):
+            await service.transition_workspace_to_extraction(
+                user_id=user_id,
+                kg_id=kg.id.value,
+            )
+
+    @pytest.mark.asyncio
+    async def test_transition_workspace_changes_mode_and_creates_session_pointer(
+        self, service, authz, kg_repo, user_id
+    ):
+        kg = _make_kg()
+        kg.set_ontology(
+            OntologyConfig(
+                node_types=(NodeTypeDefinition(label="Repository"),),
+                edge_types=(
+                    EdgeTypeDefinition(
+                        label="CONTAINS",
+                        source_labels=("Repository",),
+                        target_labels=("Repository",),
+                    ),
+                ),
+            )
+        )
+        kg_repo.seed(kg)
+        await _grant_kg_edit(authz, kg.id.value, user_id)
+
+        result = await service.transition_workspace_to_extraction(
+            user_id=user_id,
+            kg_id=kg.id.value,
+        )
+
+        assert result.workspace_mode == WorkspaceMode.EXTRACTION_OPERATIONS
+        assert result.transition_eligible is False
+        assert result.session_pointers.active_extraction_operations_session_id is not None
+
+    @pytest.mark.asyncio
+    async def test_transition_workspace_rejects_when_not_ready(
+        self, service, authz, kg_repo, user_id
+    ):
+        kg = _make_kg()
+        kg_repo.seed(kg)
+        await _grant_kg_edit(authz, kg.id.value, user_id)
+
+        with pytest.raises(ValueError, match="not ready for transition"):
+            await service.transition_workspace_to_extraction(
+                user_id=user_id,
+                kg_id=kg.id.value,
+            )
+
+
 # ---- list_for_workspace ----
 
 

--- a/src/api/tests/unit/management/presentation/test_knowledge_graphs_routes.py
+++ b/src/api/tests/unit/management/presentation/test_knowledge_graphs_routes.py
@@ -360,6 +360,102 @@ class TestGetKnowledgeGraphWorkspaceStatusRoute:
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
+class TestWorkspaceCommandsRoutes:
+    """Tests for workspace validate/transition command endpoints."""
+
+    def _status_projection(self, kg_id: str) -> KnowledgeGraphWorkspaceStatus:
+        return KnowledgeGraphWorkspaceStatus(
+            knowledge_graph_id=kg_id,
+            workspace_mode=WorkspaceMode.SCHEMA_BOOTSTRAP,
+            readiness=WorkspaceReadinessStatus(
+                has_minimum_entity_types=True,
+                has_minimum_relationship_types=True,
+                prepopulated_types_ready=True,
+            ),
+            transition_eligible=True,
+            session_pointers=WorkspaceSessionPointers(),
+        )
+
+    def test_validate_workspace_returns_200(
+        self,
+        test_client: TestClient,
+        mock_kg_service: AsyncMock,
+        sample_knowledge_graph: KnowledgeGraph,
+    ) -> None:
+        mock_kg_service.validate_workspace.return_value = self._status_projection(
+            sample_knowledge_graph.id.value
+        )
+
+        response = test_client.post(
+            f"/management/knowledge-graphs/{sample_knowledge_graph.id.value}/workspace/validate"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_validate_workspace_returns_403_when_unauthorized(
+        self,
+        test_client: TestClient,
+        mock_kg_service: AsyncMock,
+        sample_knowledge_graph: KnowledgeGraph,
+    ) -> None:
+        mock_kg_service.validate_workspace.side_effect = UnauthorizedError("forbidden")
+
+        response = test_client.post(
+            f"/management/knowledge-graphs/{sample_knowledge_graph.id.value}/workspace/validate"
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_transition_workspace_returns_200(
+        self,
+        test_client: TestClient,
+        mock_kg_service: AsyncMock,
+        sample_knowledge_graph: KnowledgeGraph,
+    ) -> None:
+        transitioned = KnowledgeGraphWorkspaceStatus(
+            knowledge_graph_id=sample_knowledge_graph.id.value,
+            workspace_mode=WorkspaceMode.EXTRACTION_OPERATIONS,
+            readiness=WorkspaceReadinessStatus(
+                has_minimum_entity_types=True,
+                has_minimum_relationship_types=True,
+                prepopulated_types_ready=True,
+            ),
+            transition_eligible=False,
+            session_pointers=WorkspaceSessionPointers(
+                active_extraction_operations_session_id="01JPQRST1234567890ABCDEFSE"
+            ),
+        )
+        mock_kg_service.transition_workspace_to_extraction.return_value = transitioned
+
+        response = test_client.post(
+            f"/management/knowledge-graphs/{sample_knowledge_graph.id.value}/workspace/transition-to-extraction"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        payload = response.json()
+        assert payload["workspace_mode"] == WorkspaceMode.EXTRACTION_OPERATIONS.value
+        assert (
+            payload["session_pointers"]["active_extraction_operations_session_id"]
+            == "01JPQRST1234567890ABCDEFSE"
+        )
+
+    def test_transition_workspace_returns_409_when_not_ready(
+        self,
+        test_client: TestClient,
+        mock_kg_service: AsyncMock,
+        sample_knowledge_graph: KnowledgeGraph,
+    ) -> None:
+        mock_kg_service.transition_workspace_to_extraction.side_effect = ValueError(
+            "not ready"
+        )
+
+        response = test_client.post(
+            f"/management/knowledge-graphs/{sample_knowledge_graph.id.value}/workspace/transition-to-extraction"
+        )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+
+
 class TestCreateKnowledgeGraphRoute:
     """Tests for POST /management/workspaces/{workspace_id}/knowledge-graphs endpoint."""
 

--- a/src/api/tests/unit/management/test_knowledge_graph.py
+++ b/src/api/tests/unit/management/test_knowledge_graph.py
@@ -240,9 +240,12 @@ class TestKnowledgeGraphWorkspaceMode:
         """Transition should move mode to extraction_operations."""
         kg = self._create_kg()
 
-        kg.transition_to_extraction_operations()
+        session_id = kg.transition_to_extraction_operations()
 
         assert kg.workspace_mode == WorkspaceMode.EXTRACTION_OPERATIONS
+        assert kg.active_extraction_operations_session_id == session_id
+        assert isinstance(session_id, str)
+        assert len(session_id) == 26
 
     def test_transition_is_irreversible(self):
         """Transitioning after extraction_operations should fail."""


### PR DESCRIPTION
## Summary
- add command endpoints for workspace bootstrap validation and transition to extraction operations
- enforce knowledge-graph `edit` authorization on both commands and return explicit conflict when transition is blocked
- persist workspace session pointer columns and stamp an extraction-mode session id during transition

## Testing
- [x] `uv run pytest tests/unit/management/test_knowledge_graph.py tests/unit/management/application/test_knowledge_graph_service.py tests/unit/management/presentation/test_knowledge_graphs_routes.py tests/unit/management/test_ontology_value_objects.py -q`

## Risks
- session creation is currently represented by persisted session pointers; full extraction session runtime service wiring remains in subsequent extraction issues

Closes #646

Made with [Cursor](https://cursor.com)