### PR TITLE
feat(management): persist mutation log run metadata (#648)

### DIFF
--- a/src/api/infrastructure/migrations/versions/f6c7d8e9f0a1_add_mutation_log_run_metadata_to_sync_runs.py
+++ b/src/api/infrastructure/migrations/versions/f6c7d8e9f0a1_add_mutation_log_run_metadata_to_sync_runs.py
@@ -1,0 +1,35 @@
+"""add mutation_log_run metadata column to data_source_sync_runs
+
+Stores run-level mutation log metadata used by extraction/graph lifecycle
+tracking (session, actor, timestamps, token/cost totals, operation counts).
+
+Revision ID: f6c7d8e9f0a1
+Revises: f5b6c7d8e9f0
+Create Date: 2026-05-14 14:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f6c7d8e9f0a1"
+down_revision: Union[str, Sequence[str], None] = "f5b6c7d8e9f0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add nullable JSONB mutation log run metadata column."""
+    op.add_column(
+        "data_source_sync_runs",
+        sa.Column("mutation_log_run", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop mutation log run metadata column."""
+    op.drop_column("data_source_sync_runs", "mutation_log_run")

--- a/src/api/management/domain/entities/__init__.py
+++ b/src/api/management/domain/entities/__init__.py
@@ -4,6 +4,9 @@ Entities are domain objects with identity but that are not aggregate roots.
 They don't emit domain events independently.
 """
 
-from management.domain.entities.data_source_sync_run import DataSourceSyncRun
+from management.domain.entities.data_source_sync_run import (
+    DataSourceSyncRun,
+    MutationLogRunMetadata,
+)
 
-__all__ = ["DataSourceSyncRun"]
+__all__ = ["DataSourceSyncRun", "MutationLogRunMetadata"]

--- a/src/api/management/domain/entities/data_source_sync_run.py
+++ b/src/api/management/domain/entities/data_source_sync_run.py
@@ -4,12 +4,71 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Any
 
 # Valid sync run status values representing the lifecycle state machine.
 TERMINAL_STATUSES = frozenset({"completed", "failed"})
 VALID_STATUSES = frozenset(
     {"pending", "ingesting", "ai_extracting", "applying", "completed", "failed"}
 )
+
+
+@dataclass
+class MutationLogRunMetadata:
+    """Run-level metadata captured for a produced/applied mutation log."""
+
+    mutation_log_id: str
+    knowledge_graph_id: str
+    session_id: str | None
+    actor_id: str | None
+    started_at: datetime
+    completed_at: datetime | None = None
+    token_usage_total: int | None = None
+    cost_total_usd: float | None = None
+    operation_counts: dict[str, int] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mutation_log_id": self.mutation_log_id,
+            "knowledge_graph_id": self.knowledge_graph_id,
+            "session_id": self.session_id,
+            "actor_id": self.actor_id,
+            "started_at": self.started_at.isoformat(),
+            "completed_at": (
+                self.completed_at.isoformat() if self.completed_at is not None else None
+            ),
+            "token_usage_total": self.token_usage_total,
+            "cost_total_usd": self.cost_total_usd,
+            "operation_counts": self.operation_counts,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "MutationLogRunMetadata":
+        return cls(
+            mutation_log_id=str(raw["mutation_log_id"]),
+            knowledge_graph_id=str(raw["knowledge_graph_id"]),
+            session_id=raw.get("session_id"),
+            actor_id=raw.get("actor_id"),
+            started_at=datetime.fromisoformat(str(raw["started_at"])),
+            completed_at=(
+                datetime.fromisoformat(str(raw["completed_at"]))
+                if raw.get("completed_at")
+                else None
+            ),
+            token_usage_total=(
+                int(raw["token_usage_total"])
+                if raw.get("token_usage_total") is not None
+                else None
+            ),
+            cost_total_usd=(
+                float(raw["cost_total_usd"])
+                if raw.get("cost_total_usd") is not None
+                else None
+            ),
+            operation_counts={
+                str(k): int(v) for k, v in (raw.get("operation_counts") or {}).items()
+            },
+        )
 
 
 @dataclass
@@ -41,6 +100,7 @@ class DataSourceSyncRun:
     error: str | None
     created_at: datetime
     logs: list[str] = field(default_factory=list)
+    mutation_log_run: MutationLogRunMetadata | None = None
 
     def is_terminal(self) -> bool:
         """Return True if the sync run is in a terminal state.

--- a/src/api/management/infrastructure/models/data_source_sync_run.py
+++ b/src/api/management/infrastructure/models/data_source_sync_run.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
     String,
     Text,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from infrastructure.database.models import Base, _utc_now
@@ -68,6 +69,9 @@ class DataSourceSyncRunModel(Base):
         nullable=False,
         default=list,
         server_default="{}",
+    )
+    mutation_log_run: Mapped[dict | None] = mapped_column(
+        JSONB, nullable=True, default=None
     )
 
     __table_args__ = (

--- a/src/api/management/infrastructure/repositories/data_source_sync_run_repository.py
+++ b/src/api/management/infrastructure/repositories/data_source_sync_run_repository.py
@@ -11,7 +11,7 @@ from sqlalchemy import select
 from sqlalchemy import desc
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from management.domain.entities import DataSourceSyncRun
+from management.domain.entities import DataSourceSyncRun, MutationLogRunMetadata
 from management.infrastructure.models import DataSourceSyncRunModel
 from management.infrastructure.observability import (
     DefaultSyncRunRepositoryProbe,
@@ -51,6 +51,11 @@ class DataSourceSyncRunRepository(IDataSourceSyncRunRepository):
             model.completed_at = sync_run.completed_at
             model.error = sync_run.error
             model.logs = sync_run.logs
+            model.mutation_log_run = (
+                sync_run.mutation_log_run.to_dict()
+                if sync_run.mutation_log_run is not None
+                else None
+            )
         else:
             model = DataSourceSyncRunModel(
                 id=sync_run.id,
@@ -61,6 +66,11 @@ class DataSourceSyncRunRepository(IDataSourceSyncRunRepository):
                 error=sync_run.error,
                 created_at=sync_run.created_at,
                 logs=sync_run.logs,
+                mutation_log_run=(
+                    sync_run.mutation_log_run.to_dict()
+                    if sync_run.mutation_log_run is not None
+                    else None
+                ),
             )
             self._session.add(model)
 
@@ -122,4 +132,9 @@ class DataSourceSyncRunRepository(IDataSourceSyncRunRepository):
             error=model.error,
             created_at=model.created_at,
             logs=model.logs if model.logs is not None else [],
+            mutation_log_run=(
+                MutationLogRunMetadata.from_dict(model.mutation_log_run)
+                if model.mutation_log_run is not None
+                else None
+            ),
         )

--- a/src/api/management/infrastructure/sync_lifecycle_handler.py
+++ b/src/api/management/infrastructure/sync_lifecycle_handler.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from management.domain.entities import MutationLogRunMetadata
 from management.domain.value_objects import DataSourceId
 
 if TYPE_CHECKING:
@@ -122,6 +123,21 @@ class SyncLifecycleHandler:
             sync_run.status = "completed"
             sync_run.completed_at = now
             sync_run.logs.append(f"[{now.isoformat()}] Sync completed")
+            if sync_run.mutation_log_run is not None:
+                sync_run.mutation_log_run.completed_at = now
+                if payload.get("token_usage_total") is not None:
+                    sync_run.mutation_log_run.token_usage_total = int(
+                        payload["token_usage_total"]
+                    )
+                if payload.get("cost_total_usd") is not None:
+                    sync_run.mutation_log_run.cost_total_usd = float(
+                        payload["cost_total_usd"]
+                    )
+                if payload.get("operation_counts") is not None:
+                    sync_run.mutation_log_run.operation_counts = {
+                        str(k): int(v)
+                        for k, v in dict(payload["operation_counts"]).items()
+                    }
             await self._update_data_source_last_sync_at(
                 data_source_id=sync_run.data_source_id,
                 now=now,
@@ -135,6 +151,36 @@ class SyncLifecycleHandler:
             sync_run.logs.append(
                 f"[{now.isoformat()}] {event_type}: status → {new_status}"
             )
+            if event_type == "MutationLogProduced":
+                sync_run.mutation_log_run = MutationLogRunMetadata(
+                    mutation_log_id=str(payload["mutation_log_id"]),
+                    knowledge_graph_id=str(payload["knowledge_graph_id"]),
+                    session_id=(
+                        str(payload["session_id"])
+                        if payload.get("session_id") is not None
+                        else None
+                    ),
+                    actor_id=(
+                        str(payload["actor_id"])
+                        if payload.get("actor_id") is not None
+                        else None
+                    ),
+                    started_at=now,
+                    token_usage_total=(
+                        int(payload["token_usage_total"])
+                        if payload.get("token_usage_total") is not None
+                        else None
+                    ),
+                    cost_total_usd=(
+                        float(payload["cost_total_usd"])
+                        if payload.get("cost_total_usd") is not None
+                        else None
+                    ),
+                    operation_counts={
+                        str(k): int(v)
+                        for k, v in dict(payload.get("operation_counts") or {}).items()
+                    },
+                )
 
         await self._sync_run_repo.save(sync_run)
         await self._session.commit()

--- a/src/api/tests/integration/management/test_data_source_sync_run_repository.py
+++ b/src/api/tests/integration/management/test_data_source_sync_run_repository.py
@@ -10,7 +10,7 @@ from datetime import datetime, UTC
 from sqlalchemy import text
 
 from management.domain.aggregates import DataSource, KnowledgeGraph
-from management.domain.entities import DataSourceSyncRun
+from management.domain.entities import DataSourceSyncRun, MutationLogRunMetadata
 from management.infrastructure.repositories.data_source_sync_run_repository import (
     DataSourceSyncRunRepository,
 )
@@ -84,6 +84,70 @@ class TestSyncRunRoundTrip:
         assert retrieved.completed_at is None
         assert retrieved.error is None
         assert retrieved.created_at is not None
+
+    @pytest.mark.asyncio
+    async def test_saves_and_retrieves_mutation_log_run_metadata(
+        self,
+        data_source_sync_run_repository: DataSourceSyncRunRepository,
+        data_source_repository: DataSourceRepository,
+        knowledge_graph_repository: KnowledgeGraphRepository,
+        async_session,
+        test_tenant: str,
+        test_workspace: str,
+        clean_management_data,
+    ):
+        """Should persist mutation log run metadata JSONB for sync runs."""
+        kg = KnowledgeGraph.create(
+            tenant_id=test_tenant,
+            workspace_id=test_workspace,
+            name="Test KG",
+            description="For sync run tests",
+        )
+        async with async_session.begin():
+            await knowledge_graph_repository.save(kg)
+
+        ds = DataSource.create(
+            knowledge_graph_id=kg.id.value,
+            tenant_id=test_tenant,
+            name="My GitHub Source",
+            adapter_type=DataSourceAdapterType.GITHUB,
+            connection_config={"repo": "org/repo", "branch": "main"},
+        )
+        async with async_session.begin():
+            await data_source_repository.save(ds)
+
+        now = datetime.now(UTC)
+        sync_run = DataSourceSyncRun(
+            id=str(ULID()),
+            data_source_id=ds.id.value,
+            status="applying",
+            started_at=now,
+            completed_at=None,
+            error=None,
+            created_at=now,
+            mutation_log_run=MutationLogRunMetadata(
+                mutation_log_id="log-001",
+                knowledge_graph_id=kg.id.value,
+                session_id="sess-001",
+                actor_id="user-001",
+                started_at=now,
+                token_usage_total=1234,
+                cost_total_usd=1.5,
+                operation_counts={"create_node": 2},
+            ),
+        )
+
+        async with async_session.begin():
+            await data_source_sync_run_repository.save(sync_run)
+
+        retrieved = await data_source_sync_run_repository.get_by_id(sync_run.id)
+
+        assert retrieved is not None
+        assert retrieved.mutation_log_run is not None
+        assert retrieved.mutation_log_run.mutation_log_id == "log-001"
+        assert retrieved.mutation_log_run.session_id == "sess-001"
+        assert retrieved.mutation_log_run.token_usage_total == 1234
+        assert retrieved.mutation_log_run.operation_counts["create_node"] == 2
 
     @pytest.mark.asyncio
     async def test_saves_completed_sync_run(

--- a/src/api/tests/unit/management/infrastructure/test_sync_lifecycle_handler.py
+++ b/src/api/tests/unit/management/infrastructure/test_sync_lifecycle_handler.py
@@ -190,6 +190,39 @@ class TestMutationLogProducedTransition:
         saved_run: DataSourceSyncRun = mock_sync_run_repo.save.call_args[0][0]
         assert saved_run.status == "applying"
 
+    async def test_mutation_log_produced_stores_run_metadata(
+        self,
+        handler: SyncLifecycleHandler,
+        mock_sync_run_repo: AsyncMock,
+    ):
+        """MutationLogProduced should persist run-level mutation metadata."""
+        run = _make_sync_run(status="ai_extracting")
+        mock_sync_run_repo.get_by_id.return_value = run
+
+        await handler.handle(
+            "MutationLogProduced",
+            _payload(
+                sync_run_id=run.id,
+                knowledge_graph_id="kg-001",
+                mutation_log_id="log-001",
+                session_id="sess-001",
+                actor_id="user-001",
+                token_usage_total=1234,
+                cost_total_usd=1.25,
+                operation_counts={"create_node": 2, "update_edge": 1},
+            ),
+        )
+
+        saved_run: DataSourceSyncRun = mock_sync_run_repo.save.call_args[0][0]
+        assert saved_run.mutation_log_run is not None
+        assert saved_run.mutation_log_run.mutation_log_id == "log-001"
+        assert saved_run.mutation_log_run.knowledge_graph_id == "kg-001"
+        assert saved_run.mutation_log_run.session_id == "sess-001"
+        assert saved_run.mutation_log_run.actor_id == "user-001"
+        assert saved_run.mutation_log_run.token_usage_total == 1234
+        assert saved_run.mutation_log_run.cost_total_usd == 1.25
+        assert saved_run.mutation_log_run.operation_counts["create_node"] == 2
+
 
 @pytest.mark.asyncio
 class TestExtractionFailedTransition:
@@ -259,6 +292,62 @@ class TestMutationsAppliedTransition:
         saved_run: DataSourceSyncRun = mock_sync_run_repo.save.call_args[0][0]
         assert saved_run.status == "completed"
         assert saved_run.completed_at is not None
+
+    async def test_mutations_applied_finalizes_mutation_log_metadata(
+        self,
+        handler: SyncLifecycleHandler,
+        mock_sync_run_repo: AsyncMock,
+        mock_ds_repo: AsyncMock,
+    ):
+        """MutationsApplied should finalize mutation run metrics and completed_at."""
+        from management.domain.aggregates import DataSource
+        from management.domain.entities import MutationLogRunMetadata
+        from management.domain.value_objects import DataSourceId, Schedule, ScheduleType
+        from shared_kernel.datasource_types import DataSourceAdapterType
+
+        run = _make_sync_run(status="applying")
+        run.mutation_log_run = MutationLogRunMetadata(
+            mutation_log_id="log-001",
+            knowledge_graph_id="kg-001",
+            session_id="sess-001",
+            actor_id="user-001",
+            started_at=datetime.now(UTC),
+        )
+        mock_sync_run_repo.get_by_id.return_value = run
+
+        now = datetime.now(UTC)
+        ds = DataSource(
+            id=DataSourceId(value="ds-001"),
+            knowledge_graph_id="kg-001",
+            tenant_id="tenant-001",
+            name="My DS",
+            adapter_type=DataSourceAdapterType.GITHUB,
+            connection_config={},
+            credentials_path=None,
+            schedule=Schedule(schedule_type=ScheduleType.MANUAL),
+            last_sync_at=None,
+            created_at=now,
+            updated_at=now,
+        )
+        mock_ds_repo.get_by_id.return_value = ds
+
+        await handler.handle(
+            "MutationsApplied",
+            _payload(
+                sync_run_id=run.id,
+                knowledge_graph_id="kg-001",
+                token_usage_total=4321,
+                cost_total_usd=2.5,
+                operation_counts={"create_node": 9},
+            ),
+        )
+
+        saved_run: DataSourceSyncRun = mock_sync_run_repo.save.call_args[0][0]
+        assert saved_run.mutation_log_run is not None
+        assert saved_run.mutation_log_run.completed_at is not None
+        assert saved_run.mutation_log_run.token_usage_total == 4321
+        assert saved_run.mutation_log_run.cost_total_usd == 2.5
+        assert saved_run.mutation_log_run.operation_counts == {"create_node": 9}
 
     async def test_mutations_applied_updates_data_source_last_sync_at(
         self,


### PR DESCRIPTION
## Summary
- add durable `mutation_log_run` metadata storage on sync runs (JSONB) with migration
- persist run scope/identity, timestamps, token+cost totals, and operation count summaries through lifecycle transitions
- add unit + integration coverage for lifecycle persistence and repository roundtrip

## Testing
- [x] `uv run pytest tests/unit/management/infrastructure/test_sync_lifecycle_handler.py -q`

## Risks
- metadata is currently persisted from lifecycle event payloads; upstream extraction/graph producers will populate richer values incrementally

Closes #648

Made with [Cursor](https://cursor.com)