### PR TITLE
feat(graph): wire mutation apply metrics into events (#647)

### DIFF
--- a/src/api/graph/infrastructure/event_handler.py
+++ b/src/api/graph/infrastructure/event_handler.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-from graph.ports.mutation_log import IMutationLogApplier
+from graph.ports.mutation_log import IMutationLogApplier, MutationLogApplyResult
 
 if TYPE_CHECKING:
     from shared_kernel.outbox.ports import IOutboxRepository
@@ -77,17 +77,20 @@ class GraphMutationEventHandler:
         now = datetime.now(UTC)
 
         try:
-            success = await self._mutation_log_applier.apply_mutation_log(
+            apply_result = await self._mutation_log_applier.apply_mutation_log(
                 mutation_log_id
             )
 
-            if success:
+            if apply_result.success:
                 await self._outbox.append(
                     event_type="MutationsApplied",
                     payload={
                         "sync_run_id": sync_run_id,
                         "data_source_id": data_source_id,
                         "knowledge_graph_id": knowledge_graph_id,
+                        "operation_counts": apply_result.operation_counts,
+                        "token_usage_total": apply_result.token_usage_total,
+                        "cost_total_usd": apply_result.cost_total_usd,
                         "occurred_at": now.isoformat(),
                     },
                     occurred_at=now,
@@ -101,6 +104,9 @@ class GraphMutationEventHandler:
                         "sync_run_id": sync_run_id,
                         "data_source_id": data_source_id,
                         "error": "Mutation application returned failure",
+                        "operation_counts": apply_result.operation_counts,
+                        "token_usage_total": apply_result.token_usage_total,
+                        "cost_total_usd": apply_result.cost_total_usd,
                         "occurred_at": now.isoformat(),
                     },
                     occurred_at=now,

--- a/src/api/graph/ports/mutation_log.py
+++ b/src/api/graph/ports/mutation_log.py
@@ -2,7 +2,18 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import Protocol
+
+
+@dataclass(frozen=True)
+class MutationLogApplyResult:
+    """Result metadata produced when applying a mutation log."""
+
+    success: bool
+    operation_counts: dict[str, int] = field(default_factory=dict)
+    token_usage_total: int | None = None
+    cost_total_usd: float | None = None
 
 
 class IMutationLogApplier(Protocol):
@@ -15,7 +26,7 @@ class IMutationLogApplier(Protocol):
     infrastructure (AGE connection pools, bulk loading strategies, etc.).
     """
 
-    async def apply_mutation_log(self, mutation_log_id: str) -> bool:
+    async def apply_mutation_log(self, mutation_log_id: str) -> MutationLogApplyResult:
         """Apply all mutations from a MutationLog to the graph database.
 
         Args:
@@ -24,7 +35,7 @@ class IMutationLogApplier(Protocol):
                 log content from storage (filesystem, object store, etc.).
 
         Returns:
-            True if all mutations were applied successfully.
+            MutationLogApplyResult with success flag and finalized run metrics.
 
         Raises:
             Exception: Any exception signals a failure; callers should

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -48,6 +48,7 @@ from shared_kernel.outbox.observability import (
 )
 from infrastructure.mcp_dependencies import dispose_mcp_auth_engine
 from query.presentation.mcp import mcp_http_app_proxy, query_mcp_app
+from graph.ports.mutation_log import MutationLogApplyResult
 
 # Default work directory for JobPackage ZIP archives
 _JOB_PACKAGE_WORK_DIR = Path("/tmp/kartograph/job_packages")  # noqa: S108
@@ -214,7 +215,7 @@ class _StubMutationLogApplier:
     result in MutationApplicationFailed being emitted.
     """
 
-    async def apply_mutation_log(self, mutation_log_id: str) -> bool:
+    async def apply_mutation_log(self, mutation_log_id: str) -> MutationLogApplyResult:
         raise NotImplementedError(
             "Graph mutation application via outbox is not yet fully implemented. "
             "Register a real IMutationLogApplier to enable graph writes from the outbox."

--- a/src/api/tests/unit/graph/infrastructure/test_graph_mutation_event_handler.py
+++ b/src/api/tests/unit/graph/infrastructure/test_graph_mutation_event_handler.py
@@ -18,6 +18,7 @@ from uuid import UUID
 import pytest
 
 from graph.infrastructure.event_handler import GraphMutationEventHandler
+from graph.ports.mutation_log import MutationLogApplyResult
 
 
 class _FakeOutboxRepository:
@@ -59,11 +60,16 @@ class _FakeMutationLogApplier:
         self._error = error
         self.calls: list[str] = []
 
-    async def apply_mutation_log(self, mutation_log_id: str) -> bool:
+    async def apply_mutation_log(self, mutation_log_id: str) -> MutationLogApplyResult:
         self.calls.append(mutation_log_id)
         if self._fail:
             raise RuntimeError(self._error)
-        return True
+        return MutationLogApplyResult(
+            success=True,
+            operation_counts={"create_node": 2, "update_edge": 1},
+            token_usage_total=321,
+            cost_total_usd=0.42,
+        )
 
 
 @pytest.fixture
@@ -150,6 +156,12 @@ class TestGraphMutationEventHandlerSuccess:
         assert event["payload"]["sync_run_id"] == "run-001"
         assert event["payload"]["data_source_id"] == "ds-001"
         assert event["payload"]["knowledge_graph_id"] == "kg-001"
+        assert event["payload"]["operation_counts"] == {
+            "create_node": 2,
+            "update_edge": 1,
+        }
+        assert event["payload"]["token_usage_total"] == 321
+        assert event["payload"]["cost_total_usd"] == 0.42
 
     async def test_mutations_applied_aggregate_type(
         self,


### PR DESCRIPTION
## Summary
- update mutation-log apply port to return run-level metric metadata
- emit operation counts plus token/cost totals in `MutationsApplied` payloads from graph mutation event handling
- align unit coverage for graph mutation event handler payload semantics

## Testing
- [x] `uv run pytest tests/unit/graph/infrastructure/test_graph_mutation_event_handler.py tests/unit/management/infrastructure/test_sync_lifecycle_handler.py -q`

## Risks
- the runtime outbox mutation applier is still a stub in main; this change wires payload contracts and tests for when the real applier is registered

Closes #647

Made with [Cursor](https://cursor.com)