### PR TITLE
feat(extraction): implement scoped agent session service (#650)

### DIFF
--- a/src/api/extraction/application/__init__.py
+++ b/src/api/extraction/application/__init__.py
@@ -4,3 +4,7 @@ Application services orchestrate extraction workflows using domain logic
 and port contracts. They do not directly depend on infrastructure.
 """
 
+from extraction.application.agent_session_service import ExtractionAgentSessionService
+
+__all__ = ["ExtractionAgentSessionService"]
+

--- a/src/api/extraction/application/agent_session_service.py
+++ b/src/api/extraction/application/agent_session_service.py
@@ -1,0 +1,82 @@
+"""Application service for extraction agent session lifecycle."""
+
+from __future__ import annotations
+
+from ulid import ULID
+
+from extraction.domain.entities.agent_session import ExtractionAgentSession
+from extraction.domain.value_objects import ExtractionSessionMode
+from extraction.ports.repositories import IExtractionAgentSessionRepository
+
+
+class ExtractionAgentSessionService:
+    """Orchestrates session create/get/list/archive behaviors by scope."""
+
+    def __init__(self, repository: IExtractionAgentSessionRepository) -> None:
+        self._repository = repository
+
+    async def get_or_create_active_session(
+        self,
+        user_id: str,
+        knowledge_graph_id: str,
+        mode: ExtractionSessionMode,
+    ) -> ExtractionAgentSession:
+        existing = await self._repository.find_active_by_scope(
+            user_id=user_id,
+            knowledge_graph_id=knowledge_graph_id,
+            mode=mode,
+        )
+        if existing is not None:
+            return existing
+
+        session = ExtractionAgentSession(
+            id=str(ULID()),
+            user_id=user_id,
+            knowledge_graph_id=knowledge_graph_id,
+            mode=mode,
+        )
+        await self._repository.save(session)
+        return session
+
+    async def clear_chat(
+        self,
+        user_id: str,
+        knowledge_graph_id: str,
+        mode: ExtractionSessionMode,
+    ) -> ExtractionAgentSession:
+        active = await self._repository.find_active_by_scope(
+            user_id=user_id,
+            knowledge_graph_id=knowledge_graph_id,
+            mode=mode,
+        )
+        if active is not None:
+            active.archive()
+            await self._repository.save(active)
+
+        return await self.get_or_create_active_session(
+            user_id=user_id,
+            knowledge_graph_id=knowledge_graph_id,
+            mode=mode,
+        )
+
+    async def list_sessions(
+        self,
+        user_id: str,
+        knowledge_graph_id: str,
+        mode: ExtractionSessionMode | None = None,
+    ) -> list[ExtractionAgentSession]:
+        return await self._repository.list_by_scope(
+            user_id=user_id,
+            knowledge_graph_id=knowledge_graph_id,
+            mode=mode,
+        )
+
+    async def archive_session(self, session_id: str) -> ExtractionAgentSession | None:
+        session = await self._repository.get_by_id(session_id)
+        if session is None:
+            return None
+        if session.is_active:
+            session.archive()
+            await self._repository.save(session)
+        return session
+

--- a/src/api/extraction/domain/__init__.py
+++ b/src/api/extraction/domain/__init__.py
@@ -1,1 +1,6 @@
 """Extraction domain layer."""
+
+from extraction.domain.entities import ExtractionAgentSession
+from extraction.domain.value_objects import ExtractionSessionMode
+
+__all__ = ["ExtractionAgentSession", "ExtractionSessionMode"]

--- a/src/api/extraction/domain/entities/__init__.py
+++ b/src/api/extraction/domain/entities/__init__.py
@@ -1,0 +1,6 @@
+"""Extraction domain entities."""
+
+from extraction.domain.entities.agent_session import ExtractionAgentSession
+
+__all__ = ["ExtractionAgentSession"]
+

--- a/src/api/extraction/domain/entities/agent_session.py
+++ b/src/api/extraction/domain/entities/agent_session.py
@@ -1,0 +1,34 @@
+"""Extraction agent session entity."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from extraction.domain.value_objects import ExtractionSessionMode
+
+
+@dataclass
+class ExtractionAgentSession:
+    """Long-running conversational session scoped to user/KG/mode."""
+
+    id: str
+    user_id: str
+    knowledge_graph_id: str
+    mode: ExtractionSessionMode
+    message_history: list[dict[str, Any]] = field(default_factory=list)
+    runtime_context: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    archived_at: datetime | None = None
+
+    @property
+    def is_active(self) -> bool:
+        return self.archived_at is None
+
+    def archive(self, *, when: datetime | None = None) -> None:
+        now = when or datetime.now(UTC)
+        self.archived_at = now
+        self.updated_at = now
+

--- a/src/api/extraction/domain/value_objects.py
+++ b/src/api/extraction/domain/value_objects.py
@@ -1,0 +1,11 @@
+"""Value objects for Extraction session lifecycle."""
+
+from enum import StrEnum
+
+
+class ExtractionSessionMode(StrEnum):
+    """Workspace mode for extraction agent sessions."""
+
+    SCHEMA_BOOTSTRAP = "schema_bootstrap"
+    EXTRACTION_OPERATIONS = "extraction_operations"
+

--- a/src/api/extraction/ports/__init__.py
+++ b/src/api/extraction/ports/__init__.py
@@ -1,6 +1,7 @@
 """Extraction port contracts."""
 
+from extraction.ports.repositories import IExtractionAgentSessionRepository
 from extraction.ports.services import IExtractionService
 
-__all__ = ["IExtractionService"]
+__all__ = ["IExtractionService", "IExtractionAgentSessionRepository"]
 

--- a/src/api/extraction/ports/repositories.py
+++ b/src/api/extraction/ports/repositories.py
@@ -1,0 +1,31 @@
+"""Repository ports for Extraction sessions."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from extraction.domain.entities.agent_session import ExtractionAgentSession
+from extraction.domain.value_objects import ExtractionSessionMode
+
+
+class IExtractionAgentSessionRepository(Protocol):
+    """Persistence contract for extraction agent sessions."""
+
+    async def save(self, session: ExtractionAgentSession) -> None: ...
+
+    async def get_by_id(self, session_id: str) -> ExtractionAgentSession | None: ...
+
+    async def find_active_by_scope(
+        self,
+        user_id: str,
+        knowledge_graph_id: str,
+        mode: ExtractionSessionMode,
+    ) -> ExtractionAgentSession | None: ...
+
+    async def list_by_scope(
+        self,
+        user_id: str,
+        knowledge_graph_id: str,
+        mode: ExtractionSessionMode | None = None,
+    ) -> list[ExtractionAgentSession]: ...
+

--- a/src/api/tests/unit/extraction/application/test_agent_session_service.py
+++ b/src/api/tests/unit/extraction/application/test_agent_session_service.py
@@ -1,0 +1,161 @@
+"""Unit tests for ExtractionAgentSessionService."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+
+import pytest
+
+from extraction.application.agent_session_service import ExtractionAgentSessionService
+from extraction.domain.entities.agent_session import ExtractionAgentSession
+from extraction.domain.value_objects import ExtractionSessionMode
+
+
+class _InMemoryAgentSessionRepository:
+    def __init__(self) -> None:
+        self._by_id: dict[str, ExtractionAgentSession] = {}
+
+    async def save(self, session: ExtractionAgentSession) -> None:
+        self._by_id[session.id] = replace(session)
+
+    async def get_by_id(self, session_id: str) -> ExtractionAgentSession | None:
+        session = self._by_id.get(session_id)
+        return replace(session) if session else None
+
+    async def find_active_by_scope(
+        self,
+        user_id: str,
+        knowledge_graph_id: str,
+        mode: ExtractionSessionMode,
+    ) -> ExtractionAgentSession | None:
+        for session in self._by_id.values():
+            if (
+                session.user_id == user_id
+                and session.knowledge_graph_id == knowledge_graph_id
+                and session.mode == mode
+                and session.archived_at is None
+            ):
+                return replace(session)
+        return None
+
+    async def list_by_scope(
+        self,
+        user_id: str,
+        knowledge_graph_id: str,
+        mode: ExtractionSessionMode | None = None,
+    ) -> list[ExtractionAgentSession]:
+        sessions = [
+            replace(session)
+            for session in self._by_id.values()
+            if session.user_id == user_id
+            and session.knowledge_graph_id == knowledge_graph_id
+            and (mode is None or session.mode == mode)
+        ]
+        return sorted(sessions, key=lambda s: s.updated_at, reverse=True)
+
+
+@pytest.mark.asyncio
+class TestExtractionAgentSessionService:
+    async def test_reuses_active_session_for_same_scope(self):
+        repo = _InMemoryAgentSessionRepository()
+        service = ExtractionAgentSessionService(repository=repo)
+
+        first = await service.get_or_create_active_session(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode=ExtractionSessionMode.SCHEMA_BOOTSTRAP,
+        )
+        second = await service.get_or_create_active_session(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode=ExtractionSessionMode.SCHEMA_BOOTSTRAP,
+        )
+
+        assert first.id == second.id
+
+    async def test_scope_isolated_by_user(self):
+        repo = _InMemoryAgentSessionRepository()
+        service = ExtractionAgentSessionService(repository=repo)
+
+        first = await service.get_or_create_active_session(
+            user_id="alice",
+            knowledge_graph_id="kg-1",
+            mode=ExtractionSessionMode.EXTRACTION_OPERATIONS,
+        )
+        second = await service.get_or_create_active_session(
+            user_id="bob",
+            knowledge_graph_id="kg-1",
+            mode=ExtractionSessionMode.EXTRACTION_OPERATIONS,
+        )
+
+        assert first.id != second.id
+
+    async def test_scope_isolated_by_mode(self):
+        repo = _InMemoryAgentSessionRepository()
+        service = ExtractionAgentSessionService(repository=repo)
+
+        bootstrap = await service.get_or_create_active_session(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode=ExtractionSessionMode.SCHEMA_BOOTSTRAP,
+        )
+        operations = await service.get_or_create_active_session(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode=ExtractionSessionMode.EXTRACTION_OPERATIONS,
+        )
+
+        assert bootstrap.id != operations.id
+
+    async def test_clear_chat_archives_old_session_and_creates_new_one(self):
+        repo = _InMemoryAgentSessionRepository()
+        service = ExtractionAgentSessionService(repository=repo)
+
+        old_session = await service.get_or_create_active_session(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode=ExtractionSessionMode.EXTRACTION_OPERATIONS,
+        )
+        old_session.message_history = [{"role": "user", "content": "hello"}]
+        old_session.runtime_context = {"draft": "x"}
+        old_session.updated_at = datetime.now(UTC)
+        await repo.save(old_session)
+
+        new_session = await service.clear_chat(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode=ExtractionSessionMode.EXTRACTION_OPERATIONS,
+        )
+
+        archived = await repo.get_by_id(old_session.id)
+        assert archived is not None
+        assert archived.archived_at is not None
+        assert new_session.id != old_session.id
+        assert new_session.message_history == []
+        assert new_session.runtime_context == {}
+
+    async def test_list_sessions_includes_archived_history(self):
+        repo = _InMemoryAgentSessionRepository()
+        service = ExtractionAgentSessionService(repository=repo)
+
+        first = await service.get_or_create_active_session(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode=ExtractionSessionMode.EXTRACTION_OPERATIONS,
+        )
+        await service.clear_chat(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode=ExtractionSessionMode.EXTRACTION_OPERATIONS,
+        )
+
+        sessions = await service.list_sessions(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode=ExtractionSessionMode.EXTRACTION_OPERATIONS,
+        )
+
+        assert len(sessions) == 2
+        assert any(session.id == first.id and session.archived_at is not None for session in sessions)
+


### PR DESCRIPTION
## Summary
- add extraction domain session primitives (`ExtractionSessionMode`, `ExtractionAgentSession`) for scoped long-running sessions
- implement `ExtractionAgentSessionService` for get/create active session, clear-chat reset, archive, and history listing behavior
- add repository port contract and unit tests for user/KG/mode scope isolation and archival retention semantics

## Testing
- [x] `uv run pytest tests/unit/extraction/application/test_agent_session_service.py -q`
- [x] `uv run pytest tests/unit/extraction/test_architecture.py tests/unit/extraction/application/test_agent_session_service.py -q`

## Risks
- persistence adapter/HTTP API wiring is intentionally deferred to follow-on issues; this PR establishes domain + application behavior contract first

Closes #650

Made with [Cursor](https://cursor.com)