### PR TITLE
feat(extraction): implement skill resolution engine (#652)

### DIFF
--- a/src/api/extraction/application/__init__.py
+++ b/src/api/extraction/application/__init__.py
@@ -5,6 +5,9 @@ and port contracts. They do not directly depend on infrastructure.
 """
 
 from extraction.application.agent_session_service import ExtractionAgentSessionService
+from extraction.application.skill_resolution_service import (
+    ExtractionSkillResolutionService,
+)
 
-__all__ = ["ExtractionAgentSessionService"]
+__all__ = ["ExtractionAgentSessionService", "ExtractionSkillResolutionService"]
 

--- a/src/api/extraction/application/skill_resolution_service.py
+++ b/src/api/extraction/application/skill_resolution_service.py
@@ -1,0 +1,66 @@
+"""Skill resolution for extraction sessions."""
+
+from __future__ import annotations
+
+from extraction.domain.value_objects import ExtractionSessionMode
+from extraction.ports.repositories import IExtractionSkillOverrideRepository
+
+
+_GLOBAL_SKILL_TEMPLATES: dict[ExtractionSessionMode, dict[str, str]] = {
+    ExtractionSessionMode.SCHEMA_BOOTSTRAP: {
+        "schema_modeling": (
+            "Guide the user to define complete entity and relationship types "
+            "with clear labels, constraints, and required properties."
+        ),
+        "prepopulation_validation": (
+            "Prioritize prepopulated type coverage and highlight any missing "
+            "instances required before extraction-mode transition."
+        ),
+    },
+    ExtractionSessionMode.EXTRACTION_OPERATIONS: {
+        "job_setup": (
+            "Prioritize extraction job setup, file-targeting strategy, and "
+            "safe incremental mutation planning."
+        ),
+        "minor_edits": (
+            "Allow focused direct graph edits while preserving mutation-log "
+            "auditability and schema consistency."
+        ),
+        "schema_edits_secondary": (
+            "Keep schema edits available but framed as secondary to "
+            "extraction and maintenance operations."
+        ),
+    },
+}
+
+
+class ExtractionSkillResolutionService:
+    """Resolve session skills from global templates + KG overrides."""
+
+    def __init__(self, override_repository: IExtractionSkillOverrideRepository) -> None:
+        self._override_repository = override_repository
+
+    async def resolve_for_session(
+        self,
+        knowledge_graph_id: str,
+        mode: ExtractionSessionMode,
+    ) -> dict[str, str]:
+        base_templates = dict(_GLOBAL_SKILL_TEMPLATES[mode])
+        overrides = await self._override_repository.get_overrides_for_knowledge_graph(
+            knowledge_graph_id=knowledge_graph_id,
+            mode=mode,
+        )
+
+        resolved = dict(base_templates)
+
+        # Merge existing keys first, then append new override keys in sorted order
+        # to ensure deterministic ordering across runs.
+        for key in sorted(overrides.keys()):
+            if key in resolved:
+                resolved[key] = overrides[key]
+        for key in sorted(overrides.keys()):
+            if key not in resolved:
+                resolved[key] = overrides[key]
+
+        return resolved
+

--- a/src/api/extraction/ports/__init__.py
+++ b/src/api/extraction/ports/__init__.py
@@ -1,7 +1,14 @@
 """Extraction port contracts."""
 
-from extraction.ports.repositories import IExtractionAgentSessionRepository
+from extraction.ports.repositories import (
+    IExtractionAgentSessionRepository,
+    IExtractionSkillOverrideRepository,
+)
 from extraction.ports.services import IExtractionService
 
-__all__ = ["IExtractionService", "IExtractionAgentSessionRepository"]
+__all__ = [
+    "IExtractionService",
+    "IExtractionAgentSessionRepository",
+    "IExtractionSkillOverrideRepository",
+]
 

--- a/src/api/extraction/ports/repositories.py
+++ b/src/api/extraction/ports/repositories.py
@@ -29,3 +29,13 @@ class IExtractionAgentSessionRepository(Protocol):
         mode: ExtractionSessionMode | None = None,
     ) -> list[ExtractionAgentSession]: ...
 
+
+class IExtractionSkillOverrideRepository(Protocol):
+    """Read KG-specific skill override templates."""
+
+    async def get_overrides_for_knowledge_graph(
+        self,
+        knowledge_graph_id: str,
+        mode: ExtractionSessionMode,
+    ) -> dict[str, str]: ...
+

--- a/src/api/tests/unit/extraction/application/test_skill_resolution_service.py
+++ b/src/api/tests/unit/extraction/application/test_skill_resolution_service.py
@@ -1,0 +1,96 @@
+"""Unit tests for ExtractionSkillResolutionService."""
+
+from __future__ import annotations
+
+import pytest
+
+from extraction.application.skill_resolution_service import (
+    ExtractionSkillResolutionService,
+)
+from extraction.domain.value_objects import ExtractionSessionMode
+
+
+class _InMemorySkillOverrideRepository:
+    def __init__(self, overrides: dict[tuple[str, ExtractionSessionMode], dict[str, str]] | None = None) -> None:
+        self._overrides = overrides or {}
+
+    async def get_overrides_for_knowledge_graph(
+        self,
+        knowledge_graph_id: str,
+        mode: ExtractionSessionMode,
+    ) -> dict[str, str]:
+        return dict(self._overrides.get((knowledge_graph_id, mode), {}))
+
+
+@pytest.mark.asyncio
+class TestExtractionSkillResolutionService:
+    async def test_bootstrap_mode_uses_bootstrap_defaults(self):
+        service = ExtractionSkillResolutionService(
+            override_repository=_InMemorySkillOverrideRepository()
+        )
+
+        resolved = await service.resolve_for_session(
+            knowledge_graph_id="kg-1",
+            mode=ExtractionSessionMode.SCHEMA_BOOTSTRAP,
+        )
+
+        assert "schema_modeling" in resolved
+        assert "prepopulation_validation" in resolved
+
+    async def test_extraction_mode_uses_extraction_defaults(self):
+        service = ExtractionSkillResolutionService(
+            override_repository=_InMemorySkillOverrideRepository()
+        )
+
+        resolved = await service.resolve_for_session(
+            knowledge_graph_id="kg-1",
+            mode=ExtractionSessionMode.EXTRACTION_OPERATIONS,
+        )
+
+        assert "job_setup" in resolved
+        assert "minor_edits" in resolved
+
+    async def test_kg_overrides_replace_matching_template_and_append_new(self):
+        repo = _InMemorySkillOverrideRepository(
+            overrides={
+                (
+                    "kg-1",
+                    ExtractionSessionMode.EXTRACTION_OPERATIONS,
+                ): {
+                    "job_setup": "KG-specific job setup instructions",
+                    "custom_review": "Custom review flow",
+                }
+            }
+        )
+        service = ExtractionSkillResolutionService(override_repository=repo)
+
+        resolved = await service.resolve_for_session(
+            knowledge_graph_id="kg-1",
+            mode=ExtractionSessionMode.EXTRACTION_OPERATIONS,
+        )
+
+        assert resolved["job_setup"] == "KG-specific job setup instructions"
+        assert resolved["custom_review"] == "Custom review flow"
+
+    async def test_override_merge_is_deterministic(self):
+        repo = _InMemorySkillOverrideRepository(
+            overrides={
+                (
+                    "kg-1",
+                    ExtractionSessionMode.SCHEMA_BOOTSTRAP,
+                ): {
+                    "z_last": "z",
+                    "a_first": "a",
+                }
+            }
+        )
+        service = ExtractionSkillResolutionService(override_repository=repo)
+
+        resolved = await service.resolve_for_session(
+            knowledge_graph_id="kg-1",
+            mode=ExtractionSessionMode.SCHEMA_BOOTSTRAP,
+        )
+
+        # Additional override keys are merged in sorted order for determinism.
+        assert list(resolved.keys())[-2:] == ["a_first", "z_last"]
+


### PR DESCRIPTION
## Summary
- add extraction skill-resolution service with mode-specific global templates
- merge KG-specific skill overrides deterministically on top of global defaults
- add unit tests covering bootstrap/extraction defaults and deterministic override behavior

## Testing
- [x] `uv run pytest tests/unit/extraction/application/test_skill_resolution_service.py tests/unit/extraction/test_architecture.py -q`

## Risks
- persistence/source of KG override templates is still abstracted behind a port and will be wired by follow-on infrastructure work

Closes #652

Made with [Cursor](https://cursor.com)