### PR TITLE
feat(management): add data-source commit reference projection (#659)

### DIFF
--- a/src/api/infrastructure/migrations/versions/f8e9f0a1b2c3_add_commit_reference_columns_to_data_sources.py
+++ b/src/api/infrastructure/migrations/versions/f8e9f0a1b2c3_add_commit_reference_columns_to_data_sources.py
@@ -1,0 +1,47 @@
+"""add commit reference columns to data_sources
+
+Adds commit reference tracking fields for Git-backed data sources:
+- clone_head_commit
+- last_extraction_baseline_commit
+- tracked_branch_head_commit
+
+Revision ID: f8e9f0a1b2c3
+Revises: f7d8e9f0a1b2
+Create Date: 2026-05-14 16:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f8e9f0a1b2c3"
+down_revision: Union[str, Sequence[str], None] = "f7d8e9f0a1b2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add nullable commit-reference columns to data_sources."""
+    op.add_column(
+        "data_sources",
+        sa.Column("clone_head_commit", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "data_sources",
+        sa.Column("last_extraction_baseline_commit", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "data_sources",
+        sa.Column("tracked_branch_head_commit", sa.String(length=64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop commit-reference columns from data_sources."""
+    op.drop_column("data_sources", "tracked_branch_head_commit")
+    op.drop_column("data_sources", "last_extraction_baseline_commit")
+    op.drop_column("data_sources", "clone_head_commit")
+

--- a/src/api/management/domain/aggregates/data_source.py
+++ b/src/api/management/domain/aggregates/data_source.py
@@ -63,6 +63,9 @@ class DataSource:
     last_sync_at: datetime | None
     created_at: datetime
     updated_at: datetime
+    clone_head_commit: str | None = None
+    last_extraction_baseline_commit: str | None = None
+    tracked_branch_head_commit: str | None = None
     ontology: Ontology | None = None
     _pending_events: list[DomainEvent] = field(default_factory=list, repr=False)
     _probe: DataSourceProbe = field(

--- a/src/api/management/infrastructure/models/data_source.py
+++ b/src/api/management/infrastructure/models/data_source.py
@@ -42,6 +42,13 @@ class DataSourceModel(Base, TimestampMixin):
     last_sync_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    clone_head_commit: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    last_extraction_baseline_commit: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )
+    tracked_branch_head_commit: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )
     ontology_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
     __table_args__ = (

--- a/src/api/management/infrastructure/repositories/data_source_repository.py
+++ b/src/api/management/infrastructure/repositories/data_source_repository.py
@@ -80,6 +80,11 @@ class DataSourceRepository(IDataSourceRepository):
                 model.schedule_type = data_source.schedule.schedule_type.value
                 model.schedule_value = data_source.schedule.value
                 model.last_sync_at = data_source.last_sync_at
+                model.clone_head_commit = data_source.clone_head_commit
+                model.last_extraction_baseline_commit = (
+                    data_source.last_extraction_baseline_commit
+                )
+                model.tracked_branch_head_commit = data_source.tracked_branch_head_commit
                 model.updated_at = data_source.updated_at
                 model.ontology_json = ontology_json
             else:
@@ -94,6 +99,11 @@ class DataSourceRepository(IDataSourceRepository):
                     schedule_type=data_source.schedule.schedule_type.value,
                     schedule_value=data_source.schedule.value,
                     last_sync_at=data_source.last_sync_at,
+                    clone_head_commit=data_source.clone_head_commit,
+                    last_extraction_baseline_commit=(
+                        data_source.last_extraction_baseline_commit
+                    ),
+                    tracked_branch_head_commit=data_source.tracked_branch_head_commit,
                     ontology_json=ontology_json,
                     created_at=data_source.created_at,
                     updated_at=data_source.updated_at,
@@ -207,5 +217,8 @@ class DataSourceRepository(IDataSourceRepository):
             last_sync_at=model.last_sync_at,
             created_at=model.created_at,
             updated_at=model.updated_at,
+            clone_head_commit=model.clone_head_commit,
+            last_extraction_baseline_commit=model.last_extraction_baseline_commit,
+            tracked_branch_head_commit=model.tracked_branch_head_commit,
             ontology=ontology,
         )

--- a/src/api/management/presentation/data_sources/models.py
+++ b/src/api/management/presentation/data_sources/models.py
@@ -189,6 +189,15 @@ class DataSourceResponse(BaseModel):
     last_sync_at: datetime | None = Field(
         None, description="When the last sync completed"
     )
+    clone_head_commit: str | None = Field(
+        None, description="Latest known commit in the local/ingested clone"
+    )
+    last_extraction_baseline_commit: str | None = Field(
+        None, description="Commit used as baseline during the last extraction run"
+    )
+    tracked_branch_head_commit: str | None = Field(
+        None, description="Latest known commit at the tracked source branch head"
+    )
     created_at: datetime = Field(..., description="When the DS was created")
     updated_at: datetime = Field(..., description="When the DS was last updated")
     ontology: OntologyModel | None = Field(
@@ -214,6 +223,9 @@ class DataSourceResponse(BaseModel):
             adapter_type=ds.adapter_type.value,
             schedule_type=ds.schedule.schedule_type.value,
             last_sync_at=ds.last_sync_at,
+            clone_head_commit=ds.clone_head_commit,
+            last_extraction_baseline_commit=ds.last_extraction_baseline_commit,
+            tracked_branch_head_commit=ds.tracked_branch_head_commit,
             created_at=ds.created_at,
             updated_at=ds.updated_at,
             ontology=(
@@ -293,6 +305,15 @@ class DataSourceWithSyncResponse(BaseModel):
     last_sync_at: datetime | None = Field(
         None, description="When the last sync completed"
     )
+    clone_head_commit: str | None = Field(
+        None, description="Latest known commit in the local/ingested clone"
+    )
+    last_extraction_baseline_commit: str | None = Field(
+        None, description="Commit used as baseline during the last extraction run"
+    )
+    tracked_branch_head_commit: str | None = Field(
+        None, description="Latest known commit at the tracked source branch head"
+    )
     created_at: datetime = Field(..., description="When the DS was created")
     updated_at: datetime = Field(..., description="When the DS was last updated")
     ontology: OntologyModel | None = Field(
@@ -325,6 +346,9 @@ class DataSourceWithSyncResponse(BaseModel):
             adapter_type=ds.adapter_type.value,
             schedule_type=ds.schedule.schedule_type.value,
             last_sync_at=ds.last_sync_at,
+            clone_head_commit=ds.clone_head_commit,
+            last_extraction_baseline_commit=ds.last_extraction_baseline_commit,
+            tracked_branch_head_commit=ds.tracked_branch_head_commit,
             created_at=ds.created_at,
             updated_at=ds.updated_at,
             ontology=(

--- a/src/api/tests/integration/management/test_data_source_repository.py
+++ b/src/api/tests/integration/management/test_data_source_repository.py
@@ -112,6 +112,49 @@ class TestDataSourceRoundTrip:
         assert retrieved is not None
         assert retrieved.credentials_path == "vault://secrets/github"
 
+    @pytest.mark.asyncio
+    async def test_saves_and_retrieves_commit_references(
+        self,
+        data_source_repository: DataSourceRepository,
+        knowledge_graph_repository: KnowledgeGraphRepository,
+        async_session,
+        test_tenant: str,
+        test_workspace: str,
+        clean_management_data,
+    ):
+        """Should roundtrip Git commit reference tracking fields."""
+        kg = KnowledgeGraph.create(
+            tenant_id=test_tenant,
+            workspace_id=test_workspace,
+            name="Test KG",
+            description="For DS commit reference tests",
+        )
+        async with async_session.begin():
+            await knowledge_graph_repository.save(kg)
+
+        ds = DataSource.create(
+            knowledge_graph_id=kg.id.value,
+            tenant_id=test_tenant,
+            name="GitHub With Commits",
+            adapter_type=DataSourceAdapterType.GITHUB,
+            connection_config={"repo": "org/repo"},
+        )
+        ds.clone_head_commit = "1111111111111111111111111111111111111111"
+        ds.last_extraction_baseline_commit = "2222222222222222222222222222222222222222"
+        ds.tracked_branch_head_commit = "3333333333333333333333333333333333333333"
+
+        async with async_session.begin():
+            await data_source_repository.save(ds)
+
+        retrieved = await data_source_repository.get_by_id(ds.id)
+        assert retrieved is not None
+        assert retrieved.clone_head_commit == ds.clone_head_commit
+        assert (
+            retrieved.last_extraction_baseline_commit
+            == ds.last_extraction_baseline_commit
+        )
+        assert retrieved.tracked_branch_head_commit == ds.tracked_branch_head_commit
+
 
 class TestDataSourceUpdate:
     """Tests for updating data sources."""

--- a/src/api/tests/unit/management/presentation/test_data_sources_routes.py
+++ b/src/api/tests/unit/management/presentation/test_data_sources_routes.py
@@ -69,6 +69,9 @@ def sample_data_source(mock_current_user: CurrentUser) -> DataSource:
         last_sync_at=None,
         created_at=now,
         updated_at=now,
+        clone_head_commit="1111111111111111111111111111111111111111",
+        last_extraction_baseline_commit="2222222222222222222222222222222222222222",
+        tracked_branch_head_commit="3333333333333333333333333333333333333333",
     )
 
 
@@ -134,6 +137,15 @@ class TestListDataSourcesRoute:
         assert result[0]["id"] == sample_data_source.id.value
         assert result[0]["name"] == sample_data_source.name
         assert result[0]["adapter_type"] == sample_data_source.adapter_type.value
+        assert result[0]["clone_head_commit"] == sample_data_source.clone_head_commit
+        assert (
+            result[0]["last_extraction_baseline_commit"]
+            == sample_data_source.last_extraction_baseline_commit
+        )
+        assert (
+            result[0]["tracked_branch_head_commit"]
+            == sample_data_source.tracked_branch_head_commit
+        )
 
     def test_list_data_sources_returns_empty_list(
         self,

--- a/src/api/tests/unit/management/test_data_source.py
+++ b/src/api/tests/unit/management/test_data_source.py
@@ -145,6 +145,19 @@ class TestDataSourceCreate:
         )
         assert ds.last_sync_at is None
 
+    def test_create_sets_commit_references_to_none(self):
+        """create() should default commit-reference tracking fields to None."""
+        ds = DataSource.create(
+            knowledge_graph_id="kg-1",
+            tenant_id="t",
+            name="Source",
+            adapter_type=DataSourceAdapterType.GITHUB,
+            connection_config={},
+        )
+        assert ds.clone_head_commit is None
+        assert ds.last_extraction_baseline_commit is None
+        assert ds.tracked_branch_head_commit is None
+
     def test_create_with_credentials_path(self):
         """create() should store optional credentials_path."""
         ds = DataSource.create(


### PR DESCRIPTION
## Summary
- add commit-reference fields to data-source domain + persistence model (clone head, extraction baseline, tracked branch head)
- persist/rehydrate commit references in DataSourceRepository and expose them in management API response models
- add migration and unit/integration coverage for defaults + API projection + repository roundtrip behavior

## Testing
- [x] `uv run pytest tests/unit/management/test_data_source.py tests/unit/management/presentation/test_data_sources_routes.py -q`

## Risks
- integration coverage for the new repository roundtrip test exists but was not run in this environment (requires integration DB)

Closes #659

Made with [Cursor](https://cursor.com)