### PR TITLE
feat(ingestion): resolve commit baseline context on sync start (#660)

### DIFF
--- a/src/api/ingestion/application/services/ingestion_service.py
+++ b/src/api/ingestion/application/services/ingestion_service.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from ingestion.ports.adapters import IDatasourceAdapter
 from shared_kernel.job_package.builder import JobPackageBuilder
 from shared_kernel.job_package.value_objects import (
+    AdapterCheckpoint,
     JobPackageId,
     SyncMode,
 )
@@ -51,6 +52,8 @@ class IngestionService:
         adapter_type: str,
         connection_config: dict[str, str],
         credentials_path: str | None,
+        credentials: dict[str, str] | None = None,
+        baseline_commit: str | None = None,
     ) -> JobPackageId:
         """Run the ingestion pipeline for a data source sync.
 
@@ -62,6 +65,9 @@ class IngestionService:
             connection_config: Key-value adapter configuration
             credentials_path: Vault path for credentials (currently unused;
                 future implementations will decrypt and pass credentials)
+            credentials: Optional decrypted credentials prepared by caller
+            baseline_commit: Optional baseline commit SHA used to seed
+                incremental extraction checkpoint state
 
         Returns:
             The JobPackageId of the produced ZIP archive
@@ -78,15 +84,22 @@ class IngestionService:
                 f"Registered adapters: {list(self._adapter_registry.keys())}"
             )
 
-        # TODO: decrypt credentials from credentials_path when secret store
-        # is injected. Currently an empty dict is passed as placeholder.
-        credentials: dict[str, str] = {}
+        # Credentials are provided by the session-aware event wrapper, which
+        # resolves tenant-scoped secrets via the shared credential reader port.
+        resolved_credentials: dict[str, str] = dict(credentials or {})
+
+        checkpoint = None
+        if baseline_commit:
+            checkpoint = AdapterCheckpoint(
+                schema_version="1.0.0",
+                data={"commit_sha": baseline_commit},
+            )
 
         # Extract raw items from the adapter using the new ExtractionResult API
         result = await adapter.extract(
             connection_config=connection_config,
-            credentials=credentials,
-            checkpoint=None,  # no checkpoint support yet; always full refresh
+            credentials=resolved_credentials,
+            checkpoint=checkpoint,
             sync_mode=SyncMode.INCREMENTAL,
         )
 

--- a/src/api/ingestion/infrastructure/event_handler.py
+++ b/src/api/ingestion/infrastructure/event_handler.py
@@ -82,6 +82,8 @@ class IngestionEventHandler:
                 adapter_type=payload["adapter_type"],
                 connection_config=payload.get("connection_config", {}),
                 credentials_path=payload.get("credentials_path"),
+                credentials=payload.get("credentials"),
+                baseline_commit=payload.get("baseline_commit"),
             )
         except asyncio.CancelledError:
             # Propagate task cancellation so the event loop can shut down

--- a/src/api/ingestion/ports/services.py
+++ b/src/api/ingestion/ports/services.py
@@ -22,6 +22,8 @@ class IIngestionService(Protocol):
         adapter_type: str,
         connection_config: dict[str, str],
         credentials_path: str | None,
+        credentials: dict[str, str] | None = None,
+        baseline_commit: str | None = None,
     ) -> JobPackageId:
         """Run the ingestion pipeline.
 
@@ -32,6 +34,8 @@ class IIngestionService(Protocol):
             adapter_type: Which adapter to use (e.g. "github")
             connection_config: Adapter-specific connection configuration
             credentials_path: Optional Vault path for credentials
+            credentials: Optional decrypted credentials prepared upstream
+            baseline_commit: Optional commit SHA used as incremental baseline
 
         Returns:
             JobPackageId for the produced archive

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -4,9 +4,11 @@ import asyncio
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+import httpx
 from util import dev_routes
 
 import health_routes
@@ -25,6 +27,7 @@ from infrastructure.settings import (
     get_cors_settings,
     get_database_settings,
     get_iam_settings,
+    get_management_settings,
     get_oidc_settings,
     get_outbox_worker_settings,
     get_spicedb_settings,
@@ -136,13 +139,80 @@ class _SessionedIngestionEventHandler:
     def supported_event_types(self) -> frozenset[str]:
         return self._SUPPORTED
 
+    @staticmethod
+    def _parse_github_connection_config(
+        config: dict[str, str],
+    ) -> tuple[str, str, str]:
+        """Parse GitHub config into owner/repo/branch."""
+        if "repo_url" in config:
+            parsed = urlparse(config["repo_url"])
+            path_parts = [part for part in parsed.path.split("/") if part]
+            if len(path_parts) < 2:
+                raise ValueError("repo_url must include owner and repo")
+            owner = path_parts[0]
+            repo = path_parts[1].removesuffix(".git")
+            branch = config.get("branch", "main")
+            if len(path_parts) >= 4 and path_parts[2] == "tree":
+                branch = path_parts[3]
+            return owner, repo, branch
+
+        if "owner" in config and "repo" in config:
+            return config["owner"], config["repo"], config.get("branch", "main")
+
+        raise ValueError(
+            "connection_config must include either 'repo_url' or 'owner'+'repo' keys"
+        )
+
+    async def _resolve_github_tracked_head_commit(
+        self,
+        connection_config: dict[str, str],
+        credentials: dict[str, str],
+    ) -> str | None:
+        """Resolve latest tracked branch head commit for GitHub sources."""
+        try:
+            owner, repo, branch = self._parse_github_connection_config(connection_config)
+        except ValueError:
+            return None
+
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        token = credentials.get("token") or credentials.get("access_token")
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+        url = f"https://api.github.com/repos/{owner}/{repo}/branches/{branch}"
+        async with httpx.AsyncClient(timeout=20.0) as client:
+            response = await client.get(url, headers=headers)
+            response.raise_for_status()
+            payload = response.json()
+        sha = payload.get("commit", {}).get("sha")
+        return str(sha) if sha else None
+
     async def handle(self, event_type: str, payload: dict[str, Any]) -> None:
         from infrastructure.outbox.repository import OutboxRepository
         from ingestion.application.services.ingestion_service import IngestionService
         from ingestion.infrastructure.event_handler import IngestionEventHandler
+        from management.domain.value_objects import DataSourceId
+        from management.infrastructure.repositories.data_source_repository import (
+            DataSourceRepository,
+        )
+        from management.infrastructure.repositories.fernet_secret_store import (
+            FernetSecretStore,
+        )
 
         async with self._session_factory() as session:
             outbox = OutboxRepository(session=session)
+            ds_repo = DataSourceRepository(session=session, outbox=outbox)
+            management_settings = get_management_settings()
+            encryption_keys = management_settings.encryption_key.get_secret_value().split(
+                ","
+            )
+            credential_reader = FernetSecretStore(
+                session=session,
+                encryption_keys=encryption_keys,
+            )
             from ingestion.infrastructure.adapters.github import GitHubAdapter
 
             ingestion_service = IngestionService(
@@ -153,7 +223,41 @@ class _SessionedIngestionEventHandler:
                 ingestion_service=ingestion_service,
                 outbox=outbox,
             )
-            await ingestion_handler.handle(event_type, payload)
+            enriched_payload = dict(payload)
+
+            data_source_id = str(payload.get("data_source_id", ""))
+            tenant_id = str(payload.get("tenant_id", "")) if payload.get("tenant_id") else ""
+            adapter_type = str(payload.get("adapter_type", ""))
+            if data_source_id and adapter_type == "github":
+                ds = await ds_repo.get_by_id(DataSourceId(value=data_source_id))
+                if ds is not None:
+                    if ds.last_extraction_baseline_commit:
+                        enriched_payload["baseline_commit"] = (
+                            ds.last_extraction_baseline_commit
+                        )
+
+                    credentials: dict[str, str] = {}
+                    if ds.credentials_path and tenant_id:
+                        try:
+                            credentials = await credential_reader.retrieve(
+                                path=ds.credentials_path,
+                                tenant_id=tenant_id,
+                            )
+                        except KeyError:
+                            credentials = {}
+                    if credentials:
+                        enriched_payload["credentials"] = credentials
+
+                    tracked_head = await self._resolve_github_tracked_head_commit(
+                        connection_config=ds.connection_config,
+                        credentials=credentials,
+                    )
+                    if tracked_head:
+                        enriched_payload["tracked_branch_head_commit"] = tracked_head
+                        ds.tracked_branch_head_commit = tracked_head
+                        await ds_repo.save(ds)
+
+            await ingestion_handler.handle(event_type, enriched_payload)
             await session.commit()
 
 

--- a/src/api/tests/unit/ingestion/application/test_ingestion_service.py
+++ b/src/api/tests/unit/ingestion/application/test_ingestion_service.py
@@ -57,6 +57,8 @@ class _FakeAdapter:
     ) -> None:
         self._result = result
         self._fail = fail
+        self.last_checkpoint: AdapterCheckpoint | None = None
+        self.last_credentials: dict[str, str] | None = None
 
     async def extract(
         self,
@@ -65,6 +67,8 @@ class _FakeAdapter:
         checkpoint: AdapterCheckpoint | None,
         sync_mode: SyncMode,
     ) -> ExtractionResult:
+        self.last_checkpoint = checkpoint
+        self.last_credentials = credentials
         if self._fail:
             raise RuntimeError("credentials expired")
         if self._result is not None:
@@ -178,3 +182,26 @@ class TestIngestionService:
                 credentials_path=None,
             )
         assert isinstance(job_id, JobPackageId)
+
+    async def test_run_uses_baseline_commit_as_checkpoint(self):
+        """run() should convert baseline_commit into an adapter checkpoint."""
+        result = _make_extraction_result()
+        adapter = _FakeAdapter(result=result)
+        registry: dict[str, IDatasourceAdapter] = {"github": adapter}
+        with tempfile.TemporaryDirectory() as tmpdir:
+            service = IngestionService(
+                adapter_registry=registry,
+                work_dir=Path(tmpdir),
+            )
+            await service.run(
+                sync_run_id="run-001",
+                data_source_id="ds-001",
+                knowledge_graph_id="kg-001",
+                adapter_type="github",
+                connection_config={"repo": "org/repo"},
+                credentials_path=None,
+                baseline_commit="abc123",
+            )
+
+        assert adapter.last_checkpoint is not None
+        assert adapter.last_checkpoint.data == {"commit_sha": "abc123"}

--- a/src/api/tests/unit/ingestion/infrastructure/test_ingestion_event_handler.py
+++ b/src/api/tests/unit/ingestion/infrastructure/test_ingestion_event_handler.py
@@ -66,6 +66,8 @@ class _FakeIngestionService:
         adapter_type: str,
         connection_config: dict[str, str],
         credentials_path: str | None,
+        credentials: dict[str, str] | None = None,
+        baseline_commit: str | None = None,
     ) -> JobPackageId:
         self.calls.append(
             {
@@ -73,6 +75,8 @@ class _FakeIngestionService:
                 "data_source_id": data_source_id,
                 "knowledge_graph_id": knowledge_graph_id,
                 "adapter_type": adapter_type,
+                "credentials": credentials,
+                "baseline_commit": baseline_commit,
             }
         )
         if self._fail:
@@ -148,6 +152,22 @@ class TestIngestionEventHandlerSuccess:
         call = ingestion_service.calls[0]
         assert call["sync_run_id"] == "run-001"
         assert call["adapter_type"] == "github"
+
+    async def test_passes_baseline_and_credentials_through_payload(
+        self,
+        handler: IngestionEventHandler,
+        ingestion_service: _FakeIngestionService,
+    ):
+        """SyncStarted payload baseline/credentials should pass to service.run()."""
+        payload = _sync_started_payload()
+        payload["baseline_commit"] = "abc123"
+        payload["credentials"] = {"token": "secret"}
+
+        await handler.handle("SyncStarted", payload)
+
+        call = ingestion_service.calls[0]
+        assert call["baseline_commit"] == "abc123"
+        assert call["credentials"] == {"token": "secret"}
 
     async def test_emits_job_package_produced_on_success(
         self,
@@ -294,6 +314,8 @@ class TestIngestionEventHandlerOutboxIsolation:
                 adapter_type: str,
                 connection_config: dict[str, str],
                 credentials_path: str | None,
+                credentials: dict[str, str] | None = None,
+                baseline_commit: str | None = None,
             ) -> JobPackageId:
                 raise asyncio.CancelledError()
 

--- a/src/api/tests/unit/test_sessioned_ingestion_handler.py
+++ b/src/api/tests/unit/test_sessioned_ingestion_handler.py
@@ -1,0 +1,107 @@
+"""Unit tests for session-aware ingestion event context preparation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from management.domain.aggregates import DataSource
+from management.domain.value_objects import DataSourceId, Schedule, ScheduleType
+from shared_kernel.datasource_types import DataSourceAdapterType
+
+
+def _make_session_factory(session):
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    factory = MagicMock(return_value=ctx)
+    return factory
+
+
+def _make_data_source() -> DataSource:
+    now = datetime.now(UTC)
+    return DataSource(
+        id=DataSourceId(value="01JTESTSESSIONHANDLERDATA00"),
+        knowledge_graph_id="01JTESTSESSIONHANDLERKG0000",
+        tenant_id="tenant-001",
+        name="GitHub Source",
+        adapter_type=DataSourceAdapterType.GITHUB,
+        connection_config={"owner": "org", "repo": "repo", "branch": "main"},
+        credentials_path="datasource/01JTESTSESSIONHANDLERDATA00/credentials",
+        schedule=Schedule(schedule_type=ScheduleType.MANUAL),
+        last_sync_at=None,
+        created_at=now,
+        updated_at=now,
+        last_extraction_baseline_commit="baseline123",
+    )
+
+
+@pytest.mark.asyncio
+async def test_sessioned_ingestion_handler_prepares_commit_context():
+    """Wrapper should inject baseline/credentials and refresh tracked head."""
+    from main import _SessionedIngestionEventHandler
+
+    session = AsyncMock()
+    session_factory = _make_session_factory(session)
+    handler = _SessionedIngestionEventHandler(session_factory=session_factory)
+    handler._resolve_github_tracked_head_commit = AsyncMock(return_value="head456")  # type: ignore[attr-defined]
+
+    outbox_repo = MagicMock()
+    ds_repo = MagicMock()
+    secret_store = MagicMock()
+    ingestion_handler = MagicMock()
+    ingestion_handler.handle = AsyncMock()
+    ingestion_service = MagicMock()
+
+    data_source = _make_data_source()
+    ds_repo.get_by_id = AsyncMock(return_value=data_source)
+    ds_repo.save = AsyncMock()
+    secret_store.retrieve = AsyncMock(return_value={"token": "tok"})
+
+    payload = {
+        "sync_run_id": "run-001",
+        "data_source_id": data_source.id.value,
+        "knowledge_graph_id": data_source.knowledge_graph_id,
+        "tenant_id": data_source.tenant_id,
+        "adapter_type": "github",
+        "connection_config": data_source.connection_config,
+        "credentials_path": data_source.credentials_path,
+    }
+
+    management_settings = MagicMock()
+    management_settings.encryption_key.get_secret_value.return_value = (
+        "WlAwWU83a2hSODl2SVY4MHBzQWpwaDBSUHhOU3NfQ3R6aXpvNTJfNE5odz0="
+    )
+
+    with (
+        patch("infrastructure.outbox.repository.OutboxRepository", return_value=outbox_repo),
+        patch(
+            "management.infrastructure.repositories.data_source_repository.DataSourceRepository",
+            return_value=ds_repo,
+        ),
+        patch(
+            "management.infrastructure.repositories.fernet_secret_store.FernetSecretStore",
+            return_value=secret_store,
+        ),
+        patch(
+            "ingestion.application.services.ingestion_service.IngestionService",
+            return_value=ingestion_service,
+        ),
+        patch(
+            "ingestion.infrastructure.event_handler.IngestionEventHandler",
+            return_value=ingestion_handler,
+        ),
+        patch("main.get_management_settings", return_value=management_settings),
+    ):
+        await handler.handle("SyncStarted", payload)
+
+    ingestion_handler.handle.assert_called_once()
+    call_payload = ingestion_handler.handle.call_args.args[1]
+    assert call_payload["baseline_commit"] == "baseline123"
+    assert call_payload["tracked_branch_head_commit"] == "head456"
+    assert call_payload["credentials"] == {"token": "tok"}
+    ds_repo.save.assert_awaited_once()
+    assert data_source.tracked_branch_head_commit == "head456"
+


### PR DESCRIPTION
## Summary
- enrich SyncStarted ingestion handling with Git-backed context preparation before extraction starts
- resolve baseline commit from data-source commit references and pass it into ingestion as checkpoint state
- refresh tracked branch head for GitHub sources and inject tenant-scoped credentials for branch-head resolution/adapter execution

## Testing
- [x] `uv run pytest tests/unit/ingestion/application/test_ingestion_service.py tests/unit/ingestion/infrastructure/test_ingestion_event_handler.py tests/unit/test_sessioned_ingestion_handler.py -q`
- [x] `uv run pytest tests/unit/test_application_lifecycle.py tests/unit/ingestion/test_architecture.py -q`

## Risks
- tracked branch refresh currently targets GitHub sources only (other adapters remain no-op until implemented)

Closes #660

Made with [Cursor](https://cursor.com)