### PR TITLE
feat(ingestion): add no-new-commit sync short-circuit (#661)

### DIFF
--- a/src/api/ingestion/infrastructure/event_handler.py
+++ b/src/api/ingestion/infrastructure/event_handler.py
@@ -74,6 +74,22 @@ class IngestionEventHandler:
         knowledge_graph_id = payload["knowledge_graph_id"]
         now = datetime.now(UTC)
 
+        if payload.get("no_changes_detected") is True:
+            await self._outbox.append(
+                event_type="MutationsApplied",
+                payload={
+                    "sync_run_id": sync_run_id,
+                    "data_source_id": data_source_id,
+                    "knowledge_graph_id": knowledge_graph_id,
+                    "no_changes_detected": True,
+                    "occurred_at": now.isoformat(),
+                },
+                occurred_at=now,
+                aggregate_type="sync_run",
+                aggregate_id=sync_run_id,
+            )
+            return
+
         try:
             job_package_id = await self._ingestion_service.run(
                 sync_run_id=sync_run_id,

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -256,6 +256,13 @@ class _SessionedIngestionEventHandler:
                         enriched_payload["tracked_branch_head_commit"] = tracked_head
                         ds.tracked_branch_head_commit = tracked_head
                         await ds_repo.save(ds)
+                        baseline_commit = enriched_payload.get("baseline_commit")
+                        if (
+                            isinstance(baseline_commit, str)
+                            and baseline_commit
+                            and baseline_commit == tracked_head
+                        ):
+                            enriched_payload["no_changes_detected"] = True
 
             await ingestion_handler.handle(event_type, enriched_payload)
             await session.commit()

--- a/src/api/management/infrastructure/sync_lifecycle_handler.py
+++ b/src/api/management/infrastructure/sync_lifecycle_handler.py
@@ -123,6 +123,11 @@ class SyncLifecycleHandler:
             sync_run.status = "completed"
             sync_run.completed_at = now
             sync_run.logs.append(f"[{now.isoformat()}] Sync completed")
+            if payload.get("no_changes_detected") is True:
+                sync_run.logs.append(
+                    f"[{now.isoformat()}] No source changes were detected; "
+                    "heavy extraction was short-circuited."
+                )
             if sync_run.mutation_log_run is not None:
                 sync_run.mutation_log_run.completed_at = now
                 if payload.get("token_usage_total") is not None:

--- a/src/api/tests/unit/ingestion/infrastructure/test_ingestion_event_handler.py
+++ b/src/api/tests/unit/ingestion/infrastructure/test_ingestion_event_handler.py
@@ -198,6 +198,27 @@ class TestIngestionEventHandlerSuccess:
         assert event["aggregate_type"] == "sync_run"
         assert event["aggregate_id"] == "run-001"
 
+    async def test_short_circuits_when_no_changes_detected(
+        self,
+        handler: IngestionEventHandler,
+        ingestion_service: _FakeIngestionService,
+        outbox: _FakeOutboxRepository,
+    ):
+        """When no_changes_detected is true, heavy ingestion is skipped."""
+        payload = _sync_started_payload(sync_run_id="run-004")
+        payload["no_changes_detected"] = True
+        payload["tracked_branch_head_commit"] = "abc123"
+        payload["baseline_commit"] = "abc123"
+
+        await handler.handle("SyncStarted", payload)
+
+        assert ingestion_service.calls == []
+        assert len(outbox.appended) == 1
+        event = outbox.appended[0]
+        assert event["event_type"] == "MutationsApplied"
+        assert event["payload"]["sync_run_id"] == "run-004"
+        assert event["payload"]["no_changes_detected"] is True
+
 
 @pytest.mark.asyncio
 class TestIngestionEventHandlerFailure:

--- a/src/api/tests/unit/management/infrastructure/test_sync_lifecycle_handler.py
+++ b/src/api/tests/unit/management/infrastructure/test_sync_lifecycle_handler.py
@@ -392,6 +392,48 @@ class TestMutationsAppliedTransition:
         saved_ds = mock_ds_repo.save.call_args[0][0]
         assert saved_ds.last_sync_at is not None
 
+    async def test_mutations_applied_logs_no_changes_short_circuit(
+        self,
+        handler: SyncLifecycleHandler,
+        mock_sync_run_repo: AsyncMock,
+        mock_ds_repo: AsyncMock,
+    ):
+        """No-change short-circuit should leave an explicit audit log entry."""
+        from management.domain.aggregates import DataSource
+        from management.domain.value_objects import DataSourceId, Schedule, ScheduleType
+        from shared_kernel.datasource_types import DataSourceAdapterType
+
+        run = _make_sync_run(status="ingesting")
+        mock_sync_run_repo.get_by_id.return_value = run
+
+        now = datetime.now(UTC)
+        ds = DataSource(
+            id=DataSourceId(value="ds-001"),
+            knowledge_graph_id="kg-001",
+            tenant_id="tenant-001",
+            name="My DS",
+            adapter_type=DataSourceAdapterType.GITHUB,
+            connection_config={},
+            credentials_path=None,
+            schedule=Schedule(schedule_type=ScheduleType.MANUAL),
+            last_sync_at=None,
+            created_at=now,
+            updated_at=now,
+        )
+        mock_ds_repo.get_by_id.return_value = ds
+
+        await handler.handle(
+            "MutationsApplied",
+            _payload(
+                sync_run_id=run.id,
+                knowledge_graph_id="kg-001",
+                no_changes_detected=True,
+            ),
+        )
+
+        saved_run: DataSourceSyncRun = mock_sync_run_repo.save.call_args[0][0]
+        assert any("No source changes were detected" in line for line in saved_run.logs)
+
 
 @pytest.mark.asyncio
 class TestMutationApplicationFailedTransition:

--- a/src/api/tests/unit/test_sessioned_ingestion_handler.py
+++ b/src/api/tests/unit/test_sessioned_ingestion_handler.py
@@ -105,3 +105,68 @@ async def test_sessioned_ingestion_handler_prepares_commit_context():
     ds_repo.save.assert_awaited_once()
     assert data_source.tracked_branch_head_commit == "head456"
 
+
+@pytest.mark.asyncio
+async def test_sessioned_ingestion_handler_sets_no_changes_flag_when_heads_match():
+    """Wrapper should short-circuit when tracked head equals baseline."""
+    from main import _SessionedIngestionEventHandler
+
+    session = AsyncMock()
+    session_factory = _make_session_factory(session)
+    handler = _SessionedIngestionEventHandler(session_factory=session_factory)
+    handler._resolve_github_tracked_head_commit = AsyncMock(return_value="baseline123")  # type: ignore[attr-defined]
+
+    outbox_repo = MagicMock()
+    ds_repo = MagicMock()
+    secret_store = MagicMock()
+    ingestion_handler = MagicMock()
+    ingestion_handler.handle = AsyncMock()
+    ingestion_service = MagicMock()
+
+    data_source = _make_data_source()
+    ds_repo.get_by_id = AsyncMock(return_value=data_source)
+    ds_repo.save = AsyncMock()
+    secret_store.retrieve = AsyncMock(return_value={"token": "tok"})
+
+    payload = {
+        "sync_run_id": "run-002",
+        "data_source_id": data_source.id.value,
+        "knowledge_graph_id": data_source.knowledge_graph_id,
+        "tenant_id": data_source.tenant_id,
+        "adapter_type": "github",
+        "connection_config": data_source.connection_config,
+        "credentials_path": data_source.credentials_path,
+    }
+
+    management_settings = MagicMock()
+    management_settings.encryption_key.get_secret_value.return_value = (
+        "WlAwWU83a2hSODl2SVY4MHBzQWpwaDBSUHhOU3NfQ3R6aXpvNTJfNE5odz0="
+    )
+
+    with (
+        patch("infrastructure.outbox.repository.OutboxRepository", return_value=outbox_repo),
+        patch(
+            "management.infrastructure.repositories.data_source_repository.DataSourceRepository",
+            return_value=ds_repo,
+        ),
+        patch(
+            "management.infrastructure.repositories.fernet_secret_store.FernetSecretStore",
+            return_value=secret_store,
+        ),
+        patch(
+            "ingestion.application.services.ingestion_service.IngestionService",
+            return_value=ingestion_service,
+        ),
+        patch(
+            "ingestion.infrastructure.event_handler.IngestionEventHandler",
+            return_value=ingestion_handler,
+        ),
+        patch("main.get_management_settings", return_value=management_settings),
+    ):
+        await handler.handle("SyncStarted", payload)
+
+    call_payload = ingestion_handler.handle.call_args.args[1]
+    assert call_payload["baseline_commit"] == "baseline123"
+    assert call_payload["tracked_branch_head_commit"] == "baseline123"
+    assert call_payload["no_changes_detected"] is True
+


### PR DESCRIPTION
## Summary
- detect no-change syncs when tracked branch head equals the last extraction baseline
- short-circuit heavy ingestion/extraction by emitting `MutationsApplied` directly for audit-only runs
- append explicit "no source changes" sync-run log entries while preserving normal completion semantics

## Testing
- [x] `uv run pytest tests/unit/ingestion/infrastructure/test_ingestion_event_handler.py tests/unit/management/infrastructure/test_sync_lifecycle_handler.py tests/unit/test_sessioned_ingestion_handler.py -q`
- [x] `uv run pytest tests/unit/ingestion/application/test_ingestion_service.py tests/unit/test_application_lifecycle.py -q`

## Risks
- current short-circuit path is driven by GitHub tracked-head/baseline equality; adapters without tracked-head refresh remain unchanged

Closes #661

Made with [Cursor](https://cursor.com)