### PR TITLE
feat(management): expose commit diff summary endpoint (#662)

### DIFF
--- a/src/api/management/dependencies/data_source.py
+++ b/src/api/management/dependencies/data_source.py
@@ -17,6 +17,7 @@ from infrastructure.outbox.repository import OutboxRepository
 from infrastructure.settings import get_management_settings
 from management.application.observability import DefaultDataSourceServiceProbe
 from management.application.services.data_source_service import DataSourceService
+from management.infrastructure.git_diff_summary_service import GitDiffSummaryService
 from management.infrastructure.repositories import (
     DataSourceRepository,
     DataSourceSyncRunRepository,
@@ -77,4 +78,21 @@ def get_data_source_service(
         authz=authz,
         scope_to_tenant=current_user.tenant_id.value,
         probe=DefaultDataSourceServiceProbe(),
+    )
+
+
+def get_git_diff_summary_service(
+    session: Annotated[AsyncSession, Depends(get_write_session)],
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+) -> GitDiffSummaryService:
+    """Get GitDiffSummaryService for commit-baseline file diff summaries."""
+    settings = get_management_settings()
+    encryption_keys = settings.encryption_key.get_secret_value().split(",")
+    secret_store = FernetSecretStore(
+        session=session,
+        encryption_keys=encryption_keys,
+    )
+    return GitDiffSummaryService(
+        credential_reader=secret_store,
+        tenant_id=current_user.tenant_id.value,
     )

--- a/src/api/management/infrastructure/git_diff_summary_service.py
+++ b/src/api/management/infrastructure/git_diff_summary_service.py
@@ -1,0 +1,143 @@
+"""Git-backed diff summary service for data-source maintenance cues."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+import httpx
+
+from management.domain.aggregates import DataSource
+from shared_kernel.credential_reader import ICredentialReader
+from shared_kernel.datasource_types import DataSourceAdapterType
+
+
+@dataclass(frozen=True)
+class DiffSummaryResult:
+    """Aggregate + file-level diff summary between baseline and tracked head."""
+
+    baseline_commit: str | None
+    tracked_head_commit: str | None
+    total_changed_files: int
+    added_count: int
+    modified_count: int
+    removed_count: int
+    renamed_count: int
+    files_truncated: bool
+    changed_files: tuple[dict[str, str], ...]
+
+
+class GitDiffSummaryService:
+    """Build a Git commit diff summary for a data source."""
+
+    def __init__(
+        self,
+        credential_reader: ICredentialReader,
+        tenant_id: str,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._credential_reader = credential_reader
+        self._tenant_id = tenant_id
+        self._http_client = http_client
+
+    @staticmethod
+    def _parse_github_connection_config(config: dict[str, str]) -> tuple[str, str]:
+        if "repo_url" in config:
+            parsed = urlparse(config["repo_url"])
+            path_parts = [part for part in parsed.path.split("/") if part]
+            if len(path_parts) < 2:
+                raise ValueError("repo_url must include owner and repo")
+            owner = path_parts[0]
+            repo = path_parts[1].removesuffix(".git")
+            return owner, repo
+
+        if "owner" in config and "repo" in config:
+            return config["owner"], config["repo"]
+
+        raise ValueError(
+            "connection_config must include either 'repo_url' or 'owner'+'repo' keys"
+        )
+
+    async def build_summary(
+        self,
+        *,
+        data_source: DataSource,
+        max_files: int,
+    ) -> DiffSummaryResult:
+        """Compute changed-file summary from baseline commit to tracked head."""
+        baseline = data_source.last_extraction_baseline_commit
+        tracked = data_source.tracked_branch_head_commit
+        if (
+            data_source.adapter_type != DataSourceAdapterType.GITHUB
+            or not baseline
+            or not tracked
+            or baseline == tracked
+        ):
+            return DiffSummaryResult(
+                baseline_commit=baseline,
+                tracked_head_commit=tracked,
+                total_changed_files=0,
+                added_count=0,
+                modified_count=0,
+                removed_count=0,
+                renamed_count=0,
+                files_truncated=False,
+                changed_files=(),
+            )
+
+        owner, repo = self._parse_github_connection_config(data_source.connection_config)
+        credentials: dict[str, str] = {}
+        if data_source.credentials_path:
+            try:
+                credentials = await self._credential_reader.retrieve(
+                    path=data_source.credentials_path,
+                    tenant_id=self._tenant_id,
+                )
+            except KeyError:
+                credentials = {}
+
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        token = credentials.get("token") or credentials.get("access_token")
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+        url = f"https://api.github.com/repos/{owner}/{repo}/compare/{baseline}...{tracked}"
+        client = self._http_client or httpx.AsyncClient(timeout=30.0)
+        try:
+            response = await client.get(url, headers=headers)
+            response.raise_for_status()
+            payload = response.json()
+        finally:
+            if self._http_client is None:
+                await client.aclose()
+
+        files: list[dict[str, str]] = []
+        counts = {"added": 0, "modified": 0, "removed": 0, "renamed": 0}
+        for file in payload.get("files", []):
+            status = str(file.get("status", "modified"))
+            if status in counts:
+                counts[status] += 1
+            files.append(
+                {
+                    "path": str(file.get("filename", "")),
+                    "status": status,
+                }
+            )
+
+        files_truncated = len(files) > max_files
+        visible_files = tuple(files[:max_files])
+        return DiffSummaryResult(
+            baseline_commit=baseline,
+            tracked_head_commit=tracked,
+            total_changed_files=len(files),
+            added_count=counts["added"],
+            modified_count=counts["modified"],
+            removed_count=counts["removed"],
+            renamed_count=counts["renamed"],
+            files_truncated=files_truncated,
+            changed_files=visible_files,
+        )
+

--- a/src/api/management/presentation/data_sources/models.py
+++ b/src/api/management/presentation/data_sources/models.py
@@ -245,6 +245,42 @@ class SyncRunLogsResponse(BaseModel):
     )
 
 
+class DiffChangedFileResponse(BaseModel):
+    """Single changed file entry in a commit diff summary."""
+
+    path: str = Field(..., description="Repository-relative file path")
+    status: str = Field(
+        ...,
+        description="GitHub compare status (added, modified, removed, renamed, ...)",
+    )
+
+
+class DataSourceDiffSummaryResponse(BaseModel):
+    """Response model for baseline-vs-tracked commit diff summary."""
+
+    baseline_commit: str | None = Field(
+        None,
+        description="Commit baseline used for the previous extraction",
+    )
+    tracked_head_commit: str | None = Field(
+        None,
+        description="Latest tracked branch head commit used for comparison",
+    )
+    total_changed_files: int = Field(..., description="Total changed files in compare")
+    added_count: int = Field(..., description="Number of files added")
+    modified_count: int = Field(..., description="Number of files modified")
+    removed_count: int = Field(..., description="Number of files removed")
+    renamed_count: int = Field(..., description="Number of files renamed")
+    files_truncated: bool = Field(
+        ...,
+        description="True when changed_files is truncated by max_files",
+    )
+    changed_files: list[DiffChangedFileResponse] = Field(
+        default_factory=list,
+        description="Changed-file entries, bounded by max_files",
+    )
+
+
 class SyncRunResponse(BaseModel):
     """Response model for a data source sync run."""
 

--- a/src/api/management/presentation/data_sources/routes.py
+++ b/src/api/management/presentation/data_sources/routes.py
@@ -4,19 +4,22 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from iam.application.value_objects import CurrentUser
 from iam.dependencies.user import get_current_user
 from management.application.services.data_source_service import DataSourceService
 from management.dependencies.data_source import (
     get_data_source_service,
+    get_git_diff_summary_service,
     get_sync_run_repository,
 )
+from management.infrastructure.git_diff_summary_service import GitDiffSummaryService
 from management.ports.exceptions import UnauthorizedError
 from management.ports.repositories import IDataSourceSyncRunRepository
 from management.presentation.data_sources.models import (
     CreateDataSourceRequest,
+    DataSourceDiffSummaryResponse,
     DataSourceListResponse,
     DataSourceResponse,
     DataSourceWithSyncResponse,
@@ -27,6 +30,56 @@ from management.presentation.data_sources.models import (
 from shared_kernel.datasource_types import DataSourceAdapterType
 
 router = APIRouter(tags=["data-sources"])
+
+
+@router.get(
+    "/data-sources/{ds_id}/diff-summary",
+    status_code=status.HTTP_200_OK,
+    summary="Get commit diff summary for a data source",
+)
+async def get_diff_summary(
+    ds_id: str,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    service: Annotated[DataSourceService, Depends(get_data_source_service)],
+    diff_service: Annotated[
+        GitDiffSummaryService, Depends(get_git_diff_summary_service)
+    ],
+    max_files: int = Query(default=200, ge=1, le=2000),
+) -> DataSourceDiffSummaryResponse:
+    """Return baseline-vs-tracked diff summary for maintenance readiness cues."""
+    try:
+        ds = await service.get(
+            user_id=current_user.user_id.value,
+            ds_id=ds_id,
+        )
+        if ds is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Data source not found",
+            )
+
+        summary = await diff_service.build_summary(
+            data_source=ds,
+            max_files=max_files,
+        )
+        return DataSourceDiffSummaryResponse(
+            baseline_commit=summary.baseline_commit,
+            tracked_head_commit=summary.tracked_head_commit,
+            total_changed_files=summary.total_changed_files,
+            added_count=summary.added_count,
+            modified_count=summary.modified_count,
+            removed_count=summary.removed_count,
+            renamed_count=summary.renamed_count,
+            files_truncated=summary.files_truncated,
+            changed_files=list(summary.changed_files),
+        )
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to build diff summary",
+        )
 
 
 @router.get(

--- a/src/api/tests/unit/management/infrastructure/test_git_diff_summary_service.py
+++ b/src/api/tests/unit/management/infrastructure/test_git_diff_summary_service.py
@@ -1,0 +1,95 @@
+"""Unit tests for GitDiffSummaryService."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+
+from management.domain.aggregates import DataSource
+from management.domain.value_objects import DataSourceId, Schedule, ScheduleType
+from management.infrastructure.git_diff_summary_service import GitDiffSummaryService
+from shared_kernel.datasource_types import DataSourceAdapterType
+
+
+class _FakeCredentialReader:
+    def __init__(self, credentials: dict[str, str] | None = None) -> None:
+        self._credentials = credentials or {}
+
+    async def retrieve(self, path: str, tenant_id: str) -> dict[str, str]:
+        return dict(self._credentials)
+
+
+def _make_data_source(
+    *,
+    baseline: str | None = "aaaa",
+    tracked: str | None = "bbbb",
+) -> DataSource:
+    now = datetime.now(UTC)
+    return DataSource(
+        id=DataSourceId(value="01JTESTDIFFSUMMARYSOURCE000"),
+        knowledge_graph_id="01JTESTDIFFSUMMARYKG0000000",
+        tenant_id="tenant-001",
+        name="GitHub DS",
+        adapter_type=DataSourceAdapterType.GITHUB,
+        connection_config={"owner": "org", "repo": "repo", "branch": "main"},
+        credentials_path=None,
+        schedule=Schedule(schedule_type=ScheduleType.MANUAL),
+        last_sync_at=None,
+        created_at=now,
+        updated_at=now,
+        last_extraction_baseline_commit=baseline,
+        tracked_branch_head_commit=tracked,
+    )
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_summary_when_commits_missing():
+    """Missing baseline/tracked refs should produce an empty summary."""
+    service = GitDiffSummaryService(
+        credential_reader=_FakeCredentialReader(),
+        tenant_id="tenant-001",
+    )
+    ds = _make_data_source(baseline=None, tracked="bbbb")
+
+    result = await service.build_summary(data_source=ds, max_files=50)
+
+    assert result.total_changed_files == 0
+    assert result.changed_files == ()
+
+
+@pytest.mark.asyncio
+async def test_truncates_changed_files_when_max_exceeded():
+    """Changed-file list should truncate safely for large diffs."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert "compare" in str(request.url)
+        return httpx.Response(
+            status_code=200,
+            json={
+                "files": [
+                    {"filename": "a.py", "status": "added"},
+                    {"filename": "b.py", "status": "modified"},
+                    {"filename": "c.py", "status": "removed"},
+                ]
+            },
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    service = GitDiffSummaryService(
+        credential_reader=_FakeCredentialReader(),
+        tenant_id="tenant-001",
+        http_client=client,
+    )
+
+    result = await service.build_summary(data_source=_make_data_source(), max_files=2)
+    await client.aclose()
+
+    assert result.total_changed_files == 3
+    assert result.files_truncated is True
+    assert len(result.changed_files) == 2
+    assert result.added_count == 1
+    assert result.modified_count == 1
+    assert result.removed_count == 1
+

--- a/src/api/tests/unit/management/presentation/test_data_sources_routes.py
+++ b/src/api/tests/unit/management/presentation/test_data_sources_routes.py
@@ -18,6 +18,7 @@ from iam.domain.value_objects import TenantId, UserId
 from management.application.services.data_source_service import DataSourceService
 from management.domain.aggregates import DataSource
 from management.domain.entities import DataSourceSyncRun
+from management.infrastructure.git_diff_summary_service import DiffSummaryResult
 from management.domain.value_objects import (
     DataSourceId,
     Ontology,
@@ -41,6 +42,12 @@ def mock_ds_service() -> AsyncMock:
 def mock_sync_run_repo() -> AsyncMock:
     """Mock DataSourceSyncRunRepository for testing."""
     return AsyncMock(spec=IDataSourceSyncRunRepository)
+
+
+@pytest.fixture
+def mock_diff_summary_service() -> AsyncMock:
+    """Mock GitDiffSummaryService for diff-summary route testing."""
+    return AsyncMock()
 
 
 @pytest.fixture
@@ -94,12 +101,14 @@ def sample_sync_run(sample_data_source: DataSource) -> DataSourceSyncRun:
 def test_client(
     mock_ds_service: AsyncMock,
     mock_sync_run_repo: AsyncMock,
+    mock_diff_summary_service: AsyncMock,
     mock_current_user: CurrentUser,
 ) -> TestClient:
     """Create TestClient with mocked dependencies."""
     from iam.dependencies.user import get_current_user
     from management.dependencies.data_source import (
         get_data_source_service,
+        get_git_diff_summary_service,
         get_sync_run_repository,
     )
     from management.presentation import router
@@ -108,6 +117,9 @@ def test_client(
 
     app.dependency_overrides[get_data_source_service] = lambda: mock_ds_service
     app.dependency_overrides[get_sync_run_repository] = lambda: mock_sync_run_repo
+    app.dependency_overrides[get_git_diff_summary_service] = (
+        lambda: mock_diff_summary_service
+    )
     app.dependency_overrides[get_current_user] = lambda: mock_current_user
 
     app.include_router(router)
@@ -726,6 +738,62 @@ class TestListAllDataSourcesRoute:
         mock_ds_service.list_all_for_user.assert_called_once_with(
             user_id=mock_current_user.user_id.value
         )
+
+
+class TestDataSourceDiffSummaryRoute:
+    """Tests for GET /management/data-sources/{ds_id}/diff-summary endpoint."""
+
+    def test_diff_summary_returns_counts_and_changed_files(
+        self,
+        test_client: TestClient,
+        mock_ds_service: AsyncMock,
+        mock_diff_summary_service: AsyncMock,
+        sample_data_source: DataSource,
+    ) -> None:
+        """Diff summary should include aggregate counts + changed file list."""
+        mock_ds_service.get.return_value = sample_data_source
+        mock_diff_summary_service.build_summary.return_value = DiffSummaryResult(
+            baseline_commit="abc",
+            tracked_head_commit="def",
+            total_changed_files=2,
+            added_count=1,
+            modified_count=1,
+            removed_count=0,
+            renamed_count=0,
+            files_truncated=False,
+            changed_files=(
+                {"path": "src/a.py", "status": "added"},
+                {"path": "src/b.py", "status": "modified"},
+            ),
+        )
+
+        response = test_client.get(
+            f"/management/data-sources/{sample_data_source.id.value}/diff-summary"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        payload = response.json()
+        assert payload["total_changed_files"] == 2
+        assert payload["added_count"] == 1
+        assert payload["modified_count"] == 1
+        assert payload["files_truncated"] is False
+        assert payload["changed_files"][0]["path"] == "src/a.py"
+
+    def test_diff_summary_returns_404_when_data_source_inaccessible(
+        self,
+        test_client: TestClient,
+        mock_ds_service: AsyncMock,
+        mock_diff_summary_service: AsyncMock,
+    ) -> None:
+        """Diff summary route should return 404 when DS is not found/authorized."""
+        mock_ds_service.get.return_value = None
+
+        response = test_client.get(
+            "/management/data-sources/01JPQRST1234567890ABCDEFDS/diff-summary"
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        mock_diff_summary_service.build_summary.assert_not_called()
 
 
 class TestUpdateDataSourceRoute:


### PR DESCRIPTION
## Summary
- add `GitDiffSummaryService` to compare tracked branch head against last extraction baseline for GitHub-backed data sources
- expose `GET /management/data-sources/{ds_id}/diff-summary` returning aggregate change counts plus a bounded changed-file list
- enforce large-list-safe behavior via `max_files` truncation and a `files_truncated` indicator for UI progressive disclosure

## Testing
- [x] `uv run pytest tests/unit/management/infrastructure/test_git_diff_summary_service.py tests/unit/management/presentation/test_data_sources_routes.py -q`
- [x] `uv run pytest tests/unit/management/test_architecture.py tests/unit/management/infrastructure/test_sync_lifecycle_handler.py -q`

## Risks
- currently implemented for GitHub-backed sources; non-Git/non-GitHub sources return an empty summary until adapter-specific compare strategies are added

Closes #662

Made with [Cursor](https://cursor.com)