### PR TITLE
feat(management): add source commit refresh actions (#675)

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -153,7 +153,7 @@ class _SessionedIngestionEventHandler:
             repo = path_parts[1].removesuffix(".git")
             branch = config.get("branch", "main")
             if len(path_parts) >= 4 and path_parts[2] == "tree":
-                branch = path_parts[3]
+                branch = "/".join(path_parts[3:])
             return owner, repo, branch
 
         if "owner" in config and "repo" in config:

--- a/src/api/management/application/services/data_source_service.py
+++ b/src/api/management/application/services/data_source_service.py
@@ -455,6 +455,86 @@ class DataSourceService:
 
         return ds
 
+    async def refresh_commit_references(
+        self,
+        user_id: str,
+        ds_id: str,
+        tracked_branch_head_commit: str,
+        clone_head_commit: str | None = None,
+    ) -> DataSource:
+        """Persist refreshed source commit references for a data source.
+
+        Requires MANAGE permission on the data source. This action updates
+        tracked and clone commit references and initializes extraction baseline
+        on first refresh so per-source diff counts can be computed immediately.
+        """
+        has_manage = await self._check_permission(
+            user_id=user_id,
+            resource_type=ResourceType.DATA_SOURCE,
+            resource_id=ds_id,
+            permission=Permission.MANAGE,
+        )
+        if not has_manage:
+            self._probe.permission_denied(
+                user_id=user_id,
+                resource_id=ds_id,
+                permission=Permission.MANAGE,
+            )
+            raise UnauthorizedError(
+                f"User {user_id} lacks manage permission on data source {ds_id}"
+            )
+
+        ds = await self._ds_repo.get_by_id(DataSourceId(value=ds_id))
+        if ds is None or ds.tenant_id != self._scope_to_tenant:
+            raise ValueError(f"Data source {ds_id} not found")
+
+        resolved_clone_head = clone_head_commit or tracked_branch_head_commit
+        ds.tracked_branch_head_commit = tracked_branch_head_commit
+        ds.clone_head_commit = resolved_clone_head
+        if ds.last_extraction_baseline_commit is None:
+            ds.last_extraction_baseline_commit = tracked_branch_head_commit
+
+        await self._ds_repo.save(ds)
+        await self._session.commit()
+        self._probe.data_source_updated(ds_id=ds_id, name=ds.name)
+        return ds
+
+    async def adopt_tracked_head_as_baseline(
+        self,
+        user_id: str,
+        ds_id: str,
+    ) -> DataSource:
+        """Move extraction baseline to the currently tracked branch head."""
+        has_manage = await self._check_permission(
+            user_id=user_id,
+            resource_type=ResourceType.DATA_SOURCE,
+            resource_id=ds_id,
+            permission=Permission.MANAGE,
+        )
+        if not has_manage:
+            self._probe.permission_denied(
+                user_id=user_id,
+                resource_id=ds_id,
+                permission=Permission.MANAGE,
+            )
+            raise UnauthorizedError(
+                f"User {user_id} lacks manage permission on data source {ds_id}"
+            )
+
+        ds = await self._ds_repo.get_by_id(DataSourceId(value=ds_id))
+        if ds is None or ds.tenant_id != self._scope_to_tenant:
+            raise ValueError(f"Data source {ds_id} not found")
+        if not ds.tracked_branch_head_commit:
+            raise ValueError(
+                "Cannot adopt tracked branch head as baseline before refs are refreshed"
+            )
+
+        ds.last_extraction_baseline_commit = ds.tracked_branch_head_commit
+        await self._ds_repo.save(ds)
+        await self._session.commit()
+        self._probe.data_source_updated(ds_id=ds_id, name=ds.name)
+        return ds
+
     async def delete(
         self,
         user_id: str,

--- a/src/api/management/dependencies/data_source.py
+++ b/src/api/management/dependencies/data_source.py
@@ -17,6 +17,9 @@ from infrastructure.outbox.repository import OutboxRepository
 from infrastructure.settings import get_management_settings
 from management.application.observability import DefaultDataSourceServiceProbe
 from management.application.services.data_source_service import DataSourceService
+from management.infrastructure.git_commit_reference_service import (
+    GitCommitReferenceService,
+)
 from management.infrastructure.git_diff_summary_service import GitDiffSummaryService
 from management.infrastructure.repositories import (
     DataSourceRepository,
@@ -93,6 +96,23 @@ def get_git_diff_summary_service(
         encryption_keys=encryption_keys,
     )
     return GitDiffSummaryService(
+        credential_reader=secret_store,
+        tenant_id=current_user.tenant_id.value,
+    )
+
+
+def get_git_commit_reference_service(
+    session: Annotated[AsyncSession, Depends(get_write_session)],
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+) -> GitCommitReferenceService:
+    """Get GitCommitReferenceService for tracked-head refresh actions."""
+    settings = get_management_settings()
+    encryption_keys = settings.encryption_key.get_secret_value().split(",")
+    secret_store = FernetSecretStore(
+        session=session,
+        encryption_keys=encryption_keys,
+    )
+    return GitCommitReferenceService(
         credential_reader=secret_store,
         tenant_id=current_user.tenant_id.value,
     )

--- a/src/api/management/infrastructure/git_commit_reference_service.py
+++ b/src/api/management/infrastructure/git_commit_reference_service.py
@@ -1,0 +1,89 @@
+"""Resolve remote commit references for Git-backed data sources."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+import httpx
+
+from management.domain.aggregates import DataSource
+from shared_kernel.credential_reader import ICredentialReader
+from shared_kernel.datasource_types import DataSourceAdapterType
+
+
+class GitCommitReferenceService:
+    """Fetch tracked branch HEAD commit metadata from remote Git providers."""
+
+    def __init__(
+        self,
+        credential_reader: ICredentialReader,
+        tenant_id: str,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._credential_reader = credential_reader
+        self._tenant_id = tenant_id
+        self._http_client = http_client
+
+    @staticmethod
+    def _parse_github_connection_config(
+        config: dict[str, str],
+    ) -> tuple[str, str, str]:
+        """Parse GitHub connection settings into owner/repo/branch."""
+        if "repo_url" in config:
+            parsed = urlparse(config["repo_url"])
+            path_parts = [part for part in parsed.path.split("/") if part]
+            if len(path_parts) < 2:
+                raise ValueError("repo_url must include owner and repo")
+            owner = path_parts[0]
+            repo = path_parts[1].removesuffix(".git")
+            branch = config.get("branch", "main")
+            if len(path_parts) >= 4 and path_parts[2] == "tree":
+                branch = "/".join(path_parts[3:])
+            return owner, repo, branch
+
+        if "owner" in config and "repo" in config:
+            return config["owner"], config["repo"], config.get("branch", "main")
+
+        raise ValueError(
+            "connection_config must include either 'repo_url' or 'owner'+'repo' keys"
+        )
+
+    async def resolve_tracked_head_commit(self, data_source: DataSource) -> str | None:
+        """Resolve tracked branch HEAD commit for GitHub data sources."""
+        if data_source.adapter_type != DataSourceAdapterType.GITHUB:
+            return None
+
+        owner, repo, branch = self._parse_github_connection_config(
+            data_source.connection_config
+        )
+
+        credentials: dict[str, str] = {}
+        if data_source.credentials_path:
+            try:
+                credentials = await self._credential_reader.retrieve(
+                    path=data_source.credentials_path,
+                    tenant_id=self._tenant_id,
+                )
+            except KeyError:
+                credentials = {}
+
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        token = credentials.get("token") or credentials.get("access_token")
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+        url = f"https://api.github.com/repos/{owner}/{repo}/branches/{branch}"
+        client = self._http_client or httpx.AsyncClient(timeout=20.0)
+        try:
+            response = await client.get(url, headers=headers)
+            response.raise_for_status()
+            payload = response.json()
+        finally:
+            if self._http_client is None:
+                await client.aclose()
+
+        sha = payload.get("commit", {}).get("sha")
+        return str(sha) if sha else None

--- a/src/api/management/presentation/data_sources/routes.py
+++ b/src/api/management/presentation/data_sources/routes.py
@@ -11,8 +11,12 @@ from iam.dependencies.user import get_current_user
 from management.application.services.data_source_service import DataSourceService
 from management.dependencies.data_source import (
     get_data_source_service,
+    get_git_commit_reference_service,
     get_git_diff_summary_service,
     get_sync_run_repository,
+)
+from management.infrastructure.git_commit_reference_service import (
+    GitCommitReferenceService,
 )
 from management.infrastructure.git_diff_summary_service import GitDiffSummaryService
 from management.ports.exceptions import UnauthorizedError
@@ -30,6 +34,101 @@ from management.presentation.data_sources.models import (
 from shared_kernel.datasource_types import DataSourceAdapterType
 
 router = APIRouter(tags=["data-sources"])
+
+
+@router.post(
+    "/data-sources/{ds_id}/commit-refs/refresh",
+    status_code=status.HTTP_200_OK,
+    summary="Refresh source commit references for a data source",
+)
+async def refresh_commit_references(
+    ds_id: str,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    service: Annotated[DataSourceService, Depends(get_data_source_service)],
+    commit_ref_service: Annotated[
+        GitCommitReferenceService, Depends(get_git_commit_reference_service)
+    ],
+) -> DataSourceResponse:
+    """Refresh tracked/cloned commit references for a Git-backed data source."""
+    try:
+        ds = await service.get(
+            user_id=current_user.user_id.value,
+            ds_id=ds_id,
+        )
+        if ds is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Data source not found",
+            )
+
+        tracked_head = await commit_ref_service.resolve_tracked_head_commit(ds)
+        if tracked_head is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Unable to resolve tracked branch head commit for this data source",
+            )
+
+        updated = await service.refresh_commit_references(
+            user_id=current_user.user_id.value,
+            ds_id=ds_id,
+            tracked_branch_head_commit=tracked_head,
+            clone_head_commit=tracked_head,
+        )
+        return DataSourceResponse.from_domain(updated)
+    except UnauthorizedError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to perform this action",
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        )
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to refresh commit references",
+        )
+
+
+@router.post(
+    "/data-sources/{ds_id}/commit-refs/adopt-tracked-head",
+    status_code=status.HTTP_200_OK,
+    summary="Adopt tracked branch head as extraction baseline",
+)
+async def adopt_tracked_head_as_baseline(
+    ds_id: str,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    service: Annotated[DataSourceService, Depends(get_data_source_service)],
+) -> DataSourceResponse:
+    """Set extraction baseline commit to the current tracked branch head."""
+    try:
+        updated = await service.adopt_tracked_head_as_baseline(
+            user_id=current_user.user_id.value,
+            ds_id=ds_id,
+        )
+        return DataSourceResponse.from_domain(updated)
+    except UnauthorizedError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to perform this action",
+        )
+    except ValueError as e:
+        detail = str(e)
+        status_code = (
+            status.HTTP_422_UNPROCESSABLE_ENTITY
+            if "tracked branch head" in detail
+            else status.HTTP_404_NOT_FOUND
+        )
+        raise HTTPException(status_code=status_code, detail=detail)
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to adopt tracked head as baseline",
+        )
 
 
 @router.get(

--- a/src/api/tests/unit/management/application/test_data_source_service.py
+++ b/src/api/tests/unit/management/application/test_data_source_service.py
@@ -1030,6 +1030,107 @@ class TestDataSourceServiceTriggerSync:
         assert ds_probe.sync_requested_calls[0]["ds_id"] == ds.id.value
 
 
+class TestDataSourceServiceCommitReferenceActions:
+    """Tests for commit reference refresh/baseline actions."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_commit_references_requires_manage_permission(
+        self, service, authz, ds_repo, user_id
+    ) -> None:
+        """refresh_commit_references() must check MANAGE permission."""
+        ds = _make_ds()
+        ds_repo.seed(ds)
+        authz.grant_all()
+
+        await service.refresh_commit_references(
+            user_id=user_id,
+            ds_id=ds.id.value,
+            tracked_branch_head_commit="abc123",
+            clone_head_commit="abc123",
+        )
+
+        authz.assert_check_called_once(
+            resource=f"data_source:{ds.id.value}",
+            permission=Permission.MANAGE,
+            subject=f"user:{user_id}",
+        )
+
+    @pytest.mark.asyncio
+    async def test_refresh_commit_references_initializes_baseline_when_empty(
+        self, service, authz, ds_repo, user_id
+    ) -> None:
+        """First commit-refresh should initialize extraction baseline."""
+        ds = _make_ds()
+        ds.last_extraction_baseline_commit = None
+        ds_repo.seed(ds)
+        authz.grant_all()
+
+        updated = await service.refresh_commit_references(
+            user_id=user_id,
+            ds_id=ds.id.value,
+            tracked_branch_head_commit="abc123",
+            clone_head_commit="abc123",
+        )
+
+        assert updated.tracked_branch_head_commit == "abc123"
+        assert updated.clone_head_commit == "abc123"
+        assert updated.last_extraction_baseline_commit == "abc123"
+
+    @pytest.mark.asyncio
+    async def test_refresh_commit_references_preserves_existing_baseline(
+        self, service, authz, ds_repo, user_id
+    ) -> None:
+        """Refresh should not overwrite an existing extraction baseline."""
+        ds = _make_ds()
+        ds.last_extraction_baseline_commit = "baseline000"
+        ds_repo.seed(ds)
+        authz.grant_all()
+
+        updated = await service.refresh_commit_references(
+            user_id=user_id,
+            ds_id=ds.id.value,
+            tracked_branch_head_commit="tracked999",
+            clone_head_commit="tracked999",
+        )
+
+        assert updated.last_extraction_baseline_commit == "baseline000"
+        assert updated.tracked_branch_head_commit == "tracked999"
+
+    @pytest.mark.asyncio
+    async def test_adopt_tracked_head_as_baseline_updates_baseline(
+        self, service, authz, ds_repo, user_id
+    ) -> None:
+        """adopt_tracked_head_as_baseline() should copy tracked head to baseline."""
+        ds = _make_ds()
+        ds.last_extraction_baseline_commit = "old-base"
+        ds.tracked_branch_head_commit = "new-head"
+        ds_repo.seed(ds)
+        authz.grant_all()
+
+        updated = await service.adopt_tracked_head_as_baseline(
+            user_id=user_id,
+            ds_id=ds.id.value,
+        )
+
+        assert updated.last_extraction_baseline_commit == "new-head"
+
+    @pytest.mark.asyncio
+    async def test_adopt_tracked_head_as_baseline_requires_tracked_head(
+        self, service, authz, ds_repo, user_id
+    ) -> None:
+        """adopt_tracked_head_as_baseline() should reject when tracked head missing."""
+        ds = _make_ds()
+        ds.tracked_branch_head_commit = None
+        ds_repo.seed(ds)
+        authz.grant_all()
+
+        with pytest.raises(ValueError, match="tracked branch head"):
+            await service.adopt_tracked_head_as_baseline(
+                user_id=user_id,
+                ds_id=ds.id.value,
+            )
+
+
 class TestDataSourceServiceListAllForUser:
     """Unit tests for DataSourceService.list_all_for_user."""
 

--- a/src/api/tests/unit/management/infrastructure/test_git_commit_reference_service.py
+++ b/src/api/tests/unit/management/infrastructure/test_git_commit_reference_service.py
@@ -1,0 +1,109 @@
+"""Unit tests for GitCommitReferenceService."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+
+from management.domain.aggregates import DataSource
+from management.domain.value_objects import DataSourceId, Schedule, ScheduleType
+from management.infrastructure.git_commit_reference_service import (
+    GitCommitReferenceService,
+)
+from shared_kernel.datasource_types import DataSourceAdapterType
+
+
+class _FakeCredentialReader:
+    def __init__(self, credentials: dict[str, str] | None = None) -> None:
+        self._credentials = credentials or {}
+
+    async def retrieve(self, path: str, tenant_id: str) -> dict[str, str]:
+        return dict(self._credentials)
+
+
+def _make_data_source(
+    *,
+    adapter_type: DataSourceAdapterType = DataSourceAdapterType.GITHUB,
+    connection_config: dict[str, str] | None = None,
+    credentials_path: str | None = None,
+) -> DataSource:
+    now = datetime.now(UTC)
+    return DataSource(
+        id=DataSourceId(value="01JTESTCOMMITREFSERVICE0000"),
+        knowledge_graph_id="01JTESTCOMMITREFKG0000000",
+        tenant_id="tenant-001",
+        name="GitHub DS",
+        adapter_type=adapter_type,
+        connection_config=connection_config
+        or {"owner": "org", "repo": "repo", "branch": "main"},
+        credentials_path=credentials_path,
+        schedule=Schedule(schedule_type=ScheduleType.MANUAL),
+        last_sync_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def test_parse_github_config_rejects_invalid_repo_url() -> None:
+    """Malformed GitHub repo URL should raise a clear error."""
+    with pytest.raises(ValueError, match="owner and repo"):
+        GitCommitReferenceService._parse_github_connection_config(
+            {"repo_url": "https://github.com/owner-only"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_resolve_tracked_head_uses_branches_endpoint_with_token() -> None:
+    """Service should call GitHub branches API with PAT when available."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert str(request.url) == "https://api.github.com/repos/org/repo/branches/main"
+        assert request.headers.get("Authorization") == "Bearer secret-token"
+        return httpx.Response(
+            status_code=200,
+            json={"commit": {"sha": "abc123"}},
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    service = GitCommitReferenceService(
+        credential_reader=_FakeCredentialReader({"access_token": "secret-token"}),
+        tenant_id="tenant-001",
+        http_client=client,
+    )
+    ds = _make_data_source(credentials_path="datasource/ds-1/credentials")
+
+    tracked = await service.resolve_tracked_head_commit(ds)
+    await client.aclose()
+
+    assert tracked == "abc123"
+
+
+@pytest.mark.asyncio
+async def test_resolve_tracked_head_parses_repo_url_branch() -> None:
+    """repo_url tree syntax should map to owner/repo/branch correctly."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert (
+            str(request.url)
+            == "https://api.github.com/repos/openshift-hyperfleet/kartograph/branches/feature/test"
+        )
+        return httpx.Response(status_code=200, json={"commit": {"sha": "head987"}})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    service = GitCommitReferenceService(
+        credential_reader=_FakeCredentialReader(),
+        tenant_id="tenant-001",
+        http_client=client,
+    )
+    ds = _make_data_source(
+        connection_config={
+            "repo_url": "https://github.com/openshift-hyperfleet/kartograph/tree/feature/test"
+        }
+    )
+
+    tracked = await service.resolve_tracked_head_commit(ds)
+    await client.aclose()
+
+    assert tracked == "head987"

--- a/src/api/tests/unit/management/presentation/test_data_sources_routes.py
+++ b/src/api/tests/unit/management/presentation/test_data_sources_routes.py
@@ -51,6 +51,12 @@ def mock_diff_summary_service() -> AsyncMock:
 
 
 @pytest.fixture
+def mock_commit_reference_service() -> AsyncMock:
+    """Mock GitCommitReferenceService for commit-ref route testing."""
+    return AsyncMock()
+
+
+@pytest.fixture
 def mock_current_user() -> CurrentUser:
     """Mock CurrentUser for authentication."""
     return CurrentUser(
@@ -102,12 +108,14 @@ def test_client(
     mock_ds_service: AsyncMock,
     mock_sync_run_repo: AsyncMock,
     mock_diff_summary_service: AsyncMock,
+    mock_commit_reference_service: AsyncMock,
     mock_current_user: CurrentUser,
 ) -> TestClient:
     """Create TestClient with mocked dependencies."""
     from iam.dependencies.user import get_current_user
     from management.dependencies.data_source import (
         get_data_source_service,
+        get_git_commit_reference_service,
         get_git_diff_summary_service,
         get_sync_run_repository,
     )
@@ -119,6 +127,9 @@ def test_client(
     app.dependency_overrides[get_sync_run_repository] = lambda: mock_sync_run_repo
     app.dependency_overrides[get_git_diff_summary_service] = (
         lambda: mock_diff_summary_service
+    )
+    app.dependency_overrides[get_git_commit_reference_service] = (
+        lambda: mock_commit_reference_service
     )
     app.dependency_overrides[get_current_user] = lambda: mock_current_user
 
@@ -794,6 +805,90 @@ class TestDataSourceDiffSummaryRoute:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         mock_diff_summary_service.build_summary.assert_not_called()
+
+
+class TestDataSourceCommitReferenceRoutes:
+    """Tests for commit-reference refresh/baseline endpoints."""
+
+    def test_refresh_commit_references_returns_updated_data_source(
+        self,
+        test_client: TestClient,
+        mock_ds_service: AsyncMock,
+        mock_commit_reference_service: AsyncMock,
+        sample_data_source: DataSource,
+    ) -> None:
+        """Refresh endpoint should return updated commit references."""
+        refreshed = sample_data_source
+        refreshed.clone_head_commit = "aaa"
+        refreshed.tracked_branch_head_commit = "aaa"
+        refreshed.last_extraction_baseline_commit = "aaa"
+        mock_ds_service.get.return_value = sample_data_source
+        mock_commit_reference_service.resolve_tracked_head_commit.return_value = "aaa"
+        mock_ds_service.refresh_commit_references.return_value = refreshed
+
+        response = test_client.post(
+            f"/management/data-sources/{sample_data_source.id.value}/commit-refs/refresh"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        payload = response.json()
+        assert payload["clone_head_commit"] == "aaa"
+        assert payload["tracked_branch_head_commit"] == "aaa"
+        assert payload["last_extraction_baseline_commit"] == "aaa"
+
+    def test_refresh_commit_references_returns_404_when_inaccessible(
+        self,
+        test_client: TestClient,
+        mock_ds_service: AsyncMock,
+        mock_commit_reference_service: AsyncMock,
+    ) -> None:
+        """Refresh endpoint should return 404 if DS not found/authorized."""
+        mock_ds_service.get.return_value = None
+
+        response = test_client.post(
+            "/management/data-sources/01JPQRST1234567890ABCDEFDS/commit-refs/refresh"
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        mock_ds_service.refresh_commit_references.assert_not_called()
+        mock_commit_reference_service.resolve_tracked_head_commit.assert_not_called()
+
+    def test_adopt_tracked_head_as_baseline_returns_updated_data_source(
+        self,
+        test_client: TestClient,
+        mock_ds_service: AsyncMock,
+        sample_data_source: DataSource,
+    ) -> None:
+        """Adopt endpoint should return DS with baseline moved to tracked head."""
+        updated = sample_data_source
+        updated.last_extraction_baseline_commit = "tracked-head"
+        updated.tracked_branch_head_commit = "tracked-head"
+        mock_ds_service.adopt_tracked_head_as_baseline.return_value = updated
+
+        response = test_client.post(
+            f"/management/data-sources/{sample_data_source.id.value}/commit-refs/adopt-tracked-head"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        payload = response.json()
+        assert payload["last_extraction_baseline_commit"] == "tracked-head"
+
+    def test_adopt_tracked_head_as_baseline_returns_404_for_missing_source(
+        self,
+        test_client: TestClient,
+        mock_ds_service: AsyncMock,
+        sample_data_source: DataSource,
+    ) -> None:
+        """Adopt endpoint should return 404 if service reports missing DS."""
+        mock_ds_service.adopt_tracked_head_as_baseline.side_effect = ValueError(
+            "Data source not found"
+        )
+
+        response = test_client.post(
+            f"/management/data-sources/{sample_data_source.id.value}/commit-refs/adopt-tracked-head"
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 class TestUpdateDataSourceRoute:

--- a/src/dev-ui/app/pages/data-sources/index.vue
+++ b/src/dev-ui/app/pages/data-sources/index.vue
@@ -22,6 +22,7 @@ import {
   ScrollText,
   FileText,
   Settings,
+  RefreshCw,
 } from 'lucide-vue-next'
 import {
   ADAPTERS,
@@ -617,6 +618,8 @@ async function approveOntology() {
 const dataSources = ref<DataSourceItem[]>([])
 const loadingDataSources = ref(false)
 const expandedDiffLists = ref<Record<string, boolean>>({})
+const refreshingCommitRefs = ref<Record<string, boolean>>({})
+const adoptingBaselines = ref<Record<string, boolean>>({})
 
 function isMaintenanceReady(ds: DataSourceItem): boolean {
   if (!ds.last_extraction_baseline_commit || !ds.tracked_branch_head_commit) return false
@@ -629,6 +632,39 @@ function isDiffExpanded(dsId: string): boolean {
 
 function toggleDiffExpanded(dsId: string) {
   expandedDiffLists.value[dsId] = !isDiffExpanded(dsId)
+}
+
+async function refreshCommitRefs(dsId: string) {
+  refreshingCommitRefs.value[dsId] = true
+  try {
+    const { apiFetch } = useApiClient()
+    await apiFetch(`/management/data-sources/${dsId}/commit-refs/refresh`, {
+      method: 'POST',
+    })
+    toast.success('Commit references refreshed')
+    await loadDataSources()
+  } catch {
+    toast.error('Failed to refresh commit references')
+  } finally {
+    refreshingCommitRefs.value[dsId] = false
+  }
+}
+
+async function adoptTrackedHeadBaseline(dsId: string) {
+  adoptingBaselines.value[dsId] = true
+  try {
+    const { apiFetch } = useApiClient()
+    await apiFetch(`/management/data-sources/${dsId}/commit-refs/adopt-tracked-head`, {
+      method: 'POST',
+    })
+    toast.success('Baseline updated to tracked head')
+    await loadDataSources()
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to update baseline'
+    toast.error('Failed to update baseline', { description: msg })
+  } finally {
+    adoptingBaselines.value[dsId] = false
+  }
 }
 
 async function loadDataSources() {
@@ -1198,6 +1234,30 @@ async function handleDeleteDs() {
                 <p class="text-[10px] uppercase tracking-wider text-muted-foreground">Tracked branch head commit</p>
                 <p class="mt-1 font-mono text-xs break-all">{{ ds.tracked_branch_head_commit ?? '—' }}</p>
               </div>
+            </div>
+            <div class="mt-2 flex flex-wrap gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                class="h-7 text-[10px]"
+                :disabled="refreshingCommitRefs[ds.id] === true"
+                @click="refreshCommitRefs(ds.id)"
+              >
+                <RefreshCw
+                  class="mr-1 size-3"
+                  :class="refreshingCommitRefs[ds.id] === true ? 'animate-spin' : ''"
+                />
+                {{ refreshingCommitRefs[ds.id] === true ? 'Refreshing…' : 'Refresh commits' }}
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                class="h-7 text-[10px]"
+                :disabled="adoptingBaselines[ds.id] === true || !isMaintenanceReady(ds)"
+                @click="adoptTrackedHeadBaseline(ds.id)"
+              >
+                {{ adoptingBaselines[ds.id] === true ? 'Updating…' : 'Adopt tracked head as baseline' }}
+              </Button>
             </div>
 
             <div

--- a/src/dev-ui/app/tests/data-sources.test.ts
+++ b/src/dev-ui/app/tests/data-sources.test.ts
@@ -2023,6 +2023,59 @@ describe('Backend API Alignment — Scenario: Resource operations succeed end-to
   })
 })
 
+describe('Source commit refresh actions', () => {
+  it('refreshCommitRefs calls refresh endpoint and reloads data sources on success', async () => {
+    const apiFetch = vi.fn().mockResolvedValue({})
+    const loadDataSources = vi.fn().mockResolvedValue(undefined)
+    const refreshingCommitRefs: Record<string, boolean> = {}
+
+    async function refreshCommitRefs(dsId: string) {
+      refreshingCommitRefs[dsId] = true
+      try {
+        await apiFetch(`/management/data-sources/${dsId}/commit-refs/refresh`, {
+          method: 'POST',
+        })
+        await loadDataSources()
+      } finally {
+        refreshingCommitRefs[dsId] = false
+      }
+    }
+
+    await refreshCommitRefs('ds-1')
+    expect(apiFetch).toHaveBeenCalledWith('/management/data-sources/ds-1/commit-refs/refresh', {
+      method: 'POST',
+    })
+    expect(loadDataSources).toHaveBeenCalledOnce()
+    expect(refreshingCommitRefs['ds-1']).toBe(false)
+  })
+
+  it('adoptTrackedHeadBaseline calls adopt endpoint and reloads data on success', async () => {
+    const apiFetch = vi.fn().mockResolvedValue({})
+    const loadDataSources = vi.fn().mockResolvedValue(undefined)
+    const adoptingBaselines: Record<string, boolean> = {}
+
+    async function adoptTrackedHeadBaseline(dsId: string) {
+      adoptingBaselines[dsId] = true
+      try {
+        await apiFetch(`/management/data-sources/${dsId}/commit-refs/adopt-tracked-head`, {
+          method: 'POST',
+        })
+        await loadDataSources()
+      } finally {
+        adoptingBaselines[dsId] = false
+      }
+    }
+
+    await adoptTrackedHeadBaseline('ds-2')
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/management/data-sources/ds-2/commit-refs/adopt-tracked-head',
+      { method: 'POST' },
+    )
+    expect(loadDataSources).toHaveBeenCalledOnce()
+    expect(adoptingBaselines['ds-2']).toBe(false)
+  })
+})
+
 describe('Diff summary panel behavior', () => {
   it('detects maintenance readiness when tracked head differs from baseline', () => {
     function isMaintenanceReady(ds: {


### PR DESCRIPTION
## Summary
- add backend commit-reference refresh infrastructure and two management actions: refresh refs and adopt tracked head as baseline
- expose new management endpoints and wire tests for service, infrastructure, and route behavior
- add dev-ui controls for refreshing commit refs and adopting baseline, with frontend unit tests for action flows

## Test plan
- [x] `cd src/api && uv run pytest tests/unit/management/application/test_data_source_service.py tests/unit/management/presentation/test_data_sources_routes.py tests/unit/management/infrastructure/test_git_commit_reference_service.py tests/unit/test_sessioned_ingestion_handler.py -q`
- [ ] `cd src/dev-ui && npm run test -- data-sources.test.ts` *(fails locally: `vitest: command not found`)*

Made with [Cursor](https://cursor.com)