### PR TITLE
feat(extraction): add mode-specific prompt hierarchy and guardrails (#678)

### DIFF
--- a/src/api/extraction/application/agent_session_service.py
+++ b/src/api/extraction/application/agent_session_service.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from ulid import ULID
 
+from extraction.application.skill_resolution_service import (
+    ExtractionSkillResolutionService,
+)
 from extraction.domain.entities.agent_session import ExtractionAgentSession
 from extraction.domain.value_objects import ExtractionSessionMode
 from extraction.ports.repositories import IExtractionAgentSessionRepository
@@ -12,8 +15,13 @@ from extraction.ports.repositories import IExtractionAgentSessionRepository
 class ExtractionAgentSessionService:
     """Orchestrates session create/get/list/archive behaviors by scope."""
 
-    def __init__(self, repository: IExtractionAgentSessionRepository) -> None:
+    def __init__(
+        self,
+        repository: IExtractionAgentSessionRepository,
+        skill_resolution_service: ExtractionSkillResolutionService | None = None,
+    ) -> None:
         self._repository = repository
+        self._skill_resolution_service = skill_resolution_service
 
     async def get_or_create_active_session(
         self,
@@ -35,6 +43,17 @@ class ExtractionAgentSessionService:
             knowledge_graph_id=knowledge_graph_id,
             mode=mode,
         )
+        if self._skill_resolution_service is not None:
+            resolved = await self._skill_resolution_service.resolve_for_session(
+                knowledge_graph_id=knowledge_graph_id,
+                mode=mode,
+            )
+            session.runtime_context["agent_configuration"] = {
+                "system_prompt": resolved.system_prompt,
+                "prompt_hierarchy": list(resolved.prompt_hierarchy),
+                "guardrails": list(resolved.guardrails),
+                "skills": dict(resolved.skills),
+            }
         await self._repository.save(session)
         return session
 

--- a/src/api/extraction/application/skill_resolution_service.py
+++ b/src/api/extraction/application/skill_resolution_service.py
@@ -2,12 +2,65 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from extraction.domain.value_objects import ExtractionSessionMode
 from extraction.ports.repositories import IExtractionSkillOverrideRepository
 
 
+@dataclass(frozen=True)
+class ResolvedExtractionSkillPack:
+    """Resolved mode-aware prompt bundle for agent runtime."""
+
+    system_prompt: str
+    prompt_hierarchy: tuple[str, ...]
+    guardrails: tuple[str, ...]
+    skills: dict[str, str]
+
+
+_GLOBAL_PROMPT_SETTINGS: dict[ExtractionSessionMode, dict[str, object]] = {
+    ExtractionSessionMode.SCHEMA_BOOTSTRAP: {
+        "system_prompt": (
+            "You are the schema bootstrap guide. Start by understanding the user's "
+            "capabilities, goals, and domain intent before proposing a graph model."
+        ),
+        "prompt_hierarchy": (
+            "platform_security_constraints",
+            "tenant_and_knowledge_graph_scope",
+            "schema_bootstrap_goals_and_capabilities_intake",
+            "mode_specific_skill_pack",
+        ),
+        "guardrails": (
+            "Prefer mutation-log compatible schema guidance over ad-hoc writes.",
+            "Never fabricate repository content or credentials.",
+            "Keep recommendations scoped to the active knowledge graph.",
+        ),
+    },
+    ExtractionSessionMode.EXTRACTION_OPERATIONS: {
+        "system_prompt": (
+            "You are the extraction operations guide. Optimize for safe incremental "
+            "job setup, scoped maintenance, and auditable mutation outcomes."
+        ),
+        "prompt_hierarchy": (
+            "platform_security_constraints",
+            "tenant_and_knowledge_graph_scope",
+            "extraction_operations_objective",
+            "mode_specific_skill_pack",
+        ),
+        "guardrails": (
+            "All write paths must remain mutation-log auditable.",
+            "Treat schema edits as secondary unless explicitly requested.",
+            "Avoid broad destructive changes without explicit confirmation.",
+        ),
+    },
+}
+
 _GLOBAL_SKILL_TEMPLATES: dict[ExtractionSessionMode, dict[str, str]] = {
     ExtractionSessionMode.SCHEMA_BOOTSTRAP: {
+        "capabilities_intake": (
+            "Begin by asking for user capabilities/goals and confirm whether they "
+            "want a first-pass schema attempt or guided co-design."
+        ),
         "schema_modeling": (
             "Guide the user to define complete entity and relationship types "
             "with clear labels, constraints, and required properties."
@@ -44,7 +97,8 @@ class ExtractionSkillResolutionService:
         self,
         knowledge_graph_id: str,
         mode: ExtractionSessionMode,
-    ) -> dict[str, str]:
+    ) -> ResolvedExtractionSkillPack:
+        prompt_settings = _GLOBAL_PROMPT_SETTINGS[mode]
         base_templates = dict(_GLOBAL_SKILL_TEMPLATES[mode])
         overrides = await self._override_repository.get_overrides_for_knowledge_graph(
             knowledge_graph_id=knowledge_graph_id,
@@ -62,5 +116,10 @@ class ExtractionSkillResolutionService:
             if key not in resolved:
                 resolved[key] = overrides[key]
 
-        return resolved
+        return ResolvedExtractionSkillPack(
+            system_prompt=str(prompt_settings["system_prompt"]),
+            prompt_hierarchy=tuple(prompt_settings["prompt_hierarchy"]),
+            guardrails=tuple(prompt_settings["guardrails"]),
+            skills=resolved,
+        )
 

--- a/src/api/extraction/dependencies.py
+++ b/src/api/extraction/dependencies.py
@@ -5,8 +5,14 @@ from typing import Annotated
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from extraction.application import ExtractionAgentSessionService
-from extraction.infrastructure.repositories import ExtractionAgentSessionRepository
+from extraction.application import (
+    ExtractionAgentSessionService,
+    ExtractionSkillResolutionService,
+)
+from extraction.infrastructure.repositories import (
+    ExtractionAgentSessionRepository,
+    ExtractionSkillOverrideRepository,
+)
 from infrastructure.database.dependencies import get_write_session
 
 
@@ -14,7 +20,11 @@ def get_extraction_agent_session_service(
     session: Annotated[AsyncSession, Depends(get_write_session)],
 ) -> ExtractionAgentSessionService:
     """Get ExtractionAgentSessionService instance."""
+    skill_resolution_service = ExtractionSkillResolutionService(
+        override_repository=ExtractionSkillOverrideRepository()
+    )
     return ExtractionAgentSessionService(
-        repository=ExtractionAgentSessionRepository(session=session)
+        repository=ExtractionAgentSessionRepository(session=session),
+        skill_resolution_service=skill_resolution_service,
     )
 

--- a/src/api/extraction/infrastructure/__init__.py
+++ b/src/api/extraction/infrastructure/__init__.py
@@ -1,7 +1,14 @@
 """Extraction infrastructure adapters and event handlers."""
 
 from extraction.infrastructure.event_handler import ExtractionEventHandler
-from extraction.infrastructure.repositories import ExtractionAgentSessionRepository
+from extraction.infrastructure.repositories import (
+    ExtractionAgentSessionRepository,
+    ExtractionSkillOverrideRepository,
+)
 
-__all__ = ["ExtractionEventHandler", "ExtractionAgentSessionRepository"]
+__all__ = [
+    "ExtractionEventHandler",
+    "ExtractionAgentSessionRepository",
+    "ExtractionSkillOverrideRepository",
+]
 

--- a/src/api/extraction/infrastructure/repositories/__init__.py
+++ b/src/api/extraction/infrastructure/repositories/__init__.py
@@ -3,6 +3,9 @@
 from extraction.infrastructure.repositories.agent_session_repository import (
     ExtractionAgentSessionRepository,
 )
+from extraction.infrastructure.repositories.skill_override_repository import (
+    ExtractionSkillOverrideRepository,
+)
 
-__all__ = ["ExtractionAgentSessionRepository"]
+__all__ = ["ExtractionAgentSessionRepository", "ExtractionSkillOverrideRepository"]
 

--- a/src/api/extraction/infrastructure/repositories/skill_override_repository.py
+++ b/src/api/extraction/infrastructure/repositories/skill_override_repository.py
@@ -1,0 +1,22 @@
+"""Infrastructure repository for extraction skill overrides."""
+
+from __future__ import annotations
+
+from extraction.domain.value_objects import ExtractionSessionMode
+from extraction.ports.repositories import IExtractionSkillOverrideRepository
+
+
+class ExtractionSkillOverrideRepository(IExtractionSkillOverrideRepository):
+    """Return KG-specific skill overrides.
+
+    Current tracer-bullet implementation returns no overrides. This still allows
+    the resolution service to compose deterministic mode defaults and provides a
+    stable extension point for persisted KG overrides.
+    """
+
+    async def get_overrides_for_knowledge_graph(
+        self,
+        knowledge_graph_id: str,
+        mode: ExtractionSessionMode,
+    ) -> dict[str, str]:
+        return {}

--- a/src/api/tests/unit/extraction/application/test_agent_session_service.py
+++ b/src/api/tests/unit/extraction/application/test_agent_session_service.py
@@ -55,6 +55,39 @@ class _InMemoryAgentSessionRepository:
         return sorted(sessions, key=lambda s: s.updated_at, reverse=True)
 
 
+class _StaticSkillResolutionService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ExtractionSessionMode]] = []
+
+    async def resolve_for_session(
+        self,
+        knowledge_graph_id: str,
+        mode: ExtractionSessionMode,
+    ):
+        self.calls.append((knowledge_graph_id, mode))
+        if mode == ExtractionSessionMode.SCHEMA_BOOTSTRAP:
+            return type(
+                "_Resolved",
+                (),
+                {
+                    "system_prompt": "Bootstrap system prompt",
+                    "prompt_hierarchy": ("platform", "mode"),
+                    "guardrails": ("never leak credentials",),
+                    "skills": {"schema_modeling": "bootstrap schema guidance"},
+                },
+            )()
+        return type(
+            "_Resolved",
+            (),
+            {
+                "system_prompt": "Operations system prompt",
+                "prompt_hierarchy": ("platform", "operations"),
+                "guardrails": ("mutation logs only",),
+                "skills": {"job_setup": "operations setup guidance"},
+            },
+        )()
+
+
 @pytest.mark.asyncio
 class TestExtractionAgentSessionService:
     async def test_reuses_active_session_for_same_scope(self):
@@ -158,4 +191,24 @@ class TestExtractionAgentSessionService:
 
         assert len(sessions) == 2
         assert any(session.id == first.id and session.archived_at is not None for session in sessions)
+
+    async def test_new_session_initializes_runtime_context_from_skill_resolution(self):
+        repo = _InMemoryAgentSessionRepository()
+        skill_resolution = _StaticSkillResolutionService()
+        service = ExtractionAgentSessionService(
+            repository=repo,
+            skill_resolution_service=skill_resolution,
+        )
+
+        session = await service.get_or_create_active_session(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode=ExtractionSessionMode.SCHEMA_BOOTSTRAP,
+        )
+
+        assert "agent_configuration" in session.runtime_context
+        config = session.runtime_context["agent_configuration"]
+        assert config["system_prompt"] == "Bootstrap system prompt"
+        assert config["skills"]["schema_modeling"] == "bootstrap schema guidance"
+        assert skill_resolution.calls == [("kg-1", ExtractionSessionMode.SCHEMA_BOOTSTRAP)]
 

--- a/src/api/tests/unit/extraction/application/test_skill_resolution_service.py
+++ b/src/api/tests/unit/extraction/application/test_skill_resolution_service.py
@@ -34,8 +34,12 @@ class TestExtractionSkillResolutionService:
             mode=ExtractionSessionMode.SCHEMA_BOOTSTRAP,
         )
 
-        assert "schema_modeling" in resolved
-        assert "prepopulation_validation" in resolved
+        assert "schema_modeling" in resolved.skills
+        assert "prepopulation_validation" in resolved.skills
+        assert "capabilities_intake" in resolved.skills
+        assert "goal" in resolved.system_prompt.lower()
+        assert len(resolved.prompt_hierarchy) > 0
+        assert len(resolved.guardrails) > 0
 
     async def test_extraction_mode_uses_extraction_defaults(self):
         service = ExtractionSkillResolutionService(
@@ -47,8 +51,12 @@ class TestExtractionSkillResolutionService:
             mode=ExtractionSessionMode.EXTRACTION_OPERATIONS,
         )
 
-        assert "job_setup" in resolved
-        assert "minor_edits" in resolved
+        assert "job_setup" in resolved.skills
+        assert "minor_edits" in resolved.skills
+        assert "schema_edits_secondary" in resolved.skills
+        assert "extraction" in resolved.system_prompt.lower()
+        assert len(resolved.prompt_hierarchy) > 0
+        assert len(resolved.guardrails) > 0
 
     async def test_kg_overrides_replace_matching_template_and_append_new(self):
         repo = _InMemorySkillOverrideRepository(
@@ -69,8 +77,8 @@ class TestExtractionSkillResolutionService:
             mode=ExtractionSessionMode.EXTRACTION_OPERATIONS,
         )
 
-        assert resolved["job_setup"] == "KG-specific job setup instructions"
-        assert resolved["custom_review"] == "Custom review flow"
+        assert resolved.skills["job_setup"] == "KG-specific job setup instructions"
+        assert resolved.skills["custom_review"] == "Custom review flow"
 
     async def test_override_merge_is_deterministic(self):
         repo = _InMemorySkillOverrideRepository(
@@ -92,5 +100,5 @@ class TestExtractionSkillResolutionService:
         )
 
         # Additional override keys are merged in sorted order for determinism.
-        assert list(resolved.keys())[-2:] == ["a_first", "z_last"]
+        assert list(resolved.skills.keys())[-2:] == ["a_first", "z_last"]
 


### PR DESCRIPTION
## Summary
- introduce structured resolved skill packs for extraction modes with explicit system prompt, prompt hierarchy, guardrails, and default mode-specific skills
- add a tracer-bullet extraction skill override repository and wire dependency injection so session creation resolves mode-aware configuration
- persist resolved agent configuration into new session runtime context for stable downstream agent runtime usage

## Testing
- [x] `cd src/api && uv run pytest tests/unit/extraction/application/test_skill_resolution_service.py tests/unit/extraction/application/test_agent_session_service.py tests/unit/extraction/presentation/test_routes.py tests/unit/extraction/test_architecture.py -q`

## Risks
- low: extraction session runtime_context shape now includes `agent_configuration`; existing sessions without this key remain supported

Closes #678

Made with [Cursor](https://cursor.com)