### PR TITLE
feat(extraction): implement bootstrap capabilities intake flow (#677)

### DIFF
--- a/src/api/extraction/application/agent_session_service.py
+++ b/src/api/extraction/application/agent_session_service.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 from ulid import ULID
 
 from extraction.application.skill_resolution_service import (
     ExtractionSkillResolutionService,
 )
 from extraction.domain.entities.agent_session import ExtractionAgentSession
-from extraction.domain.value_objects import ExtractionSessionMode
+from extraction.domain.value_objects import BootstrapIntakePath, ExtractionSessionMode
 from extraction.ports.repositories import IExtractionAgentSessionRepository
 
 
@@ -22,6 +24,15 @@ class ExtractionAgentSessionService:
     ) -> None:
         self._repository = repository
         self._skill_resolution_service = skill_resolution_service
+
+    @staticmethod
+    def _build_bootstrap_intake_prompt() -> str:
+        return (
+            "Before we draft schema types, share your capabilities and goals for this "
+            "knowledge graph. Then choose one path: "
+            "(1) immediate first-pass schema attempt, or "
+            "(2) guided question-by-question co-design."
+        )
 
     async def get_or_create_active_session(
         self,
@@ -53,6 +64,19 @@ class ExtractionAgentSessionService:
                 "prompt_hierarchy": list(resolved.prompt_hierarchy),
                 "guardrails": list(resolved.guardrails),
                 "skills": dict(resolved.skills),
+            }
+        if mode == ExtractionSessionMode.SCHEMA_BOOTSTRAP:
+            session.message_history.append(
+                {"role": "assistant", "content": self._build_bootstrap_intake_prompt()}
+            )
+            session.runtime_context["bootstrap_intake"] = {
+                "status": "awaiting_path_selection",
+                "selected_path": None,
+                "capabilities_goals": None,
+                "path_options": [
+                    BootstrapIntakePath.FIRST_PASS_SCHEMA_ATTEMPT.value,
+                    BootstrapIntakePath.GUIDED_CO_DESIGN.value,
+                ],
             }
         await self._repository.save(session)
         return session
@@ -97,5 +121,28 @@ class ExtractionAgentSessionService:
         if session.is_active:
             session.archive()
             await self._repository.save(session)
+        return session
+
+    async def set_bootstrap_intake_path_for_active_session(
+        self,
+        user_id: str,
+        knowledge_graph_id: str,
+        selected_path: BootstrapIntakePath,
+        capabilities_goals: str | None,
+    ) -> ExtractionAgentSession:
+        """Persist bootstrap path selection for session continuity."""
+        session = await self.get_or_create_active_session(
+            user_id=user_id,
+            knowledge_graph_id=knowledge_graph_id,
+            mode=ExtractionSessionMode.SCHEMA_BOOTSTRAP,
+        )
+        intake = dict(session.runtime_context.get("bootstrap_intake", {}))
+        intake["status"] = "path_selected"
+        intake["selected_path"] = selected_path.value
+        intake["capabilities_goals"] = capabilities_goals
+        intake["selected_at"] = datetime.now(UTC).isoformat()
+        session.runtime_context["bootstrap_intake"] = intake
+        session.updated_at = datetime.now(UTC)
+        await self._repository.save(session)
         return session
 

--- a/src/api/extraction/domain/value_objects.py
+++ b/src/api/extraction/domain/value_objects.py
@@ -9,3 +9,10 @@ class ExtractionSessionMode(StrEnum):
     SCHEMA_BOOTSTRAP = "schema_bootstrap"
     EXTRACTION_OPERATIONS = "extraction_operations"
 
+
+class BootstrapIntakePath(StrEnum):
+    """User-selected bootstrap onboarding path."""
+
+    FIRST_PASS_SCHEMA_ATTEMPT = "first_pass_schema_attempt"
+    GUIDED_CO_DESIGN = "guided_co_design"
+

--- a/src/api/extraction/presentation/models.py
+++ b/src/api/extraction/presentation/models.py
@@ -8,7 +8,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from extraction.domain.entities.agent_session import ExtractionAgentSession
-from extraction.domain.value_objects import ExtractionSessionMode
+from extraction.domain.value_objects import BootstrapIntakePath, ExtractionSessionMode
 
 
 class ExtractionSessionResponse(BaseModel):
@@ -44,4 +44,14 @@ class ExtractionSessionListResponse(BaseModel):
 
     sessions: list[ExtractionSessionResponse]
     count: int
+
+
+class BootstrapIntakePathSelectionRequest(BaseModel):
+    """Request model for bootstrap intake path selection."""
+
+    selected_path: BootstrapIntakePath
+    capabilities_goals: str | None = Field(
+        default=None,
+        description="Optional user summary of capabilities and schema goals",
+    )
 

--- a/src/api/extraction/presentation/routes.py
+++ b/src/api/extraction/presentation/routes.py
@@ -10,6 +10,7 @@ from extraction.application import ExtractionAgentSessionService
 from extraction.dependencies import get_extraction_agent_session_service
 from extraction.domain.value_objects import ExtractionSessionMode
 from extraction.presentation.models import (
+    BootstrapIntakePathSelectionRequest,
     ExtractionSessionListResponse,
     ExtractionSessionResponse,
 )
@@ -118,6 +119,33 @@ async def clear_chat(
         user_id=current_user.user_id.value,
         knowledge_graph_id=knowledge_graph_id,
         mode=mode,
+    )
+    return ExtractionSessionResponse.from_domain(session)
+
+
+@router.post(
+    "/knowledge-graphs/{knowledge_graph_id}/sessions/schema_bootstrap/active/intake-path",
+    response_model=ExtractionSessionResponse,
+)
+async def select_bootstrap_intake_path(
+    knowledge_graph_id: str,
+    request: BootstrapIntakePathSelectionRequest,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    service: Annotated[
+        ExtractionAgentSessionService, Depends(get_extraction_agent_session_service)
+    ],
+    authz: Annotated[AuthorizationProvider, Depends(get_spicedb_client)],
+) -> ExtractionSessionResponse:
+    await _assert_kg_edit_permission(
+        authz=authz,
+        current_user=current_user,
+        knowledge_graph_id=knowledge_graph_id,
+    )
+    session = await service.set_bootstrap_intake_path_for_active_session(
+        user_id=current_user.user_id.value,
+        knowledge_graph_id=knowledge_graph_id,
+        selected_path=request.selected_path,
+        capabilities_goals=request.capabilities_goals,
     )
     return ExtractionSessionResponse.from_domain(session)
 

--- a/src/api/tests/unit/extraction/application/test_agent_session_service.py
+++ b/src/api/tests/unit/extraction/application/test_agent_session_service.py
@@ -9,7 +9,7 @@ import pytest
 
 from extraction.application.agent_session_service import ExtractionAgentSessionService
 from extraction.domain.entities.agent_session import ExtractionAgentSession
-from extraction.domain.value_objects import ExtractionSessionMode
+from extraction.domain.value_objects import BootstrapIntakePath, ExtractionSessionMode
 
 
 class _InMemoryAgentSessionRepository:
@@ -211,4 +211,43 @@ class TestExtractionAgentSessionService:
         assert config["system_prompt"] == "Bootstrap system prompt"
         assert config["skills"]["schema_modeling"] == "bootstrap schema guidance"
         assert skill_resolution.calls == [("kg-1", ExtractionSessionMode.SCHEMA_BOOTSTRAP)]
+
+    async def test_bootstrap_session_seeds_capabilities_intake_prompt_state(self):
+        repo = _InMemoryAgentSessionRepository()
+        service = ExtractionAgentSessionService(repository=repo)
+
+        session = await service.get_or_create_active_session(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode=ExtractionSessionMode.SCHEMA_BOOTSTRAP,
+        )
+
+        assert session.message_history
+        assert session.message_history[0]["role"] == "assistant"
+        assert "capabilities" in session.message_history[0]["content"].lower()
+        intake = session.runtime_context["bootstrap_intake"]
+        assert intake["status"] == "awaiting_path_selection"
+        assert intake["selected_path"] is None
+
+    async def test_select_bootstrap_intake_path_persists_choice_for_continuity(self):
+        repo = _InMemoryAgentSessionRepository()
+        service = ExtractionAgentSessionService(repository=repo)
+        session = await service.get_or_create_active_session(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode=ExtractionSessionMode.SCHEMA_BOOTSTRAP,
+        )
+
+        updated = await service.set_bootstrap_intake_path_for_active_session(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            selected_path=BootstrapIntakePath.GUIDED_CO_DESIGN,
+            capabilities_goals="I can provide domain terms but need guidance.",
+        )
+
+        intake = updated.runtime_context["bootstrap_intake"]
+        assert intake["selected_path"] == BootstrapIntakePath.GUIDED_CO_DESIGN.value
+        assert intake["status"] == "path_selected"
+        assert intake["capabilities_goals"] == "I can provide domain terms but need guidance."
+        assert updated.id == session.id
 

--- a/src/api/tests/unit/extraction/presentation/test_routes.py
+++ b/src/api/tests/unit/extraction/presentation/test_routes.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 
 from extraction.application.agent_session_service import ExtractionAgentSessionService
 from extraction.domain.entities.agent_session import ExtractionAgentSession
+from extraction.domain.value_objects import BootstrapIntakePath
 from iam.application.value_objects import CurrentUser
 from iam.domain.value_objects import TenantId, UserId
 
@@ -175,4 +176,24 @@ class TestExtractionSessionRoutes:
         assert first.status_code == status.HTTP_200_OK
         assert second.status_code == status.HTTP_200_OK
         assert first.json()["id"] == second.json()["id"]
+
+    def test_select_bootstrap_intake_path_persists_choice(self, extraction_client):
+        client, _ = extraction_client
+        active = client.get(
+            "/extraction/knowledge-graphs/kg-123/sessions/schema_bootstrap/active"
+        )
+        assert active.status_code == status.HTTP_200_OK
+
+        response = client.post(
+            "/extraction/knowledge-graphs/kg-123/sessions/schema_bootstrap/active/intake-path",
+            json={
+                "selected_path": BootstrapIntakePath.GUIDED_CO_DESIGN.value,
+                "capabilities_goals": "I know core entities but need help with relationships.",
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+        payload = response.json()
+        intake = payload["runtime_context"]["bootstrap_intake"]
+        assert intake["selected_path"] == BootstrapIntakePath.GUIDED_CO_DESIGN.value
+        assert intake["status"] == "path_selected"
 


### PR DESCRIPTION
## Summary
- seed schema-bootstrap sessions with an immediate capabilities/goals intake message offering two explicit paths: first-pass schema attempt or guided co-design
- add a dedicated bootstrap intake path selection endpoint that persists the selected path and capability summary in session runtime context
- extend extraction domain/session tests and route tests to verify continuity of persisted bootstrap intake state

## Testing
- [x] `cd src/api && uv run pytest tests/unit/extraction/application/test_agent_session_service.py tests/unit/extraction/presentation/test_routes.py tests/unit/extraction/application/test_skill_resolution_service.py tests/unit/extraction/test_architecture.py -q`

## Risks
- low: new endpoint is scoped to `schema_bootstrap` active sessions and guarded by existing KG edit authorization checks

Closes #677

Made with [Cursor](https://cursor.com)