### PR TITLE
feat(extraction): package workload runtime context and skills mounts (#679)

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -145,6 +145,7 @@ services:
       - kartograph
     volumes:
       - ./certs:/certs:ro
+      - ./skills:/app/skills:ro
       # Mount host CA bundle (supports multiple OS types via env var)
       # Default fallback order: RHEL/Fedora -> Debian/Ubuntu -> macOS
       - ${HOST_CA_BUNDLE:-/etc/pki/tls/certs/ca-bundle.crt}:/etc/ssl/certs/ca-bundle.crt:ro
@@ -156,6 +157,7 @@ services:
       - GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=/certs/spicedb-cert.pem
       # SSL cert file uses mounted path (same for all systems)
       - SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+      - KARTOGRAPH_EXTRACTION_SKILLS_DIR=/app/skills
     depends_on:
       postgres:
         condition: service_healthy

--- a/deploy/apps/kartograph/base/api-deployment.yaml
+++ b/deploy/apps/kartograph/base/api-deployment.yaml
@@ -155,11 +155,15 @@ spec:
                 secretKeyRef:
                   name: kartograph-sso-client-swagger-docs
                   key: client_id
+            - name: KARTOGRAPH_EXTRACTION_SKILLS_DIR
+              value: /app/skills
 
           volumeMounts:
             - name: spicedb-ca
               mountPath: /etc/spicedb-ca
               readOnly: true
+            - name: extraction-skills
+              mountPath: /app/skills
           livenessProbe:
             httpGet:
               path: /health
@@ -190,3 +194,5 @@ spec:
             items:
               - key: service-ca.crt
                 path: service-ca.crt
+        - name: extraction-skills
+          emptyDir: {}

--- a/src/api/extraction/infrastructure/__init__.py
+++ b/src/api/extraction/infrastructure/__init__.py
@@ -5,10 +5,14 @@ from extraction.infrastructure.repositories import (
     ExtractionAgentSessionRepository,
     ExtractionSkillOverrideRepository,
 )
+from extraction.infrastructure.runtime_context_builder import (
+    FilesystemExtractionRuntimeContextBuilder,
+)
 
 __all__ = [
     "ExtractionEventHandler",
     "ExtractionAgentSessionRepository",
     "ExtractionSkillOverrideRepository",
+    "FilesystemExtractionRuntimeContextBuilder",
 ]
 

--- a/src/api/extraction/infrastructure/event_handler.py
+++ b/src/api/extraction/infrastructure/event_handler.py
@@ -40,6 +40,7 @@ class ExtractionEventHandler:
         self,
         extraction_service: IExtractionService,
         outbox: "IOutboxRepository",
+        runtime_context_builder: Any,
     ) -> None:
         """Initialize the extraction event handler.
 
@@ -50,6 +51,7 @@ class ExtractionEventHandler:
         """
         self._extraction_service = extraction_service
         self._outbox = outbox
+        self._runtime_context_builder = runtime_context_builder
 
     def supported_event_types(self) -> frozenset[str]:
         """Return event types handled by this handler."""
@@ -80,11 +82,16 @@ class ExtractionEventHandler:
         now = datetime.now(UTC)
 
         try:
+            runtime_context = self._runtime_context_builder.build(
+                sync_run_id=sync_run_id,
+                job_package_id=job_package_id,
+            )
             mutation_log_id = await self._extraction_service.run(
                 sync_run_id=sync_run_id,
                 data_source_id=data_source_id,
                 knowledge_graph_id=knowledge_graph_id,
                 job_package_id=job_package_id,
+                runtime_context=runtime_context,
             )
         except Exception as exc:
             await self._outbox.append(

--- a/src/api/extraction/infrastructure/runtime_context_builder.py
+++ b/src/api/extraction/infrastructure/runtime_context_builder.py
@@ -1,0 +1,52 @@
+"""Filesystem runtime context preparation for extraction workloads."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import zipfile
+
+from extraction.ports.services import ExtractionRuntimeContext
+from shared_kernel.job_package.path_safety import validate_zip_entry_name
+from shared_kernel.job_package.reader import JobPackageReader
+from shared_kernel.job_package.value_objects import JobPackageId
+
+
+class FilesystemExtractionRuntimeContextBuilder:
+    """Prepare runtime directories from JobPackage + skills mount path."""
+
+    def __init__(self, *, work_dir: Path, skills_dir: Path) -> None:
+        self._work_dir = work_dir
+        self._skills_dir = skills_dir
+
+    def build(self, *, sync_run_id: str, job_package_id: str) -> ExtractionRuntimeContext:
+        package_id = JobPackageId(value=job_package_id)
+        archive_path = self._work_dir / package_id.archive_name()
+        reader = JobPackageReader(archive_path)
+
+        run_root = self._work_dir / "extraction-runtimes" / sync_run_id
+        ingestion_context_dir = run_root / "ingestion-context"
+        repository_files_dir = run_root / "repository-files"
+        ingestion_context_dir.mkdir(parents=True, exist_ok=True)
+        repository_files_dir.mkdir(parents=True, exist_ok=True)
+        self._skills_dir.mkdir(parents=True, exist_ok=True)
+
+        with zipfile.ZipFile(archive_path) as archive:
+            for entry_name in archive.namelist():
+                validate_zip_entry_name(entry_name)
+                archive.extract(entry_name, path=ingestion_context_dir)
+
+        # Materialize repository-style files for agent-friendly traversal.
+        for change in reader.iter_changeset():
+            if change.content_ref is None or not change.path:
+                continue
+            validate_zip_entry_name(change.path)
+            output_path = repository_files_dir / change.path
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(reader.read_content(change.content_ref))
+
+        return ExtractionRuntimeContext(
+            ingestion_context_dir=str(ingestion_context_dir),
+            repository_files_dir=str(repository_files_dir),
+            skills_dir=str(self._skills_dir),
+            job_package_archive=str(archive_path),
+        )

--- a/src/api/extraction/ports/services.py
+++ b/src/api/extraction/ports/services.py
@@ -2,7 +2,18 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Protocol
+
+
+@dataclass(frozen=True)
+class ExtractionRuntimeContext:
+    """Resolved runtime paths available to extraction workloads."""
+
+    ingestion_context_dir: str
+    repository_files_dir: str
+    skills_dir: str
+    job_package_archive: str
 
 
 class IExtractionService(Protocol):
@@ -22,6 +33,7 @@ class IExtractionService(Protocol):
         data_source_id: str,
         knowledge_graph_id: str,
         job_package_id: str,
+        runtime_context: ExtractionRuntimeContext,
     ) -> str:
         """Run the AI extraction pipeline for a JobPackage.
 
@@ -30,6 +42,8 @@ class IExtractionService(Protocol):
             data_source_id: Identifier for the data source being extracted
             knowledge_graph_id: Identifier for the target knowledge graph
             job_package_id: Identifier for the JobPackage to process
+            runtime_context: Resolved runtime context paths for ingestion resources,
+                reconstructed repository files, and skills availability.
 
         Returns:
             mutation_log_id: Identifier for the produced MutationLog (JSONL)

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from contextlib import asynccontextmanager
+import os
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -56,6 +57,9 @@ from graph.ports.mutation_log import MutationLogApplyResult
 
 # Default work directory for JobPackage ZIP archives
 _JOB_PACKAGE_WORK_DIR = Path("/tmp/kartograph/job_packages")  # noqa: S108
+_EXTRACTION_SKILLS_DIR = Path(
+    os.getenv("KARTOGRAPH_EXTRACTION_SKILLS_DIR", "/app/skills")
+)
 
 # Scheduler polling interval (seconds)
 _SCHEDULER_POLL_INTERVAL_SECONDS = 60
@@ -281,6 +285,7 @@ class _StubExtractionService:
         data_source_id: str,
         knowledge_graph_id: str,
         job_package_id: str,
+        runtime_context: Any,
     ) -> str:
         raise NotImplementedError(
             "AI extraction pipeline is not yet implemented. "
@@ -308,12 +313,20 @@ class _SessionedExtractionEventHandler:
     async def handle(self, event_type: str, payload: dict[str, Any]) -> None:
         from infrastructure.outbox.repository import OutboxRepository
         from extraction.infrastructure.event_handler import ExtractionEventHandler
+        from extraction.infrastructure.runtime_context_builder import (
+            FilesystemExtractionRuntimeContextBuilder,
+        )
 
         async with self._session_factory() as session:
             outbox = OutboxRepository(session=session)
+            runtime_context_builder = FilesystemExtractionRuntimeContextBuilder(
+                work_dir=_JOB_PACKAGE_WORK_DIR,
+                skills_dir=_EXTRACTION_SKILLS_DIR,
+            )
             extraction_handler = ExtractionEventHandler(
                 extraction_service=self._extraction_service,
                 outbox=outbox,
+                runtime_context_builder=runtime_context_builder,
             )
             await extraction_handler.handle(event_type, payload)
             await session.commit()

--- a/src/api/tests/unit/extraction/infrastructure/test_extraction_event_handler.py
+++ b/src/api/tests/unit/extraction/infrastructure/test_extraction_event_handler.py
@@ -18,6 +18,7 @@ from uuid import UUID
 import pytest
 
 from extraction.infrastructure.event_handler import ExtractionEventHandler
+from extraction.ports.services import ExtractionRuntimeContext
 
 
 class _FakeOutboxRepository:
@@ -65,6 +66,7 @@ class _FakeExtractionService:
         data_source_id: str,
         knowledge_graph_id: str,
         job_package_id: str,
+        runtime_context: ExtractionRuntimeContext,
     ) -> str:
         self.calls.append(
             {
@@ -72,11 +74,28 @@ class _FakeExtractionService:
                 "data_source_id": data_source_id,
                 "knowledge_graph_id": knowledge_graph_id,
                 "job_package_id": job_package_id,
+                "runtime_context": runtime_context,
             }
         )
         if self._fail:
             raise RuntimeError(self._error)
         return "mutation-log-001"
+
+
+class _FakeRuntimeContextBuilder:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, str]] = []
+
+    def build(self, *, sync_run_id: str, job_package_id: str) -> ExtractionRuntimeContext:
+        self.calls.append(
+            {"sync_run_id": sync_run_id, "job_package_id": job_package_id}
+        )
+        return ExtractionRuntimeContext(
+            ingestion_context_dir="/tmp/ingestion-context",
+            repository_files_dir="/tmp/repository-files",
+            skills_dir="/app/skills",
+            job_package_archive="/tmp/job-package.zip",
+        )
 
 
 @pytest.fixture
@@ -99,9 +118,11 @@ def handler(
     extraction_service: _FakeExtractionService,
     outbox: _FakeOutboxRepository,
 ) -> ExtractionEventHandler:
+    runtime_context_builder = _FakeRuntimeContextBuilder()
     return ExtractionEventHandler(
         extraction_service=extraction_service,
         outbox=outbox,
+        runtime_context_builder=runtime_context_builder,
     )
 
 
@@ -151,6 +172,7 @@ class TestExtractionEventHandlerSuccess:
         assert call["job_package_id"] == "pkg-001"
         assert call["data_source_id"] == "ds-001"
         assert call["knowledge_graph_id"] == "kg-001"
+        assert call["runtime_context"].skills_dir == "/app/skills"
 
     async def test_emits_mutation_log_produced_on_success(
         self,
@@ -208,6 +230,7 @@ class TestExtractionEventHandlerFailure:
         handler = ExtractionEventHandler(
             extraction_service=failing_service,
             outbox=outbox,
+            runtime_context_builder=_FakeRuntimeContextBuilder(),
         )
         payload = _job_package_produced_payload(sync_run_id="run-002")
         await handler.handle("JobPackageProduced", payload)
@@ -228,6 +251,7 @@ class TestExtractionEventHandlerFailure:
         handler = ExtractionEventHandler(
             extraction_service=failing_service,
             outbox=outbox,
+            runtime_context_builder=_FakeRuntimeContextBuilder(),
         )
         await handler.handle(
             "JobPackageProduced",
@@ -285,6 +309,7 @@ class TestExtractionEventHandlerOutboxIsolation:
         handler = ExtractionEventHandler(
             extraction_service=extraction_service,
             outbox=failing_outbox,
+            runtime_context_builder=_FakeRuntimeContextBuilder(),
         )
 
         with pytest.raises(RuntimeError, match="outbox write failed"):

--- a/src/api/tests/unit/extraction/infrastructure/test_runtime_context_builder.py
+++ b/src/api/tests/unit/extraction/infrastructure/test_runtime_context_builder.py
@@ -1,0 +1,74 @@
+"""Unit tests for filesystem extraction runtime context builder."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from extraction.infrastructure.runtime_context_builder import (
+    FilesystemExtractionRuntimeContextBuilder,
+)
+from shared_kernel.job_package.builder import JobPackageBuilder
+from shared_kernel.job_package.value_objects import (
+    AdapterCheckpoint,
+    ChangeOperation,
+    ChangesetEntry,
+    ContentRef,
+    SyncMode,
+)
+
+
+def _build_job_package(archive_dir: Path) -> str:
+    content_bytes = b"print('hello runtime context')\n"
+    content_ref = ContentRef.from_bytes(content_bytes)
+    changeset_entry = ChangesetEntry(
+        operation=ChangeOperation.ADD,
+        id="file-1",
+        type="io.kartograph.change.file",
+        path="src/main.py",
+        content_ref=content_ref,
+        content_type="text/x-python",
+        metadata={},
+    )
+    builder = JobPackageBuilder(
+        data_source_id="ds-123",
+        knowledge_graph_id="kg-123",
+        sync_mode=SyncMode.FULL_REFRESH,
+    )
+    ref = builder.add_content(content_bytes)
+    builder.add_changeset_entry(
+        ChangesetEntry(
+            operation=ChangeOperation.ADD,
+            id=changeset_entry.id,
+            type=changeset_entry.type,
+            path=changeset_entry.path,
+            content_ref=ref,
+            content_type=changeset_entry.content_type,
+            metadata=changeset_entry.metadata,
+        )
+    )
+    builder.set_checkpoint(AdapterCheckpoint(schema_version="1.0.0", data={}))
+    archive_path = builder.build(archive_dir)
+    return archive_path.stem.removeprefix("job-package-")
+
+
+@pytest.mark.asyncio
+async def test_build_materializes_ingestion_context_and_repository_files(tmp_path: Path):
+    work_dir = tmp_path / "work"
+    work_dir.mkdir(parents=True, exist_ok=True)
+    package_id = _build_job_package(work_dir)
+    skills_dir = tmp_path / "skills"
+
+    builder = FilesystemExtractionRuntimeContextBuilder(
+        work_dir=work_dir,
+        skills_dir=skills_dir,
+    )
+    runtime = builder.build(sync_run_id="run-123", job_package_id=package_id)
+
+    assert Path(runtime.ingestion_context_dir).exists()
+    assert Path(runtime.repository_files_dir, "src/main.py").exists()
+    assert Path(runtime.repository_files_dir, "src/main.py").read_text() == (
+        "print('hello runtime context')\n"
+    )
+    assert Path(runtime.skills_dir).exists()


### PR DESCRIPTION
## Summary
- add filesystem runtime-context preparation for extraction workloads: ingest JobPackage resources, materialize repository files, and guarantee skills directory availability
- wire extraction event handling to build and pass runtime context into extraction service execution
- update local compose and deployed API deployment config so extraction runtime skills path is explicitly mounted/configured for both local and cluster runtimes

## Testing
- [x] `cd src/api && uv run pytest tests/unit/extraction/infrastructure/test_extraction_event_handler.py tests/unit/extraction/infrastructure/test_runtime_context_builder.py tests/unit/test_application_lifecycle.py -q`
- [x] `cd src/api && uv run pytest tests/unit/extraction -q`

## Risks
- medium-low: runtime context preparation now depends on JobPackage archive availability at extraction time (failure still cleanly reports ExtractionFailed through existing error path)

Closes #679

Made with [Cursor](https://cursor.com)