### PR TITLE
feat(management): add extraction run-control APIs (#671)

### DIFF
--- a/src/api/management/application/services/data_source_service.py
+++ b/src/api/management/application/services/data_source_service.py
@@ -49,6 +49,16 @@ class DataSourceWithLatestRun:
     latest_sync_run: DataSourceSyncRun | None
 
 
+@dataclass
+class RunControlResult:
+    """Result payload for extraction run-control commands."""
+
+    action: str
+    affected_count: int
+    updated_runs: list[DataSourceSyncRun]
+    started_run: DataSourceSyncRun | None = None
+
+
 class DataSourceService:
     """Application service for data source management.
 
@@ -655,3 +665,93 @@ class DataSourceService:
         self._probe.sync_requested(ds_id=ds_id)
 
         return sync_run
+
+    async def apply_run_control(
+        self,
+        user_id: str,
+        ds_id: str,
+        action: str,
+    ) -> RunControlResult:
+        """Apply run-control action to sync runs for a data source."""
+        if action == "start":
+            started = await self.trigger_sync(user_id=user_id, ds_id=ds_id)
+            return RunControlResult(
+                action=action,
+                affected_count=1,
+                updated_runs=[],
+                started_run=started,
+            )
+
+        has_manage = await self._check_permission(
+            user_id=user_id,
+            resource_type=ResourceType.DATA_SOURCE,
+            resource_id=ds_id,
+            permission=Permission.MANAGE,
+        )
+        if not has_manage:
+            self._probe.permission_denied(
+                user_id=user_id,
+                resource_id=ds_id,
+                permission=Permission.MANAGE,
+            )
+            raise UnauthorizedError(
+                f"User {user_id} lacks manage permission on data source {ds_id}"
+            )
+
+        ds = await self._ds_repo.get_by_id(DataSourceId(value=ds_id))
+        if ds is None or ds.tenant_id != self._scope_to_tenant:
+            raise ValueError(f"Data source {ds_id} not found")
+
+        runs = await self._sync_run_repo.find_by_data_source(ds_id)
+        active_statuses = {"pending", "ingesting", "ai_extracting", "applying"}
+        targets: list[DataSourceSyncRun] = []
+        now = datetime.now(UTC)
+
+        if action == "pause":
+            targets = [run for run in runs if run.status in active_statuses]
+            for run in targets:
+                run.status = "pending"
+                run.logs.append("Run paused by control plane")
+        elif action == "halt":
+            targets = [run for run in runs if run.status in active_statuses]
+            for run in targets:
+                run.status = "failed"
+                run.completed_at = now
+                run.error = "Run halted by control plane"
+                run.logs.append("Run halted by control plane")
+        elif action == "reset_running":
+            targets = [run for run in runs if run.status in active_statuses]
+            for run in targets:
+                run.status = "pending"
+                run.completed_at = None
+                run.error = None
+        elif action == "reset_failed":
+            targets = [run for run in runs if run.status == "failed"]
+            for run in targets:
+                run.status = "pending"
+                run.completed_at = None
+                run.error = None
+        elif action == "reset_completed":
+            targets = [run for run in runs if run.status == "completed"]
+            for run in targets:
+                run.status = "pending"
+                run.completed_at = None
+                run.error = None
+        elif action == "reset_all":
+            targets = list(runs)
+            for run in targets:
+                run.status = "pending"
+                run.completed_at = None
+                run.error = None
+        else:
+            raise ValueError(f"Unsupported run control action: {action}")
+
+        for run in targets:
+            await self._sync_run_repo.save(run)
+        await self._session.commit()
+
+        return RunControlResult(
+            action=action,
+            affected_count=len(targets),
+            updated_runs=targets,
+        )

--- a/src/api/management/presentation/data_sources/models.py
+++ b/src/api/management/presentation/data_sources/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -318,6 +319,26 @@ class SyncRunResponse(BaseModel):
             error=run.error,
             created_at=run.created_at,
         )
+
+
+RunControlAction = Literal[
+    "start",
+    "pause",
+    "halt",
+    "reset_running",
+    "reset_failed",
+    "reset_completed",
+    "reset_all",
+]
+
+
+class RunControlResponse(BaseModel):
+    """Response model for run-control actions."""
+
+    action: RunControlAction
+    affected_count: int
+    updated_runs: list[SyncRunResponse] = Field(default_factory=list)
+    started_run: SyncRunResponse | None = None
 
 
 class DataSourceWithSyncResponse(BaseModel):

--- a/src/api/management/presentation/data_sources/routes.py
+++ b/src/api/management/presentation/data_sources/routes.py
@@ -27,6 +27,8 @@ from management.presentation.data_sources.models import (
     DataSourceListResponse,
     DataSourceResponse,
     DataSourceWithSyncResponse,
+    RunControlAction,
+    RunControlResponse,
     SyncRunLogsResponse,
     SyncRunResponse,
     UpdateDataSourceRequest,
@@ -439,6 +441,53 @@ async def list_sync_runs(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to list sync runs",
+        )
+
+
+@router.post(
+    "/data-sources/{ds_id}/run-controls/{action}",
+    status_code=status.HTTP_200_OK,
+)
+async def control_sync_runs(
+    ds_id: str,
+    action: RunControlAction,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    service: Annotated[DataSourceService, Depends(get_data_source_service)],
+) -> RunControlResponse:
+    """Apply run-control action to extraction sync runs for a data source."""
+    try:
+        result = await service.apply_run_control(
+            user_id=current_user.user_id.value,
+            ds_id=ds_id,
+            action=action,
+        )
+        return RunControlResponse(
+            action=action,
+            affected_count=result.affected_count,
+            updated_runs=[SyncRunResponse.from_domain(run) for run in result.updated_runs],
+            started_run=(
+                SyncRunResponse.from_domain(result.started_run)
+                if result.started_run is not None
+                else None
+            ),
+        )
+    except UnauthorizedError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to perform this action",
+        )
+    except ValueError as e:
+        detail = str(e)
+        status_code = (
+            status.HTTP_422_UNPROCESSABLE_ENTITY
+            if "Unsupported run control action" in detail
+            else status.HTTP_404_NOT_FOUND
+        )
+        raise HTTPException(status_code=status_code, detail=detail)
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to apply run control action",
         )
 
 

--- a/src/api/tests/unit/management/application/test_data_source_service.py
+++ b/src/api/tests/unit/management/application/test_data_source_service.py
@@ -459,6 +459,25 @@ def _make_ds(
     return ds
 
 
+def _make_sync_run(
+    *,
+    run_id: str,
+    data_source_id: str,
+    status: str,
+) -> DataSourceSyncRun:
+    now = datetime.now(UTC)
+    return DataSourceSyncRun(
+        id=run_id,
+        data_source_id=data_source_id,
+        status=status,
+        started_at=now,
+        completed_at=None,
+        error=None,
+        created_at=now,
+        logs=[],
+    )
+
+
 # ---- create ----
 
 
@@ -1028,6 +1047,99 @@ class TestDataSourceServiceTriggerSync:
         assert len(ds_repo.saved) == 1
         assert len(ds_probe.sync_requested_calls) == 1
         assert ds_probe.sync_requested_calls[0]["ds_id"] == ds.id.value
+
+
+class TestDataSourceServiceRunControls:
+    """Tests for extraction run-control operations."""
+
+    @pytest.mark.asyncio
+    async def test_pause_updates_active_runs_to_pending(
+        self, service, authz, ds_repo, sync_run_repo, user_id
+    ) -> None:
+        ds = _make_ds()
+        authz.grant_all()
+        ds_repo.seed(ds)
+        sync_run_repo.seed(
+            _make_sync_run(run_id="run-1", data_source_id=ds.id.value, status="ingesting"),
+            _make_sync_run(run_id="run-2", data_source_id=ds.id.value, status="applying"),
+            _make_sync_run(run_id="run-3", data_source_id=ds.id.value, status="completed"),
+        )
+
+        result = await service.apply_run_control(
+            user_id=user_id,
+            ds_id=ds.id.value,
+            action="pause",
+        )
+
+        assert result.affected_count == 2
+        assert all(run.status == "pending" for run in result.updated_runs)
+
+    @pytest.mark.asyncio
+    async def test_halt_marks_active_runs_as_failed(
+        self, service, authz, ds_repo, sync_run_repo, user_id
+    ) -> None:
+        ds = _make_ds()
+        authz.grant_all()
+        ds_repo.seed(ds)
+        sync_run_repo.seed(
+            _make_sync_run(
+                run_id="run-1", data_source_id=ds.id.value, status="ai_extracting"
+            )
+        )
+
+        result = await service.apply_run_control(
+            user_id=user_id,
+            ds_id=ds.id.value,
+            action="halt",
+        )
+
+        assert result.affected_count == 1
+        halted = result.updated_runs[0]
+        assert halted.status == "failed"
+        assert halted.completed_at is not None
+        assert halted.error is not None
+
+    @pytest.mark.asyncio
+    async def test_reset_failed_moves_failed_runs_to_pending(
+        self, service, authz, ds_repo, sync_run_repo, user_id
+    ) -> None:
+        ds = _make_ds()
+        authz.grant_all()
+        ds_repo.seed(ds)
+        failed = _make_sync_run(run_id="run-1", data_source_id=ds.id.value, status="failed")
+        failed.error = "old error"
+        failed.completed_at = datetime.now(UTC)
+        sync_run_repo.seed(failed)
+
+        result = await service.apply_run_control(
+            user_id=user_id,
+            ds_id=ds.id.value,
+            action="reset_failed",
+        )
+
+        assert result.affected_count == 1
+        updated = result.updated_runs[0]
+        assert updated.status == "pending"
+        assert updated.error is None
+        assert updated.completed_at is None
+
+    @pytest.mark.asyncio
+    async def test_start_action_creates_new_sync_run(
+        self, service, authz, ds_repo, user_id
+    ) -> None:
+        ds = _make_ds()
+        authz.grant_all()
+        ds_repo.seed(ds)
+
+        result = await service.apply_run_control(
+            user_id=user_id,
+            ds_id=ds.id.value,
+            action="start",
+        )
+
+        assert result.started_run is not None
+        assert result.started_run.status == "pending"
+        assert result.affected_count == 1
 
 
 class TestDataSourceServiceCommitReferenceActions:

--- a/src/api/tests/unit/management/presentation/test_data_sources_routes.py
+++ b/src/api/tests/unit/management/presentation/test_data_sources_routes.py
@@ -466,6 +466,78 @@ class TestListSyncRunsRoute:
         mock_sync_run_repo.find_by_data_source.assert_not_called()
 
 
+class TestRunControlRoutes:
+    """Tests for POST /management/data-sources/{ds_id}/run-controls/{action}."""
+
+    def test_pause_run_control_returns_200_with_affected_count(
+        self,
+        test_client: TestClient,
+        mock_ds_service: AsyncMock,
+        sample_sync_run: DataSourceSyncRun,
+    ) -> None:
+        mock_ds_service.apply_run_control.return_value = type(
+            "_Result",
+            (),
+            {
+                "action": "pause",
+                "affected_count": 1,
+                "updated_runs": [sample_sync_run],
+                "started_run": None,
+            },
+        )()
+
+        response = test_client.post(
+            "/management/data-sources/01JPQRST1234567890ABCDEFDS/run-controls/pause"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        payload = response.json()
+        assert payload["action"] == "pause"
+        assert payload["affected_count"] == 1
+        assert len(payload["updated_runs"]) == 1
+        assert payload["started_run"] is None
+
+    def test_start_run_control_returns_started_run(
+        self,
+        test_client: TestClient,
+        mock_ds_service: AsyncMock,
+        sample_sync_run: DataSourceSyncRun,
+    ) -> None:
+        mock_ds_service.apply_run_control.return_value = type(
+            "_Result",
+            (),
+            {
+                "action": "start",
+                "affected_count": 1,
+                "updated_runs": [],
+                "started_run": sample_sync_run,
+            },
+        )()
+
+        response = test_client.post(
+            "/management/data-sources/01JPQRST1234567890ABCDEFDS/run-controls/start"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        payload = response.json()
+        assert payload["action"] == "start"
+        assert payload["affected_count"] == 1
+        assert payload["started_run"]["id"] == sample_sync_run.id
+
+    def test_run_control_returns_403_when_unauthorized(
+        self,
+        test_client: TestClient,
+        mock_ds_service: AsyncMock,
+    ) -> None:
+        mock_ds_service.apply_run_control.side_effect = UnauthorizedError("no permission")
+
+        response = test_client.post(
+            "/management/data-sources/01JPQRST1234567890ABCDEFDS/run-controls/halt"
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
 class TestGetSyncRunLogsRoute:
     """Tests for GET /management/data-sources/{ds_id}/sync-runs/{run_id}/logs endpoint.
 


### PR DESCRIPTION
## Summary
- add run-control orchestration in `DataSourceService` for `start`, `pause`, `halt`, `reset_running`, `reset_failed`, `reset_completed`, and `reset_all`
- expose control-plane endpoint `POST /management/data-sources/{ds_id}/run-controls/{action}` with manage authorization and fail-safe no-op semantics when no runs are actionable
- add API response model for control outcomes and expand unit tests to cover status transitions plus route behavior

## Testing
- [x] `cd src/api && uv run pytest tests/unit/management/application/test_data_source_service.py tests/unit/management/presentation/test_data_sources_routes.py -q`

Closes #671

Made with [Cursor](https://cursor.com)