### PR TITLE
feat(dev-ui): build extraction telemetry dashboard (#672)

### DIFF
--- a/src/api/management/presentation/data_sources/models.py
+++ b/src/api/management/presentation/data_sources/models.py
@@ -296,6 +296,12 @@ class SyncRunResponse(BaseModel):
         None, description="When the sync run completed"
     )
     error: str | None = Field(None, description="Error message if the sync run failed")
+    token_usage_total: int | None = Field(
+        None, description="Total model tokens consumed during extraction for this run"
+    )
+    cost_total_usd: float | None = Field(
+        None, description="Estimated USD cost for extraction execution in this run"
+    )
     created_at: datetime = Field(
         ..., description="When the sync run record was created"
     )
@@ -317,6 +323,16 @@ class SyncRunResponse(BaseModel):
             started_at=run.started_at,
             completed_at=run.completed_at,
             error=run.error,
+            token_usage_total=(
+                run.mutation_log_run.token_usage_total
+                if run.mutation_log_run is not None
+                else None
+            ),
+            cost_total_usd=(
+                run.mutation_log_run.cost_total_usd
+                if run.mutation_log_run is not None
+                else None
+            ),
             created_at=run.created_at,
         )
 

--- a/src/api/tests/unit/management/presentation/test_data_sources_routes.py
+++ b/src/api/tests/unit/management/presentation/test_data_sources_routes.py
@@ -18,6 +18,7 @@ from iam.domain.value_objects import TenantId, UserId
 from management.application.services.data_source_service import DataSourceService
 from management.domain.aggregates import DataSource
 from management.domain.entities import DataSourceSyncRun
+from management.domain.entities.data_source_sync_run import MutationLogRunMetadata
 from management.infrastructure.git_diff_summary_service import DiffSummaryResult
 from management.domain.value_objects import (
     DataSourceId,
@@ -448,6 +449,36 @@ class TestListSyncRunsRoute:
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == []
+
+    def test_list_sync_runs_includes_token_and_cost_metadata_when_available(
+        self,
+        test_client: TestClient,
+        mock_ds_service: AsyncMock,
+        mock_sync_run_repo: AsyncMock,
+        sample_data_source: DataSource,
+        sample_sync_run: DataSourceSyncRun,
+    ) -> None:
+        """Sync run response should expose token/cost telemetry metadata."""
+        sample_sync_run.mutation_log_run = MutationLogRunMetadata(
+            mutation_log_id="mlog-1",
+            knowledge_graph_id=sample_data_source.knowledge_graph_id,
+            session_id="sess-1",
+            actor_id="actor-1",
+            started_at=sample_sync_run.started_at,
+            token_usage_total=3210,
+            cost_total_usd=1.23,
+        )
+        mock_ds_service.get.return_value = sample_data_source
+        mock_sync_run_repo.find_by_data_source.return_value = [sample_sync_run]
+
+        response = test_client.get(
+            f"/management/data-sources/{sample_data_source.id.value}/sync-runs"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        payload = response.json()[0]
+        assert payload["token_usage_total"] == 3210
+        assert payload["cost_total_usd"] == pytest.approx(1.23)
 
     def test_list_sync_runs_returns_404_when_ds_not_found(
         self,

--- a/src/dev-ui/app/pages/data-sources/index.vue
+++ b/src/dev-ui/app/pages/data-sources/index.vue
@@ -23,6 +23,10 @@ import {
   FileText,
   Settings,
   RefreshCw,
+  Cpu,
+  Coins,
+  DollarSign,
+  Clock3,
 } from 'lucide-vue-next'
 import {
   ADAPTERS,
@@ -86,6 +90,8 @@ interface SyncRun {
   started_at: string
   completed_at: string | null
   error: string | null
+  token_usage_total?: number | null
+  cost_total_usd?: number | null
   created_at: string
 }
 
@@ -728,6 +734,59 @@ const hasActiveSyncs = computed(() =>
   }),
 )
 
+const telemetryRows = computed(() =>
+  dataSources.value.flatMap((ds) =>
+    (ds.sync_runs ?? []).map(run => ({ ...run, data_source_name: ds.name })),
+  ),
+)
+
+const telemetryStatusBuckets = computed(() => {
+  const buckets = {
+    pending: 0,
+    ingesting: 0,
+    ai_extracting: 0,
+    applying: 0,
+    completed: 0,
+    failed: 0,
+  }
+  for (const row of telemetryRows.value) {
+    buckets[row.status] += 1
+  }
+  return buckets
+})
+
+const telemetryRecentJobs = computed(() =>
+  [...telemetryRows.value]
+    .sort((a, b) => new Date(b.started_at).getTime() - new Date(a.started_at).getTime())
+    .slice(0, 8),
+)
+
+const telemetryActiveWorkers = computed(() =>
+  telemetryRows.value.filter(row => ACTIVE_STATUSES.includes(row.status)).length,
+)
+
+const telemetryTokenTotal = computed(() =>
+  telemetryRows.value.reduce((sum, row) => sum + (row.token_usage_total ?? 0), 0),
+)
+
+const telemetryCostTotal = computed(() =>
+  telemetryRows.value.reduce((sum, row) => sum + (row.cost_total_usd ?? 0), 0),
+)
+
+const telemetryCostTrend = computed(() => {
+  const now = Date.now()
+  const oneDayMs = 24 * 60 * 60 * 1000
+  let current = 0
+  let previous = 0
+  for (const row of telemetryRows.value) {
+    const eventMs = new Date(row.completed_at ?? row.started_at).getTime()
+    if (eventMs >= now - oneDayMs) current += row.cost_total_usd ?? 0
+    else if (eventMs >= now - oneDayMs * 2) previous += row.cost_total_usd ?? 0
+  }
+  const delta = current - previous
+  return { current, previous, delta }
+})
+
 /** Holds the active setInterval handle, or null when not polling. */
 const pollInterval = ref<ReturnType<typeof setInterval> | null>(null)
 
@@ -1144,6 +1203,83 @@ async function handleDeleteDs() {
     </div>
 
     <template v-else>
+      <!-- Extraction operations telemetry dashboard -->
+      <div class="grid gap-3 md:grid-cols-4">
+        <Card>
+          <CardHeader class="pb-2">
+            <CardDescription class="flex items-center gap-1.5 text-[11px]">
+              <Cpu class="size-3.5" />
+              Active workers
+            </CardDescription>
+            <CardTitle class="text-xl">{{ telemetryActiveWorkers }}</CardTitle>
+          </CardHeader>
+          <CardContent class="text-[11px] text-muted-foreground">
+            Pending {{ telemetryStatusBuckets.pending }} / Ingesting {{ telemetryStatusBuckets.ingesting }} / Extracting {{ telemetryStatusBuckets.ai_extracting }} / Applying {{ telemetryStatusBuckets.applying }}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader class="pb-2">
+            <CardDescription class="flex items-center gap-1.5 text-[11px]">
+              <Clock3 class="size-3.5" />
+              Recent jobs tracked
+            </CardDescription>
+            <CardTitle class="text-xl">{{ telemetryRows.length }}</CardTitle>
+          </CardHeader>
+          <CardContent class="text-[11px] text-muted-foreground">
+            Completed {{ telemetryStatusBuckets.completed }} / Failed {{ telemetryStatusBuckets.failed }}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader class="pb-2">
+            <CardDescription class="flex items-center gap-1.5 text-[11px]">
+              <Coins class="size-3.5" />
+              Total token usage
+            </CardDescription>
+            <CardTitle class="text-xl">{{ telemetryTokenTotal.toLocaleString() }}</CardTitle>
+          </CardHeader>
+          <CardContent class="text-[11px] text-muted-foreground">
+            Aggregated from sync-run mutation metadata.
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader class="pb-2">
+            <CardDescription class="flex items-center gap-1.5 text-[11px]">
+              <DollarSign class="size-3.5" />
+              Estimated cost trend
+            </CardDescription>
+            <CardTitle class="text-xl">${{ telemetryCostTrend.current.toFixed(2) }}</CardTitle>
+          </CardHeader>
+          <CardContent class="text-[11px]" :class="telemetryCostTrend.delta <= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-amber-600 dark:text-amber-400'">
+            {{ telemetryCostTrend.delta <= 0 ? 'Down' : 'Up' }} {{ Math.abs(telemetryCostTrend.delta).toFixed(2) }} vs previous 24h
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader class="pb-2">
+          <CardTitle class="text-sm">Recent job events</CardTitle>
+          <CardDescription class="text-xs">Auto-refreshes while active runs are in progress.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div v-if="telemetryRecentJobs.length === 0" class="text-xs text-muted-foreground">
+            No sync jobs yet.
+          </div>
+          <div v-else class="space-y-1.5">
+            <div v-for="job in telemetryRecentJobs" :key="job.id" class="flex items-center justify-between rounded border px-2 py-1.5 text-xs">
+              <div class="min-w-0">
+                <p class="truncate font-medium">{{ job.data_source_name }}</p>
+                <p class="truncate text-muted-foreground">{{ new Date(job.started_at).toLocaleString() }}</p>
+              </div>
+              <div class="flex items-center gap-2">
+                <SyncPhaseIndicator :status="job.status" />
+                <span class="font-mono text-muted-foreground">{{ job.token_usage_total ?? 0 }} tk</span>
+                <span class="font-mono text-muted-foreground">${{ (job.cost_total_usd ?? 0).toFixed(2) }}</span>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
       <!-- Empty state (no data sources yet) -->
       <div v-if="dataSources.length === 0" class="flex flex-col items-center gap-4 py-16 text-center">
         <div class="rounded-full bg-muted p-5">

--- a/src/dev-ui/app/tests/data-sources.test.ts
+++ b/src/dev-ui/app/tests/data-sources.test.ts
@@ -3138,3 +3138,27 @@ describe('Data Sources — kg_id query param pre-selects KG and opens wizard (Ta
     expect(source).toMatch(/openWizard\s*\([^)]*preselectedKgId/)
   })
 })
+
+describe('Extraction telemetry dashboard - structural verification', () => {
+  const { readFileSync } = require('fs')
+  const { resolve } = require('path')
+  const source = readFileSync(
+    resolve(__dirname, '../pages/data-sources/index.vue'),
+    'utf-8',
+  )
+
+  it('declares telemetry status buckets and recent jobs computeds', () => {
+    expect(source).toContain('telemetryStatusBuckets')
+    expect(source).toContain('telemetryRecentJobs')
+  })
+
+  it('renders active worker and token usage cards', () => {
+    expect(source).toContain('Active workers')
+    expect(source).toContain('Total token usage')
+  })
+
+  it('renders estimated cost trend with 24h comparison', () => {
+    expect(source).toContain('Estimated cost trend')
+    expect(source).toContain('previous 24h')
+  })
+})


### PR DESCRIPTION
## Summary
- expose per-sync token and cost telemetry in `SyncRunResponse` using mutation-log run metadata
- add extraction operations telemetry dashboard cards in data-sources UI for active workers, status buckets, token totals, and 24h cost trend delta
- add recent-job events table with per-run status/token/cost values and extend tests for backend telemetry serialization plus dashboard structural coverage

## Testing
- [x] `cd src/api && uv run pytest tests/unit/management/presentation/test_data_sources_routes.py -q`
- [ ] `cd src/dev-ui && npm test -- app/tests/data-sources.test.ts` *(blocked in current environment: `vitest` unavailable)*

Closes #672

Made with [Cursor](https://cursor.com)