### PR TITLE
feat: add KG maintenance scheduling and orchestration history (#673)

### DIFF
--- a/src/api/infrastructure/migrations/versions/fa0b1c2d3e4f_add_kg_maintenance_schedule_and_history.py
+++ b/src/api/infrastructure/migrations/versions/fa0b1c2d3e4f_add_kg_maintenance_schedule_and_history.py
@@ -1,0 +1,42 @@
+"""Add knowledge-graph maintenance schedule and run history columns.
+
+Revision ID: fa0b1c2d3e4f
+Revises: f8e9f0a1b2c3
+Create Date: 2026-05-14 12:00:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "fa0b1c2d3e4f"
+down_revision = "f8e9f0a1b2c3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add maintenance schedule and run history JSONB columns."""
+    op.add_column(
+        "knowledge_graphs",
+        sa.Column("maintenance_schedule", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+    op.add_column(
+        "knowledge_graphs",
+        sa.Column(
+            "maintenance_run_history",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+    )
+    op.alter_column("knowledge_graphs", "maintenance_run_history", server_default=None)
+
+
+def downgrade() -> None:
+    """Remove maintenance schedule and run history columns."""
+    op.drop_column("knowledge_graphs", "maintenance_run_history")
+    op.drop_column("knowledge_graphs", "maintenance_schedule")

--- a/src/api/management/application/services/knowledge_graph_service.py
+++ b/src/api/management/application/services/knowledge_graph_service.py
@@ -6,15 +6,24 @@ transaction management, and observability.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from croniter import CroniterBadCronError, croniter
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from ulid import ULID
 
 from management.application.observability import (
     DefaultKnowledgeGraphServiceProbe,
     KnowledgeGraphServiceProbe,
 )
 from management.domain.aggregates import KnowledgeGraph
+from management.domain.entities.data_source_sync_run import DataSourceSyncRun
 from management.domain.value_objects import (
+    KnowledgeGraphMaintenanceRunOutcome,
+    KnowledgeGraphMaintenanceRunRecord,
+    KnowledgeGraphMaintenanceSchedule,
     KnowledgeGraphId,
     KnowledgeGraphWorkspaceStatus,
     OntologyConfig,
@@ -29,6 +38,7 @@ from management.ports.exceptions import (
 )
 from management.ports.repositories import (
     IDataSourceRepository,
+    IDataSourceSyncRunRepository,
     IKnowledgeGraphRepository,
 )
 from management.ports.secret_store import ISecretStoreRepository
@@ -57,6 +67,7 @@ class KnowledgeGraphService:
         scope_to_tenant: str,
         probe: KnowledgeGraphServiceProbe | None = None,
         data_source_repository: IDataSourceRepository | None = None,
+        sync_run_repository: IDataSourceSyncRunRepository | None = None,
         secret_store: ISecretStoreRepository | None = None,
     ) -> None:
         """Initialize KnowledgeGraphService with dependencies.
@@ -76,7 +87,222 @@ class KnowledgeGraphService:
         self._scope_to_tenant = scope_to_tenant
         self._probe = probe or DefaultKnowledgeGraphServiceProbe()
         self._ds_repo = data_source_repository
+        self._sync_run_repo = sync_run_repository
         self._secret_store = secret_store
+
+    def _compute_next_run_at_utc(
+        self,
+        *,
+        cron_expression: str,
+        timezone_name: str,
+        now_utc: datetime | None = None,
+    ) -> datetime:
+        """Compute next scheduled runtime in UTC from cron + timezone."""
+        if not croniter.is_valid(cron_expression):
+            raise ValueError(f"Invalid cron expression: {cron_expression!r}")
+        try:
+            tz = ZoneInfo(timezone_name)
+        except ZoneInfoNotFoundError as exc:
+            raise ValueError(f"Unknown timezone: {timezone_name!r}") from exc
+
+        now_utc = now_utc or datetime.now(UTC)
+        local_now = now_utc.astimezone(tz)
+        try:
+            itr = croniter(cron_expression, local_now)
+            next_local = itr.get_next(datetime)
+        except (CroniterBadCronError, ValueError) as exc:
+            raise ValueError(f"Invalid cron expression: {cron_expression!r}") from exc
+
+        if next_local.tzinfo is None:
+            next_local = next_local.replace(tzinfo=tz)
+        return next_local.astimezone(UTC)
+
+    async def _get_tenant_scoped_kg(
+        self, *, kg_id: str, user_id: str, permission: Permission
+    ) -> KnowledgeGraph:
+        """Resolve KG with tenant and authz checks."""
+        has_permission = await self._check_permission(
+            user_id=user_id,
+            resource_type=ResourceType.KNOWLEDGE_GRAPH,
+            resource_id=kg_id,
+            permission=permission,
+        )
+        if not has_permission:
+            self._probe.permission_denied(
+                user_id=user_id,
+                resource_id=kg_id,
+                permission=permission,
+            )
+            raise UnauthorizedError(
+                f"User {user_id} lacks {permission.value} permission on knowledge graph {kg_id}"
+            )
+
+        kg = await self._kg_repo.get_by_id(KnowledgeGraphId(value=kg_id))
+        if kg is None or kg.tenant_id != self._scope_to_tenant:
+            raise KnowledgeGraphNotFoundError(f"Knowledge graph {kg_id} not found")
+        return kg
+
+    async def get_maintenance_schedule(
+        self, *, user_id: str, kg_id: str
+    ) -> KnowledgeGraphMaintenanceSchedule:
+        """Return KG-level maintenance schedule config."""
+        kg = await self._get_tenant_scoped_kg(
+            kg_id=kg_id,
+            user_id=user_id,
+            permission=Permission.VIEW,
+        )
+        return kg.maintenance_schedule or KnowledgeGraphMaintenanceSchedule(
+            enabled=False,
+            cron_expression="0 2 * * *",
+            timezone_name="UTC",
+            next_run_at=None,
+        )
+
+    async def upsert_maintenance_schedule(
+        self,
+        *,
+        user_id: str,
+        kg_id: str,
+        cron_expression: str,
+        timezone_name: str,
+        enabled: bool,
+    ) -> KnowledgeGraphMaintenanceSchedule:
+        """Create or update KG-level maintenance schedule configuration."""
+        kg = await self._get_tenant_scoped_kg(
+            kg_id=kg_id,
+            user_id=user_id,
+            permission=Permission.MANAGE,
+        )
+        next_run_at = (
+            self._compute_next_run_at_utc(
+                cron_expression=cron_expression,
+                timezone_name=timezone_name,
+            )
+            if enabled
+            else None
+        )
+        schedule = KnowledgeGraphMaintenanceSchedule(
+            enabled=enabled,
+            cron_expression=cron_expression,
+            timezone_name=timezone_name,
+            next_run_at=next_run_at,
+        )
+        kg.set_maintenance_schedule(schedule)
+        await self._kg_repo.save(kg)
+        await self._session.commit()
+        return schedule
+
+    async def list_maintenance_runs(
+        self, *, user_id: str, kg_id: str, limit: int = 20
+    ) -> list[KnowledgeGraphMaintenanceRunRecord]:
+        """List persisted maintenance run outcomes for a KG."""
+        kg = await self._get_tenant_scoped_kg(
+            kg_id=kg_id,
+            user_id=user_id,
+            permission=Permission.VIEW,
+        )
+        capped_limit = max(1, min(limit, 100))
+        return list(kg.maintenance_run_history[-capped_limit:])[::-1]
+
+    async def trigger_maintenance_run(
+        self, *, user_id: str, kg_id: str
+    ) -> KnowledgeGraphMaintenanceRunRecord:
+        """Trigger maintenance orchestration across all data sources in a KG."""
+        kg = await self._get_tenant_scoped_kg(
+            kg_id=kg_id,
+            user_id=user_id,
+            permission=Permission.MANAGE,
+        )
+        if self._ds_repo is None:
+            raise ValueError("Data source repository is not configured")
+
+        data_sources = await self._ds_repo.find_by_knowledge_graph(kg_id)
+        run_id = str(ULID())
+        now = datetime.now(UTC)
+
+        if not data_sources:
+            run = KnowledgeGraphMaintenanceRunRecord(
+                run_id=run_id,
+                triggered_at=now,
+                outcome=KnowledgeGraphMaintenanceRunOutcome.PREFLIGHT_FAILED,
+                message="No data sources connected to this knowledge graph",
+            )
+            kg.append_maintenance_run(run)
+            await self._kg_repo.save(kg)
+            await self._session.commit()
+            return run
+
+        changed_sources = [
+            ds
+            for ds in data_sources
+            if ds.tracked_branch_head_commit is not None
+            and ds.last_extraction_baseline_commit is not None
+            and ds.tracked_branch_head_commit != ds.last_extraction_baseline_commit
+        ]
+        target_data_source_ids = tuple(ds.id.value for ds in data_sources)
+
+        if not changed_sources:
+            run = KnowledgeGraphMaintenanceRunRecord(
+                run_id=run_id,
+                triggered_at=now,
+                outcome=KnowledgeGraphMaintenanceRunOutcome.NO_CHANGES,
+                message="No source commit delta detected across connected data sources",
+                target_data_source_ids=target_data_source_ids,
+            )
+            kg.append_maintenance_run(run)
+            await self._kg_repo.save(kg)
+            await self._session.commit()
+            return run
+
+        if self._sync_run_repo is None:
+            run = KnowledgeGraphMaintenanceRunRecord(
+                run_id=run_id,
+                triggered_at=now,
+                outcome=KnowledgeGraphMaintenanceRunOutcome.LAUNCH_FAILED,
+                message="Sync run repository is not configured",
+                target_data_source_ids=tuple(ds.id.value for ds in changed_sources),
+            )
+            kg.append_maintenance_run(run)
+            await self._kg_repo.save(kg)
+            await self._session.commit()
+            return run
+
+        try:
+            for data_source in changed_sources:
+                sync_run_id = str(ULID())
+                sync_run = DataSourceSyncRun(
+                    id=sync_run_id,
+                    data_source_id=data_source.id.value,
+                    status="pending",
+                    started_at=now,
+                    completed_at=None,
+                    error=None,
+                    created_at=now,
+                )
+                await self._sync_run_repo.save(sync_run)
+                data_source.request_sync(sync_run_id=sync_run_id, requested_by=user_id)
+                await self._ds_repo.save(data_source)
+
+            run = KnowledgeGraphMaintenanceRunRecord(
+                run_id=run_id,
+                triggered_at=now,
+                outcome=KnowledgeGraphMaintenanceRunOutcome.STARTED,
+                message="Scheduled maintenance sync runs started",
+                target_data_source_ids=tuple(ds.id.value for ds in changed_sources),
+            )
+        except Exception as exc:
+            run = KnowledgeGraphMaintenanceRunRecord(
+                run_id=run_id,
+                triggered_at=now,
+                outcome=KnowledgeGraphMaintenanceRunOutcome.LAUNCH_FAILED,
+                message=f"Failed to launch maintenance syncs: {exc}",
+                target_data_source_ids=tuple(ds.id.value for ds in changed_sources),
+            )
+
+        kg.append_maintenance_run(run)
+        await self._kg_repo.save(kg)
+        await self._session.commit()
+        return run
 
     async def _check_permission(
         self,

--- a/src/api/management/dependencies/knowledge_graph.py
+++ b/src/api/management/dependencies/knowledge_graph.py
@@ -21,6 +21,7 @@ from management.application.services.knowledge_graph_service import (
 )
 from management.infrastructure.repositories import (
     DataSourceRepository,
+    DataSourceSyncRunRepository,
     FernetSecretStore,
     KnowledgeGraphRepository,
 )
@@ -46,6 +47,7 @@ def get_knowledge_graph_service(
     outbox = OutboxRepository(session=session)
     kg_repo = KnowledgeGraphRepository(session=session, outbox=outbox)
     ds_repo = DataSourceRepository(session=session, outbox=outbox)
+    sync_run_repo = DataSourceSyncRunRepository(session=session)
     encryption_keys = settings.encryption_key.get_secret_value().split(",")
     secret_store = FernetSecretStore(
         session=session,
@@ -55,6 +57,7 @@ def get_knowledge_graph_service(
         session=session,
         knowledge_graph_repository=kg_repo,
         data_source_repository=ds_repo,
+        sync_run_repository=sync_run_repo,
         secret_store=secret_store,
         authz=authz,
         scope_to_tenant=current_user.tenant_id.value,

--- a/src/api/management/domain/aggregates/knowledge_graph.py
+++ b/src/api/management/domain/aggregates/knowledge_graph.py
@@ -24,6 +24,8 @@ from management.domain.observability import (
     KnowledgeGraphProbe,
 )
 from management.domain.value_objects import (
+    KnowledgeGraphMaintenanceRunRecord,
+    KnowledgeGraphMaintenanceSchedule,
     KnowledgeGraphId,
     OntologyConfig,
     WorkspaceMode,
@@ -58,6 +60,10 @@ class KnowledgeGraph:
     created_at: datetime
     updated_at: datetime
     ontology: OntologyConfig | None = field(default=None)
+    maintenance_schedule: KnowledgeGraphMaintenanceSchedule | None = field(default=None)
+    maintenance_run_history: tuple[KnowledgeGraphMaintenanceRunRecord, ...] = field(
+        default_factory=tuple
+    )
     workspace_mode: WorkspaceMode = field(default=WorkspaceMode.SCHEMA_BOOTSTRAP)
     active_schema_bootstrap_session_id: str | None = field(default=None)
     active_extraction_operations_session_id: str | None = field(default=None)
@@ -240,6 +246,27 @@ class KnowledgeGraph:
                 "Cannot clear ontology on a deleted knowledge graph"
             )
         self.ontology = None
+        self.updated_at = datetime.now(UTC)
+
+    def set_maintenance_schedule(self, schedule: KnowledgeGraphMaintenanceSchedule) -> None:
+        """Persist KG-level maintenance schedule configuration."""
+        if self._deleted:
+            raise AggregateDeletedError(
+                "Cannot set maintenance schedule on a deleted knowledge graph"
+            )
+        self.maintenance_schedule = schedule
+        self.updated_at = datetime.now(UTC)
+
+    def append_maintenance_run(
+        self, run: KnowledgeGraphMaintenanceRunRecord, *, max_history: int = 50
+    ) -> None:
+        """Append a maintenance orchestration run to KG-scoped history."""
+        if self._deleted:
+            raise AggregateDeletedError(
+                "Cannot append maintenance history on a deleted knowledge graph"
+            )
+        history = [*self.maintenance_run_history, run]
+        self.maintenance_run_history = tuple(history[-max_history:])
         self.updated_at = datetime.now(UTC)
 
     def transition_to_extraction_operations(self) -> str:

--- a/src/api/management/domain/value_objects.py
+++ b/src/api/management/domain/value_objects.py
@@ -142,6 +142,86 @@ class KnowledgeGraphWorkspaceStatus:
     session_pointers: WorkspaceSessionPointers
 
 
+class KnowledgeGraphMaintenanceRunOutcome(StrEnum):
+    """Allowed outcomes for a KG-scoped maintenance orchestration attempt."""
+
+    STARTED = "started"
+    NO_CHANGES = "no-changes"
+    PREFLIGHT_FAILED = "preflight-failed"
+    LAUNCH_FAILED = "launch-failed"
+
+
+@dataclass(frozen=True)
+class KnowledgeGraphMaintenanceSchedule:
+    """Knowledge-graph level maintenance schedule configuration."""
+
+    enabled: bool
+    cron_expression: str
+    timezone_name: str
+    next_run_at: datetime | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to JSON-compatible dictionary."""
+        return {
+            "enabled": self.enabled,
+            "cron_expression": self.cron_expression,
+            "timezone_name": self.timezone_name,
+            "next_run_at": (
+                self.next_run_at.isoformat() if self.next_run_at is not None else None
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "KnowledgeGraphMaintenanceSchedule":
+        """Reconstruct schedule from persisted JSON dictionary."""
+        next_run_at_raw = data.get("next_run_at")
+        next_run_at = (
+            datetime.fromisoformat(str(next_run_at_raw))
+            if next_run_at_raw is not None
+            else None
+        )
+        return cls(
+            enabled=bool(data.get("enabled", False)),
+            cron_expression=str(data.get("cron_expression", "0 2 * * *")),
+            timezone_name=str(data.get("timezone_name", "UTC")),
+            next_run_at=next_run_at,
+        )
+
+
+@dataclass(frozen=True)
+class KnowledgeGraphMaintenanceRunRecord:
+    """Immutable audit record for a KG maintenance orchestration attempt."""
+
+    run_id: str
+    triggered_at: datetime
+    outcome: KnowledgeGraphMaintenanceRunOutcome
+    message: str | None = None
+    target_data_source_ids: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to JSON-compatible dictionary."""
+        return {
+            "run_id": self.run_id,
+            "triggered_at": self.triggered_at.isoformat(),
+            "outcome": self.outcome.value,
+            "message": self.message,
+            "target_data_source_ids": list(self.target_data_source_ids),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "KnowledgeGraphMaintenanceRunRecord":
+        """Reconstruct a run record from persisted JSON dictionary."""
+        return cls(
+            run_id=str(data["run_id"]),
+            triggered_at=datetime.fromisoformat(str(data["triggered_at"])),
+            outcome=KnowledgeGraphMaintenanceRunOutcome(str(data["outcome"])),
+            message=(str(data["message"]) if data.get("message") is not None else None),
+            target_data_source_ids=tuple(
+                str(ds_id) for ds_id in data.get("target_data_source_ids", [])
+            ),
+        )
+
+
 @dataclass(frozen=True)
 class Schedule:
     """Schedule configuration for data source synchronization.

--- a/src/api/management/infrastructure/models/knowledge_graph.py
+++ b/src/api/management/infrastructure/models/knowledge_graph.py
@@ -47,6 +47,12 @@ class KnowledgeGraphModel(Base, TimestampMixin):
         String(26), nullable=True
     )
     ontology: Mapped[dict | None] = mapped_column(JSONB, nullable=True, default=None)
+    maintenance_schedule: Mapped[dict | None] = mapped_column(
+        JSONB, nullable=True, default=None
+    )
+    maintenance_run_history: Mapped[list[dict]] = mapped_column(
+        JSONB, nullable=False, default=list
+    )
 
     __table_args__ = (
         UniqueConstraint("tenant_id", "name", name="uq_knowledge_graphs_tenant_name"),

--- a/src/api/management/infrastructure/repositories/knowledge_graph_repository.py
+++ b/src/api/management/infrastructure/repositories/knowledge_graph_repository.py
@@ -14,6 +14,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from management.domain.aggregates import KnowledgeGraph
 from management.domain.value_objects import (
+    KnowledgeGraphMaintenanceRunRecord,
+    KnowledgeGraphMaintenanceSchedule,
     KnowledgeGraphId,
     OntologyConfig,
     WorkspaceMode,
@@ -82,6 +84,14 @@ class KnowledgeGraphRepository(IKnowledgeGraphRepository):
                     knowledge_graph.most_recent_completed_session_id
                 )
                 model.updated_at = knowledge_graph.updated_at
+                model.maintenance_schedule = (
+                    knowledge_graph.maintenance_schedule.to_dict()
+                    if knowledge_graph.maintenance_schedule is not None
+                    else None
+                )
+                model.maintenance_run_history = [
+                    run.to_dict() for run in knowledge_graph.maintenance_run_history
+                ]
             else:
                 model = KnowledgeGraphModel(
                     id=knowledge_graph.id.value,
@@ -101,6 +111,14 @@ class KnowledgeGraphRepository(IKnowledgeGraphRepository):
                     ),
                     created_at=knowledge_graph.created_at,
                     updated_at=knowledge_graph.updated_at,
+                    maintenance_schedule=(
+                        knowledge_graph.maintenance_schedule.to_dict()
+                        if knowledge_graph.maintenance_schedule is not None
+                        else None
+                    ),
+                    maintenance_run_history=[
+                        run.to_dict() for run in knowledge_graph.maintenance_run_history
+                    ],
                 )
                 self._session.add(model)
 
@@ -233,6 +251,15 @@ class KnowledgeGraphRepository(IKnowledgeGraphRepository):
         ontology: OntologyConfig | None = None
         if model.ontology is not None:
             ontology = OntologyConfig.from_dict(model.ontology)
+        maintenance_schedule: KnowledgeGraphMaintenanceSchedule | None = None
+        if model.maintenance_schedule is not None:
+            maintenance_schedule = KnowledgeGraphMaintenanceSchedule.from_dict(
+                model.maintenance_schedule
+            )
+        maintenance_run_history = tuple(
+            KnowledgeGraphMaintenanceRunRecord.from_dict(raw_run)
+            for raw_run in (model.maintenance_run_history or [])
+        )
 
         return KnowledgeGraph(
             id=KnowledgeGraphId(value=model.id),
@@ -243,6 +270,8 @@ class KnowledgeGraphRepository(IKnowledgeGraphRepository):
             created_at=model.created_at,
             updated_at=model.updated_at,
             ontology=ontology,
+            maintenance_schedule=maintenance_schedule,
+            maintenance_run_history=maintenance_run_history,
             workspace_mode=WorkspaceMode(model.workspace_mode),
             active_schema_bootstrap_session_id=model.active_schema_bootstrap_session_id,
             active_extraction_operations_session_id=(

--- a/src/api/management/presentation/knowledge_graphs/models.py
+++ b/src/api/management/presentation/knowledge_graphs/models.py
@@ -9,6 +9,8 @@ from pydantic import BaseModel, Field
 from management.domain.aggregates import KnowledgeGraph
 from management.domain.value_objects import (
     EdgeTypeDefinition,
+    KnowledgeGraphMaintenanceRunRecord,
+    KnowledgeGraphMaintenanceSchedule,
     KnowledgeGraphWorkspaceStatus,
     NodeTypeDefinition,
     OntologyConfig,
@@ -168,6 +170,72 @@ class KnowledgeGraphWorkspaceStatusResponse(BaseModel):
                 status.session_pointers
             ),
         )
+
+
+class MaintenanceScheduleUpsertRequest(BaseModel):
+    """Request body for KG maintenance schedule upsert."""
+
+    enabled: bool = Field(
+        default=True,
+        description="Whether scheduled maintenance is enabled for this KG",
+    )
+    cron_expression: str = Field(
+        default="0 2 * * *",
+        description="Cron expression interpreted in timezone_name",
+    )
+    timezone_name: str = Field(
+        default="UTC",
+        description="IANA timezone identifier used for schedule evaluation",
+    )
+
+
+class MaintenanceScheduleResponse(BaseModel):
+    """Response model for KG maintenance schedule configuration."""
+
+    enabled: bool
+    cron_expression: str
+    timezone_name: str
+    next_run_at: datetime | None
+
+    @classmethod
+    def from_domain(
+        cls, schedule: KnowledgeGraphMaintenanceSchedule
+    ) -> "MaintenanceScheduleResponse":
+        return cls(
+            enabled=schedule.enabled,
+            cron_expression=schedule.cron_expression,
+            timezone_name=schedule.timezone_name,
+            next_run_at=schedule.next_run_at,
+        )
+
+
+class MaintenanceRunResponse(BaseModel):
+    """Response model for an individual KG maintenance run outcome."""
+
+    run_id: str
+    triggered_at: datetime
+    outcome: str
+    message: str | None
+    target_data_source_ids: list[str]
+
+    @classmethod
+    def from_domain(
+        cls, run: KnowledgeGraphMaintenanceRunRecord
+    ) -> "MaintenanceRunResponse":
+        return cls(
+            run_id=run.run_id,
+            triggered_at=run.triggered_at,
+            outcome=run.outcome.value,
+            message=run.message,
+            target_data_source_ids=list(run.target_data_source_ids),
+        )
+
+
+class MaintenanceRunListResponse(BaseModel):
+    """Response model for KG maintenance run history."""
+
+    runs: list[MaintenanceRunResponse]
+    count: int
 
 
 # ---------------------------------------------------------------------------

--- a/src/api/management/presentation/knowledge_graphs/routes.py
+++ b/src/api/management/presentation/knowledge_graphs/routes.py
@@ -22,6 +22,10 @@ from management.presentation.knowledge_graphs.models import (
     KnowledgeGraphListResponse,
     KnowledgeGraphResponse,
     KnowledgeGraphWorkspaceStatusResponse,
+    MaintenanceRunListResponse,
+    MaintenanceRunResponse,
+    MaintenanceScheduleResponse,
+    MaintenanceScheduleUpsertRequest,
     OntologyConfigRequest,
     OntologyConfigResponse,
     UpdateKnowledgeGraphRequest,
@@ -29,6 +33,160 @@ from management.presentation.knowledge_graphs.models import (
 from shared_kernel.authorization.types import Permission
 
 router = APIRouter(tags=["knowledge-graphs"])
+
+
+@router.get(
+    "/knowledge-graphs/{kg_id}/maintenance-schedule",
+    response_model=MaintenanceScheduleResponse,
+    summary="Get KG maintenance schedule configuration",
+)
+async def get_knowledge_graph_maintenance_schedule(
+    kg_id: str,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    service: Annotated[KnowledgeGraphService, Depends(get_knowledge_graph_service)],
+) -> MaintenanceScheduleResponse:
+    """Get knowledge-graph scoped maintenance schedule settings."""
+    try:
+        schedule = await service.get_maintenance_schedule(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+        )
+        return MaintenanceScheduleResponse.from_domain(schedule)
+    except UnauthorizedError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to perform this action",
+        )
+    except KnowledgeGraphNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        )
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to load maintenance schedule",
+        )
+
+
+@router.put(
+    "/knowledge-graphs/{kg_id}/maintenance-schedule",
+    response_model=MaintenanceScheduleResponse,
+    summary="Create or update KG maintenance schedule configuration",
+)
+async def upsert_knowledge_graph_maintenance_schedule(
+    kg_id: str,
+    request: MaintenanceScheduleUpsertRequest,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    service: Annotated[KnowledgeGraphService, Depends(get_knowledge_graph_service)],
+) -> MaintenanceScheduleResponse:
+    """Upsert knowledge-graph scoped maintenance schedule settings."""
+    try:
+        schedule = await service.upsert_maintenance_schedule(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+            cron_expression=request.cron_expression,
+            timezone_name=request.timezone_name,
+            enabled=request.enabled,
+        )
+        return MaintenanceScheduleResponse.from_domain(schedule)
+    except UnauthorizedError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to perform this action",
+        )
+    except KnowledgeGraphNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to save maintenance schedule",
+        )
+
+
+@router.get(
+    "/knowledge-graphs/{kg_id}/maintenance-runs",
+    response_model=MaintenanceRunListResponse,
+    summary="List KG maintenance run outcomes",
+)
+async def list_knowledge_graph_maintenance_runs(
+    kg_id: str,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    service: Annotated[KnowledgeGraphService, Depends(get_knowledge_graph_service)],
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+) -> MaintenanceRunListResponse:
+    """List persisted maintenance orchestration outcomes for a KG."""
+    try:
+        runs = await service.list_maintenance_runs(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+            limit=limit,
+        )
+        items = [MaintenanceRunResponse.from_domain(run) for run in runs]
+        return MaintenanceRunListResponse(runs=items, count=len(items))
+    except UnauthorizedError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to perform this action",
+        )
+    except KnowledgeGraphNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        )
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list maintenance runs",
+        )
+
+
+@router.post(
+    "/knowledge-graphs/{kg_id}/maintenance-runs/trigger",
+    response_model=MaintenanceRunResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Trigger KG maintenance orchestration",
+)
+async def trigger_knowledge_graph_maintenance_run(
+    kg_id: str,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    service: Annotated[KnowledgeGraphService, Depends(get_knowledge_graph_service)],
+) -> MaintenanceRunResponse:
+    """Trigger a maintenance run across all data sources in a knowledge graph."""
+    try:
+        run = await service.trigger_maintenance_run(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+        )
+        return MaintenanceRunResponse.from_domain(run)
+    except UnauthorizedError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to perform this action",
+        )
+    except KnowledgeGraphNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e),
+        )
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to trigger maintenance run",
+        )
 
 
 @router.get(

--- a/src/api/tests/unit/management/application/test_knowledge_graph_service.py
+++ b/src/api/tests/unit/management/application/test_knowledge_graph_service.py
@@ -19,9 +19,13 @@ from management.application.services.knowledge_graph_service import (
     KnowledgeGraphService,
 )
 from management.domain.aggregates import DataSource, KnowledgeGraph
+from management.domain.entities.data_source_sync_run import DataSourceSyncRun
 from management.domain.value_objects import (
     DataSourceId,
     EdgeTypeDefinition,
+    KnowledgeGraphMaintenanceRunOutcome,
+    KnowledgeGraphMaintenanceSchedule,
+    KnowledgeGraphMaintenanceRunRecord,
     KnowledgeGraphWorkspaceStatus,
     KnowledgeGraphId,
     NodeTypeDefinition,
@@ -1290,6 +1294,140 @@ class TestListForWorkspaceWithPermission:
 
         assert len(result) == 1
         assert result[0].id.value == kg1.id.value
+
+
+class _InMemorySyncRunRepository:
+    """Minimal in-memory sync-run repository for KG maintenance tests."""
+
+    def __init__(self) -> None:
+        self.saved: list[DataSourceSyncRun] = []
+
+    async def save(self, sync_run: DataSourceSyncRun) -> None:
+        self.saved.append(sync_run)
+
+    async def get_by_id(self, sync_run_id: str) -> DataSourceSyncRun | None:
+        for run in self.saved:
+            if run.id == sync_run_id:
+                return run
+        return None
+
+    async def find_by_data_source(self, data_source_id: str) -> list[DataSourceSyncRun]:
+        return [run for run in self.saved if run.data_source_id == data_source_id]
+
+    async def get_latest_for_data_source(
+        self, data_source_id: str
+    ) -> DataSourceSyncRun | None:
+        matches = [run for run in self.saved if run.data_source_id == data_source_id]
+        return max(matches, key=lambda run: run.created_at) if matches else None
+
+
+class TestKnowledgeGraphMaintenanceScheduling:
+    """Tests for KG-scoped maintenance schedule and run history APIs."""
+
+    @pytest.mark.asyncio
+    async def test_upsert_maintenance_schedule_persists_timezone_and_next_run(
+        self, mock_session, kg_repo, ds_repo, secret_store, authz, probe, tenant_id, user_id
+    ):
+        """Upserting schedule stores config and computes a next_run_at timestamp."""
+        kg = _make_kg(kg_id="kg-maint-001", tenant_id=tenant_id)
+        kg_repo.seed(kg)
+        await _grant_kg_manage(authz, kg.id.value, user_id)
+        sync_run_repo = _InMemorySyncRunRepository()
+        svc = KnowledgeGraphService(
+            session=mock_session,
+            knowledge_graph_repository=kg_repo,
+            data_source_repository=ds_repo,
+            secret_store=secret_store,
+            authz=authz,
+            scope_to_tenant=tenant_id,
+            probe=probe,
+            sync_run_repository=sync_run_repo,
+        )
+
+        schedule = await svc.upsert_maintenance_schedule(
+            user_id=user_id,
+            kg_id=kg.id.value,
+            cron_expression="0 9 * * *",
+            timezone_name="America/New_York",
+            enabled=True,
+        )
+
+        assert isinstance(schedule, KnowledgeGraphMaintenanceSchedule)
+        assert schedule.cron_expression == "0 9 * * *"
+        assert schedule.timezone_name == "America/New_York"
+        assert schedule.enabled is True
+        assert schedule.next_run_at is not None
+
+    @pytest.mark.asyncio
+    async def test_trigger_maintenance_run_records_no_changes_outcome(
+        self, mock_session, kg_repo, ds_repo, secret_store, authz, probe, tenant_id, user_id
+    ):
+        """When no DS has commit deltas, trigger records NO_CHANGES."""
+        kg = _make_kg(kg_id="kg-maint-002", tenant_id=tenant_id)
+        kg_repo.seed(kg)
+        await _grant_kg_manage(authz, kg.id.value, user_id)
+
+        ds_no_change = _make_ds(ds_id="ds-no-change", kg_id=kg.id.value, tenant_id=tenant_id)
+        ds_no_change.last_extraction_baseline_commit = "abc123"
+        ds_no_change.tracked_branch_head_commit = "abc123"
+        ds_repo.seed(ds_no_change)
+
+        sync_run_repo = _InMemorySyncRunRepository()
+        svc = KnowledgeGraphService(
+            session=mock_session,
+            knowledge_graph_repository=kg_repo,
+            data_source_repository=ds_repo,
+            secret_store=secret_store,
+            authz=authz,
+            scope_to_tenant=tenant_id,
+            probe=probe,
+            sync_run_repository=sync_run_repo,
+        )
+
+        run = await svc.trigger_maintenance_run(
+            user_id=user_id,
+            kg_id=kg.id.value,
+        )
+
+        assert isinstance(run, KnowledgeGraphMaintenanceRunRecord)
+        assert run.outcome == KnowledgeGraphMaintenanceRunOutcome.NO_CHANGES
+        assert run.target_data_source_ids == ("ds-no-change",)
+        assert len(sync_run_repo.saved) == 0
+
+    @pytest.mark.asyncio
+    async def test_trigger_maintenance_run_records_started_and_creates_sync_runs(
+        self, mock_session, kg_repo, ds_repo, secret_store, authz, probe, tenant_id, user_id
+    ):
+        """When DS commit deltas exist, trigger records STARTED and enqueues sync runs."""
+        kg = _make_kg(kg_id="kg-maint-003", tenant_id=tenant_id)
+        kg_repo.seed(kg)
+        await _grant_kg_manage(authz, kg.id.value, user_id)
+
+        ds_changed = _make_ds(ds_id="ds-changed", kg_id=kg.id.value, tenant_id=tenant_id)
+        ds_changed.last_extraction_baseline_commit = "abc123"
+        ds_changed.tracked_branch_head_commit = "def456"
+        ds_repo.seed(ds_changed)
+
+        sync_run_repo = _InMemorySyncRunRepository()
+        svc = KnowledgeGraphService(
+            session=mock_session,
+            knowledge_graph_repository=kg_repo,
+            data_source_repository=ds_repo,
+            secret_store=secret_store,
+            authz=authz,
+            scope_to_tenant=tenant_id,
+            probe=probe,
+            sync_run_repository=sync_run_repo,
+        )
+
+        run = await svc.trigger_maintenance_run(
+            user_id=user_id,
+            kg_id=kg.id.value,
+        )
+
+        assert run.outcome == KnowledgeGraphMaintenanceRunOutcome.STARTED
+        assert run.target_data_source_ids == ("ds-changed",)
+        assert len(sync_run_repo.saved) == 1
 
     @pytest.mark.asyncio
     async def test_returns_empty_list_when_no_kgs_in_workspace(

--- a/src/api/tests/unit/management/presentation/test_knowledge_graphs_routes.py
+++ b/src/api/tests/unit/management/presentation/test_knowledge_graphs_routes.py
@@ -20,6 +20,9 @@ from management.application.services.knowledge_graph_service import (
 )
 from management.domain.aggregates import KnowledgeGraph
 from management.domain.value_objects import (
+    KnowledgeGraphMaintenanceRunOutcome,
+    KnowledgeGraphMaintenanceRunRecord,
+    KnowledgeGraphMaintenanceSchedule,
     KnowledgeGraphId,
     KnowledgeGraphWorkspaceStatus,
     WorkspaceMode,
@@ -358,6 +361,133 @@ class TestGetKnowledgeGraphWorkspaceStatusRoute:
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestKnowledgeGraphMaintenanceRoutes:
+    """Tests for KG maintenance schedule and run history routes."""
+
+    def test_get_maintenance_schedule_returns_200(
+        self,
+        test_client: TestClient,
+        mock_kg_service: AsyncMock,
+        sample_knowledge_graph: KnowledgeGraph,
+        mock_current_user: CurrentUser,
+    ) -> None:
+        mock_kg_service.get_maintenance_schedule.return_value = (
+            KnowledgeGraphMaintenanceSchedule(
+                enabled=True,
+                cron_expression="0 9 * * *",
+                timezone_name="UTC",
+                next_run_at=datetime.now(UTC),
+            )
+        )
+
+        response = test_client.get(
+            f"/management/knowledge-graphs/{sample_knowledge_graph.id.value}/maintenance-schedule"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        payload = response.json()
+        assert payload["enabled"] is True
+        assert payload["cron_expression"] == "0 9 * * *"
+        mock_kg_service.get_maintenance_schedule.assert_called_once_with(
+            user_id=mock_current_user.user_id.value,
+            kg_id=sample_knowledge_graph.id.value,
+        )
+
+    def test_put_maintenance_schedule_calls_service(
+        self,
+        test_client: TestClient,
+        mock_kg_service: AsyncMock,
+        sample_knowledge_graph: KnowledgeGraph,
+        mock_current_user: CurrentUser,
+    ) -> None:
+        mock_kg_service.upsert_maintenance_schedule.return_value = (
+            KnowledgeGraphMaintenanceSchedule(
+                enabled=True,
+                cron_expression="30 8 * * *",
+                timezone_name="America/New_York",
+                next_run_at=datetime.now(UTC),
+            )
+        )
+
+        response = test_client.put(
+            f"/management/knowledge-graphs/{sample_knowledge_graph.id.value}/maintenance-schedule",
+            json={
+                "enabled": True,
+                "cron_expression": "30 8 * * *",
+                "timezone_name": "America/New_York",
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_kg_service.upsert_maintenance_schedule.assert_called_once_with(
+            user_id=mock_current_user.user_id.value,
+            kg_id=sample_knowledge_graph.id.value,
+            cron_expression="30 8 * * *",
+            timezone_name="America/New_York",
+            enabled=True,
+        )
+
+    def test_list_maintenance_runs_returns_200(
+        self,
+        test_client: TestClient,
+        mock_kg_service: AsyncMock,
+        sample_knowledge_graph: KnowledgeGraph,
+        mock_current_user: CurrentUser,
+    ) -> None:
+        mock_kg_service.list_maintenance_runs.return_value = [
+            KnowledgeGraphMaintenanceRunRecord(
+                run_id="01JTESTRUN1234567890ABCDE",
+                triggered_at=datetime.now(UTC),
+                outcome=KnowledgeGraphMaintenanceRunOutcome.NO_CHANGES,
+                message="No commit delta detected",
+                target_data_source_ids=("ds-1",),
+            )
+        ]
+
+        response = test_client.get(
+            f"/management/knowledge-graphs/{sample_knowledge_graph.id.value}/maintenance-runs"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        payload = response.json()
+        assert len(payload["runs"]) == 1
+        assert payload["runs"][0]["outcome"] == "no-changes"
+        mock_kg_service.list_maintenance_runs.assert_called_once_with(
+            user_id=mock_current_user.user_id.value,
+            kg_id=sample_knowledge_graph.id.value,
+            limit=20,
+        )
+
+    def test_trigger_maintenance_run_returns_201(
+        self,
+        test_client: TestClient,
+        mock_kg_service: AsyncMock,
+        sample_knowledge_graph: KnowledgeGraph,
+        mock_current_user: CurrentUser,
+    ) -> None:
+        mock_kg_service.trigger_maintenance_run.return_value = (
+            KnowledgeGraphMaintenanceRunRecord(
+                run_id="01JTRIGGER1234567890ABCDE",
+                triggered_at=datetime.now(UTC),
+                outcome=KnowledgeGraphMaintenanceRunOutcome.STARTED,
+                message="Scheduled maintenance launched",
+                target_data_source_ids=("ds-1", "ds-2"),
+            )
+        )
+
+        response = test_client.post(
+            f"/management/knowledge-graphs/{sample_knowledge_graph.id.value}/maintenance-runs/trigger"
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        payload = response.json()
+        assert payload["outcome"] == "started"
+        mock_kg_service.trigger_maintenance_run.assert_called_once_with(
+            user_id=mock_current_user.user_id.value,
+            kg_id=sample_knowledge_graph.id.value,
+        )
 
 
 class TestWorkspaceCommandsRoutes:

--- a/src/dev-ui/app/pages/data-sources/index.vue
+++ b/src/dev-ui/app/pages/data-sources/index.vue
@@ -95,6 +95,21 @@ interface SyncRun {
   created_at: string
 }
 
+interface MaintenanceSchedule {
+  enabled: boolean
+  cron_expression: string
+  timezone_name: string
+  next_run_at: string | null
+}
+
+interface MaintenanceRun {
+  run_id: string
+  triggered_at: string
+  outcome: 'started' | 'no-changes' | 'preflight-failed' | 'launch-failed'
+  message: string | null
+  target_data_source_ids: string[]
+}
+
 interface DataSourceItem {
   id: string
   name: string
@@ -683,6 +698,16 @@ async function loadDataSources() {
       '/management/knowledge-graphs'
     )
     const kgs = kgResult.knowledge_graphs ?? []
+    maintenanceKnowledgeGraphs.value = kgs
+    if (!selectedMaintenanceKnowledgeGraphId.value && kgs.length > 0) {
+      selectedMaintenanceKnowledgeGraphId.value = kgs[0].id
+    }
+    if (
+      selectedMaintenanceKnowledgeGraphId.value
+      && !kgs.some(kg => kg.id === selectedMaintenanceKnowledgeGraphId.value)
+    ) {
+      selectedMaintenanceKnowledgeGraphId.value = kgs[0]?.id ?? ''
+    }
     const all: DataSourceItem[] = []
     for (const kg of kgs) {
       try {
@@ -714,8 +739,12 @@ async function loadDataSources() {
       }
     }
     dataSources.value = all
+    await loadMaintenanceOrchestration()
   } catch {
     dataSources.value = []
+    maintenanceKnowledgeGraphs.value = []
+    selectedMaintenanceKnowledgeGraphId.value = ''
+    maintenanceRuns.value = []
   } finally {
     loadingDataSources.value = false
   }
@@ -787,6 +816,97 @@ const telemetryCostTrend = computed(() => {
   return { current, previous, delta }
 })
 
+const maintenanceKnowledgeGraphs = ref<Array<{ id: string; name: string }>>([])
+const selectedMaintenanceKnowledgeGraphId = ref('')
+const maintenanceSchedule = ref<MaintenanceSchedule>({
+  enabled: false,
+  cron_expression: '0 2 * * *',
+  timezone_name: 'UTC',
+  next_run_at: null,
+})
+const maintenanceRuns = ref<MaintenanceRun[]>([])
+const maintenanceLoading = ref(false)
+const maintenanceSaving = ref(false)
+const maintenanceTriggering = ref(false)
+
+function maintenanceOutcomeTone(
+  outcome: MaintenanceRun['outcome'],
+): 'default' | 'secondary' | 'destructive' {
+  if (outcome === 'started') return 'default'
+  if (outcome === 'launch-failed' || outcome === 'preflight-failed') return 'destructive'
+  return 'secondary'
+}
+
+async function loadMaintenanceOrchestration() {
+  if (!selectedMaintenanceKnowledgeGraphId.value) {
+    maintenanceRuns.value = []
+    return
+  }
+  maintenanceLoading.value = true
+  try {
+    const { apiFetch } = useApiClient()
+    const [schedule, runs] = await Promise.all([
+      apiFetch<MaintenanceSchedule>(
+        `/management/knowledge-graphs/${selectedMaintenanceKnowledgeGraphId.value}/maintenance-schedule`,
+      ),
+      apiFetch<{ runs: MaintenanceRun[] }>(
+        `/management/knowledge-graphs/${selectedMaintenanceKnowledgeGraphId.value}/maintenance-runs`,
+      ),
+    ])
+    maintenanceSchedule.value = schedule
+    maintenanceRuns.value = runs.runs ?? []
+  } catch {
+    maintenanceRuns.value = []
+  } finally {
+    maintenanceLoading.value = false
+  }
+}
+
+async function saveMaintenanceSchedule() {
+  if (!selectedMaintenanceKnowledgeGraphId.value) return
+  maintenanceSaving.value = true
+  try {
+    const { apiFetch } = useApiClient()
+    const schedule = await apiFetch<MaintenanceSchedule>(
+      `/management/knowledge-graphs/${selectedMaintenanceKnowledgeGraphId.value}/maintenance-schedule`,
+      {
+        method: 'PUT',
+        body: {
+          enabled: maintenanceSchedule.value.enabled,
+          cron_expression: maintenanceSchedule.value.cron_expression,
+          timezone_name: maintenanceSchedule.value.timezone_name,
+        },
+      },
+    )
+    maintenanceSchedule.value = schedule
+    toast.success('Maintenance schedule saved')
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to save maintenance schedule'
+    toast.error('Failed to save maintenance schedule', { description: msg })
+  } finally {
+    maintenanceSaving.value = false
+  }
+}
+
+async function triggerMaintenanceRun() {
+  if (!selectedMaintenanceKnowledgeGraphId.value) return
+  maintenanceTriggering.value = true
+  try {
+    const { apiFetch } = useApiClient()
+    await apiFetch(
+      `/management/knowledge-graphs/${selectedMaintenanceKnowledgeGraphId.value}/maintenance-runs/trigger`,
+      { method: 'POST' },
+    )
+    await loadMaintenanceOrchestration()
+    toast.success('Maintenance orchestration completed')
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to trigger maintenance'
+    toast.error('Failed to trigger maintenance', { description: msg })
+  } finally {
+    maintenanceTriggering.value = false
+  }
+}
+
 /** Holds the active setInterval handle, or null when not polling. */
 const pollInterval = ref<ReturnType<typeof setInterval> | null>(null)
 
@@ -855,6 +975,10 @@ watch(tenantVersion, () => {
   // Clear stale data immediately so old tenant's sources are not shown during load
   dataSources.value = []
   loadDataSources()
+})
+
+watch(selectedMaintenanceKnowledgeGraphId, () => {
+  loadMaintenanceOrchestration()
 })
 
 async function triggerSync(dsId: string) {
@@ -1274,6 +1398,105 @@ async function handleDeleteDs() {
                 <SyncPhaseIndicator :status="job.status" />
                 <span class="font-mono text-muted-foreground">{{ job.token_usage_total ?? 0 }} tk</span>
                 <span class="font-mono text-muted-foreground">${{ (job.cost_total_usd ?? 0).toFixed(2) }}</span>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader class="pb-2">
+          <CardTitle class="text-sm">Scheduled maintenance orchestration</CardTitle>
+          <CardDescription class="text-xs">
+            Configure one schedule per knowledge graph and review launch outcomes.
+          </CardDescription>
+        </CardHeader>
+        <CardContent class="space-y-3">
+          <div class="grid gap-3 md:grid-cols-4">
+            <div class="space-y-1">
+              <Label class="text-xs">Knowledge graph</Label>
+              <Select v-model="selectedMaintenanceKnowledgeGraphId">
+                <SelectTrigger class="h-8">
+                  <SelectValue placeholder="Select a knowledge graph" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem
+                    v-for="kg in maintenanceKnowledgeGraphs"
+                    :key="kg.id"
+                    :value="kg.id"
+                  >
+                    {{ kg.name }}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div class="space-y-1">
+              <Label class="text-xs">Cron</Label>
+              <Input v-model="maintenanceSchedule.cron_expression" class="h-8 font-mono text-xs" />
+            </div>
+            <div class="space-y-1">
+              <Label class="text-xs">Timezone</Label>
+              <Input v-model="maintenanceSchedule.timezone_name" class="h-8 text-xs" />
+            </div>
+            <div class="flex items-end gap-2">
+              <Button
+                size="sm"
+                variant="secondary"
+                :disabled="!selectedMaintenanceKnowledgeGraphId"
+                @click="maintenanceSchedule.enabled = !maintenanceSchedule.enabled"
+              >
+                {{ maintenanceSchedule.enabled ? 'Disable' : 'Enable' }}
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                :disabled="maintenanceSaving || !selectedMaintenanceKnowledgeGraphId"
+                @click="saveMaintenanceSchedule"
+              >
+                <Loader2 v-if="maintenanceSaving" class="mr-1.5 size-3.5 animate-spin" />
+                Save schedule
+              </Button>
+              <Button
+                size="sm"
+                :disabled="maintenanceTriggering || !selectedMaintenanceKnowledgeGraphId"
+                @click="triggerMaintenanceRun"
+              >
+                <Loader2 v-if="maintenanceTriggering" class="mr-1.5 size-3.5 animate-spin" />
+                Run now
+              </Button>
+            </div>
+          </div>
+          <div class="flex items-center justify-between rounded border px-3 py-2 text-xs">
+            <p class="text-muted-foreground">
+              Next run:
+              <span class="font-medium text-foreground">
+                {{ maintenanceSchedule.next_run_at ? new Date(maintenanceSchedule.next_run_at).toLocaleString() : 'Not scheduled' }}
+              </span>
+            </p>
+            <Badge :variant="maintenanceSchedule.enabled ? 'default' : 'secondary'">
+              {{ maintenanceSchedule.enabled ? 'Enabled' : 'Disabled' }}
+            </Badge>
+          </div>
+          <div v-if="maintenanceLoading" class="flex items-center gap-2 text-xs text-muted-foreground">
+            <Loader2 class="size-3.5 animate-spin" />
+            Loading maintenance run history...
+          </div>
+          <div v-else-if="maintenanceRuns.length === 0" class="text-xs text-muted-foreground">
+            No maintenance orchestration runs recorded yet.
+          </div>
+          <div v-else class="space-y-1.5">
+            <div
+              v-for="run in maintenanceRuns"
+              :key="run.run_id"
+              class="flex items-center justify-between rounded border px-2 py-1.5 text-xs"
+            >
+              <div>
+                <p class="font-medium">{{ new Date(run.triggered_at).toLocaleString() }}</p>
+                <p class="text-muted-foreground">{{ run.message ?? 'No message provided' }}</p>
+              </div>
+              <div class="flex items-center gap-2">
+                <Badge :variant="maintenanceOutcomeTone(run.outcome)">{{ run.outcome }}</Badge>
+                <span class="text-muted-foreground">{{ run.target_data_source_ids.length }} sources</span>
               </div>
             </div>
           </div>

--- a/src/dev-ui/app/tests/data-sources.test.ts
+++ b/src/dev-ui/app/tests/data-sources.test.ts
@@ -3162,3 +3162,26 @@ describe('Extraction telemetry dashboard - structural verification', () => {
     expect(source).toContain('previous 24h')
   })
 })
+
+describe('Scheduled maintenance orchestration - structural verification', () => {
+  const source = readFileSync(
+    resolve(__dirname, '../pages/data-sources/index.vue'),
+    'utf-8',
+  )
+
+  it('declares maintenance schedule state and loader function', () => {
+    expect(source).toContain('maintenanceSchedule')
+    expect(source).toContain('loadMaintenanceOrchestration')
+  })
+
+  it('renders the scheduled maintenance panel and trigger action', () => {
+    expect(source).toContain('Scheduled maintenance orchestration')
+    expect(source).toContain('maintenance-runs/trigger')
+    expect(source).toContain('Run now')
+  })
+
+  it('renders maintenance outcome history list', () => {
+    expect(source).toContain('No maintenance orchestration runs recorded yet.')
+    expect(source).toContain('maintenanceOutcomeTone')
+  })
+})


### PR DESCRIPTION
Closes #673

## Summary
- add knowledge-graph scoped maintenance schedule APIs with timezone-aware cron next-run calculation
- persist maintenance run outcomes (`started`, `no-changes`, `preflight-failed`, `launch-failed`) on each knowledge graph with migration support
- add a data-sources operations panel to configure maintenance schedules, trigger runs, and view run history

## Testing
- [x] `cd src/api && uv run pytest tests/unit/management/application/test_knowledge_graph_service.py tests/unit/management/presentation/test_knowledge_graphs_routes.py -q`
- [ ] `pnpm test -- data-sources.test.ts` (not runnable in this environment)
- [ ] manual UI verification in browser

## Risks
- maintenance run history is currently stored in KG JSONB and capped in-app; later iterations may move this to a dedicated table for larger audit volumes.

Made with [Cursor](https://cursor.com)