### PR TITLE
feat: add KG-scoped mutation log browser with run previews (#658)

### DIFF
--- a/src/api/management/presentation/data_sources/models.py
+++ b/src/api/management/presentation/data_sources/models.py
@@ -296,6 +296,19 @@ class SyncRunResponse(BaseModel):
         None, description="When the sync run completed"
     )
     error: str | None = Field(None, description="Error message if the sync run failed")
+    mutation_log_id: str | None = Field(
+        None, description="Associated mutation log run ID when available"
+    )
+    session_id: str | None = Field(
+        None, description="Extraction session ID associated with this mutation run"
+    )
+    actor_id: str | None = Field(
+        None, description="Actor identity associated with this mutation run"
+    )
+    operation_counts: dict[str, int] = Field(
+        default_factory=dict,
+        description="Operation counts grouped by operation class for this run",
+    )
     token_usage_total: int | None = Field(
         None, description="Total model tokens consumed during extraction for this run"
     )
@@ -323,6 +336,26 @@ class SyncRunResponse(BaseModel):
             started_at=run.started_at,
             completed_at=run.completed_at,
             error=run.error,
+            mutation_log_id=(
+                run.mutation_log_run.mutation_log_id
+                if run.mutation_log_run is not None
+                else None
+            ),
+            session_id=(
+                run.mutation_log_run.session_id
+                if run.mutation_log_run is not None
+                else None
+            ),
+            actor_id=(
+                run.mutation_log_run.actor_id
+                if run.mutation_log_run is not None
+                else None
+            ),
+            operation_counts=(
+                dict(run.mutation_log_run.operation_counts)
+                if run.mutation_log_run is not None
+                else {}
+            ),
             token_usage_total=(
                 run.mutation_log_run.token_usage_total
                 if run.mutation_log_run is not None

--- a/src/api/tests/unit/management/presentation/test_data_sources_routes.py
+++ b/src/api/tests/unit/management/presentation/test_data_sources_routes.py
@@ -480,6 +480,43 @@ class TestListSyncRunsRoute:
         assert payload["token_usage_total"] == 3210
         assert payload["cost_total_usd"] == pytest.approx(1.23)
 
+    def test_list_sync_runs_includes_mutation_log_run_preview_fields(
+        self,
+        test_client: TestClient,
+        mock_ds_service: AsyncMock,
+        mock_sync_run_repo: AsyncMock,
+        sample_data_source: DataSource,
+        sample_sync_run: DataSourceSyncRun,
+    ) -> None:
+        """Sync run response should include mutation-run IDs and op class counts."""
+        sample_sync_run.mutation_log_run = MutationLogRunMetadata(
+            mutation_log_id="mlog-preview-1",
+            knowledge_graph_id=sample_data_source.knowledge_graph_id,
+            session_id="sess-preview-1",
+            actor_id="actor-preview-1",
+            started_at=sample_sync_run.started_at,
+            token_usage_total=144,
+            cost_total_usd=0.07,
+            operation_counts={"create_node": 8, "create_edge": 13, "update_node": 2},
+        )
+        mock_ds_service.get.return_value = sample_data_source
+        mock_sync_run_repo.find_by_data_source.return_value = [sample_sync_run]
+
+        response = test_client.get(
+            f"/management/data-sources/{sample_data_source.id.value}/sync-runs"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        payload = response.json()[0]
+        assert payload["mutation_log_id"] == "mlog-preview-1"
+        assert payload["session_id"] == "sess-preview-1"
+        assert payload["actor_id"] == "actor-preview-1"
+        assert payload["operation_counts"] == {
+            "create_node": 8,
+            "create_edge": 13,
+            "update_node": 2,
+        }
+
     def test_list_sync_runs_returns_404_when_ds_not_found(
         self,
         test_client: TestClient,

--- a/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
+++ b/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import { toast } from 'vue-sonner'
-import { ArrowLeft, CheckCircle2, Loader2, PlayCircle, ShieldAlert } from 'lucide-vue-next'
+import { ArrowLeft, CheckCircle2, Coins, DollarSign, Loader2, PlayCircle, ShieldAlert } from 'lucide-vue-next'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
@@ -29,6 +29,27 @@ interface WorkspaceStatusResponse {
   session_pointers: WorkspaceSessionPointers
 }
 
+interface DataSourceRef {
+  id: string
+  name: string
+}
+
+interface MutationLogRunView {
+  id: string
+  data_source_id: string
+  data_source_name: string
+  status: string
+  started_at: string
+  completed_at: string | null
+  mutation_log_id: string | null
+  session_id: string | null
+  actor_id: string | null
+  operation_counts: Record<string, number>
+  token_usage_total: number | null
+  cost_total_usd: number | null
+  error: string | null
+}
+
 const route = useRoute()
 const { hasTenant, tenantVersion } = useTenant()
 const { extractErrorMessage } = useErrorHandler()
@@ -38,6 +59,9 @@ const loading = ref(false)
 const validating = ref(false)
 const transitioning = ref(false)
 const statusProjection = ref<WorkspaceStatusResponse | null>(null)
+const mutationLogLoading = ref(false)
+const mutationLogRuns = ref<MutationLogRunView[]>([])
+const selectedMutationLogRunId = ref<string | null>(null)
 
 const modeLabel = computed(() =>
   statusProjection.value?.workspace_mode === 'extraction_operations'
@@ -48,6 +72,10 @@ const modeLabel = computed(() =>
 const canTransition = computed(() =>
   statusProjection.value?.workspace_mode === 'schema_bootstrap'
   && statusProjection.value?.transition_eligible === true,
+)
+
+const selectedMutationLogRun = computed(() =>
+  mutationLogRuns.value.find((run) => run.id === selectedMutationLogRunId.value) ?? null,
 )
 
 async function loadWorkspaceStatus() {
@@ -64,6 +92,53 @@ async function loadWorkspaceStatus() {
     })
   } finally {
     loading.value = false
+  }
+}
+
+async function loadMutationLogRuns() {
+  if (!hasTenant.value || !kgId.value) return
+  mutationLogLoading.value = true
+  try {
+    const dataSources = await apiFetch<DataSourceRef[]>(
+      `/management/knowledge-graphs/${kgId.value}/data-sources`,
+    )
+
+    const collected: MutationLogRunView[] = []
+    for (const ds of dataSources) {
+      try {
+        const runs = await apiFetch<MutationLogRunView[]>(
+          `/management/data-sources/${ds.id}/sync-runs`,
+        )
+        for (const run of runs) {
+          if (!run.mutation_log_id) continue
+          collected.push({
+            ...run,
+            data_source_name: ds.name,
+          })
+        }
+      } catch {
+        // Keep page resilient when one data source run list fails.
+      }
+    }
+
+    collected.sort(
+      (a, b) => new Date(b.started_at).getTime() - new Date(a.started_at).getTime(),
+    )
+    mutationLogRuns.value = collected
+    if (
+      !selectedMutationLogRunId.value
+      || !collected.some((run) => run.id === selectedMutationLogRunId.value)
+    ) {
+      selectedMutationLogRunId.value = collected[0]?.id ?? null
+    }
+  } catch (err) {
+    mutationLogRuns.value = []
+    selectedMutationLogRunId.value = null
+    toast.error('Failed to load mutation log runs', {
+      description: extractErrorMessage(err),
+    })
+  } finally {
+    mutationLogLoading.value = false
   }
 }
 
@@ -106,11 +181,13 @@ async function transitionToExtraction() {
 
 onMounted(() => {
   loadWorkspaceStatus()
+  loadMutationLogRuns()
 })
 
 watch(tenantVersion, () => {
   statusProjection.value = null
   loadWorkspaceStatus()
+  loadMutationLogRuns()
 })
 </script>
 
@@ -236,6 +313,115 @@ watch(tenantVersion, () => {
             <p class="font-mono break-all mt-1">
               {{ statusProjection.session_pointers.most_recent_completed_session_id ?? 'None' }}
             </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle class="text-base">MutationLog Browser</CardTitle>
+          <CardDescription>
+            Knowledge-graph scoped mutation runs with per-entry operation previews and run metrics.
+          </CardDescription>
+        </CardHeader>
+        <CardContent class="grid gap-4 lg:grid-cols-[320px_1fr]">
+          <div class="rounded border">
+            <div class="flex items-center justify-between border-b px-3 py-2">
+              <p class="text-xs font-medium text-muted-foreground">Runs</p>
+              <Button size="sm" variant="ghost" class="h-6 px-2 text-[10px]" @click="loadMutationLogRuns">
+                Refresh
+              </Button>
+            </div>
+            <div v-if="mutationLogLoading" class="flex items-center gap-2 px-3 py-4 text-xs text-muted-foreground">
+              <Loader2 class="size-3.5 animate-spin" />
+              Loading mutation runs...
+            </div>
+            <div v-else-if="mutationLogRuns.length === 0" class="px-3 py-4 text-xs text-muted-foreground">
+              No mutation log runs found for this knowledge graph yet.
+            </div>
+            <div v-else class="max-h-72 overflow-auto p-2 space-y-1.5">
+              <button
+                v-for="run in mutationLogRuns"
+                :key="run.id"
+                class="w-full rounded border px-2 py-1.5 text-left text-xs transition-colors"
+                :class="selectedMutationLogRunId === run.id ? 'border-primary bg-primary/5' : 'hover:bg-muted/40'"
+                @click="selectedMutationLogRunId = run.id"
+              >
+                <p class="font-medium truncate">{{ run.data_source_name }}</p>
+                <p class="text-muted-foreground truncate">{{ new Date(run.started_at).toLocaleString() }}</p>
+                <div class="mt-1 flex items-center justify-between">
+                  <Badge variant="outline" class="text-[10px]">{{ run.status }}</Badge>
+                  <span class="font-mono text-[10px] text-muted-foreground">{{ run.mutation_log_id }}</span>
+                </div>
+              </button>
+            </div>
+          </div>
+
+          <div v-if="selectedMutationLogRun" class="space-y-3 rounded border p-3">
+            <div class="flex flex-wrap items-center gap-2">
+              <Badge>{{ selectedMutationLogRun.status }}</Badge>
+              <p class="text-xs text-muted-foreground">
+                Data source: <span class="font-medium text-foreground">{{ selectedMutationLogRun.data_source_name }}</span>
+              </p>
+              <p class="text-xs text-muted-foreground">
+                MutationLog: <span class="font-mono text-foreground">{{ selectedMutationLogRun.mutation_log_id }}</span>
+              </p>
+            </div>
+            <div class="grid gap-2 sm:grid-cols-2">
+              <div class="rounded border px-3 py-2 text-xs">
+                <p class="text-muted-foreground">Started</p>
+                <p class="mt-1">{{ new Date(selectedMutationLogRun.started_at).toLocaleString() }}</p>
+              </div>
+              <div class="rounded border px-3 py-2 text-xs">
+                <p class="text-muted-foreground">Completed</p>
+                <p class="mt-1">
+                  {{ selectedMutationLogRun.completed_at ? new Date(selectedMutationLogRun.completed_at).toLocaleString() : 'In progress' }}
+                </p>
+              </div>
+              <div class="rounded border px-3 py-2 text-xs">
+                <p class="text-muted-foreground">Session</p>
+                <p class="mt-1 font-mono break-all">{{ selectedMutationLogRun.session_id ?? 'None' }}</p>
+              </div>
+              <div class="rounded border px-3 py-2 text-xs">
+                <p class="text-muted-foreground">Actor</p>
+                <p class="mt-1 font-mono break-all">{{ selectedMutationLogRun.actor_id ?? 'None' }}</p>
+              </div>
+            </div>
+            <div class="grid gap-2 sm:grid-cols-2">
+              <div class="rounded border px-3 py-2 text-xs">
+                <p class="text-muted-foreground flex items-center gap-1.5">
+                  <Coins class="size-3.5" />
+                  Token usage
+                </p>
+                <p class="mt-1 font-medium">{{ (selectedMutationLogRun.token_usage_total ?? 0).toLocaleString() }}</p>
+              </div>
+              <div class="rounded border px-3 py-2 text-xs">
+                <p class="text-muted-foreground flex items-center gap-1.5">
+                  <DollarSign class="size-3.5" />
+                  Cost (USD)
+                </p>
+                <p class="mt-1 font-medium">${{ (selectedMutationLogRun.cost_total_usd ?? 0).toFixed(2) }}</p>
+              </div>
+            </div>
+            <div class="rounded border p-3">
+              <p class="mb-2 text-xs font-medium text-muted-foreground">Per-entry operation previews</p>
+              <div v-if="Object.keys(selectedMutationLogRun.operation_counts).length === 0" class="text-xs text-muted-foreground">
+                No operation class counts recorded for this run.
+              </div>
+              <div v-else class="space-y-1.5">
+                <div
+                  v-for="([opClass, count]) in Object.entries(selectedMutationLogRun.operation_counts)"
+                  :key="opClass"
+                  class="flex items-center justify-between rounded border px-2 py-1.5 text-xs"
+                >
+                  <span class="font-mono">{{ opClass }}</span>
+                  <Badge variant="secondary">{{ count }}</Badge>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div v-else class="rounded border border-dashed p-6 text-sm text-muted-foreground">
+            Select a mutation run to view summary and per-entry previews.
           </div>
         </CardContent>
       </Card>

--- a/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
+++ b/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
@@ -37,3 +37,29 @@ describe('Knowledge Graph Manage Workspace - mode-aware controls', () => {
     expect(manageWorkspaceVue).toContain('active_extraction_operations_session_id')
   })
 })
+
+describe('Knowledge Graph Manage Workspace - mutation log browser', () => {
+  it('renders mutation log browser card and scoped run listing', () => {
+    expect(manageWorkspaceVue).toContain('MutationLog Browser')
+    expect(manageWorkspaceVue).toContain('loadMutationLogRuns')
+    expect(manageWorkspaceVue).toContain('/management/knowledge-graphs/${kgId.value}/data-sources')
+  })
+
+  it('loads sync runs per data source and filters to mutation-log runs', () => {
+    expect(manageWorkspaceVue).toContain('/management/data-sources/${ds.id}/sync-runs')
+    expect(manageWorkspaceVue).toContain('if (!run.mutation_log_id) continue')
+  })
+
+  it('renders run detail summary with token and cost metrics', () => {
+    expect(manageWorkspaceVue).toContain('Token usage')
+    expect(manageWorkspaceVue).toContain('Cost (USD)')
+    expect(manageWorkspaceVue).toContain('token_usage_total')
+    expect(manageWorkspaceVue).toContain('cost_total_usd')
+  })
+
+  it('renders per-entry operation preview rows from operation_counts', () => {
+    expect(manageWorkspaceVue).toContain('Per-entry operation previews')
+    expect(manageWorkspaceVue).toContain('operation_counts')
+    expect(manageWorkspaceVue).toContain('Object.entries(selectedMutationLogRun.operation_counts)')
+  })
+})


### PR DESCRIPTION
Closes #658

## Summary
- enrich sync-run API responses with mutation-log preview fields (`mutation_log_id`, `session_id`, `actor_id`, `operation_counts`) for run-level inspection
- add a knowledge-graph-scoped MutationLog browser panel to the manage workspace that aggregates runs across the graph's data sources
- render run summary, per-entry operation class previews, and token/cost metrics in the detail pane

## Testing
- [x] `cd src/api && uv run pytest tests/unit/management/presentation/test_data_sources_routes.py -q`
- [ ] `pnpm test -- knowledge-graph-manage-workspace.test.ts` (command exits non-zero with no output in this environment)
- [x] ReadLints check for changed files

## Notes
- `src/api/uv.lock` drift from local `uv run` execution was restored before commit.

Made with [Cursor](https://cursor.com)