### PR TITLE
test: lock commit-hash cue coverage for data source cards (#664)

### DIFF
--- a/src/dev-ui/app/tests/data-sources.test.ts
+++ b/src/dev-ui/app/tests/data-sources.test.ts
@@ -3185,3 +3185,23 @@ describe('Scheduled maintenance orchestration - structural verification', () => 
     expect(source).toContain('maintenanceOutcomeTone')
   })
 })
+
+describe('Commit-hash status cues - structural verification', () => {
+  const source = readFileSync(
+    resolve(__dirname, '../pages/data-sources/index.vue'),
+    'utf-8',
+  )
+
+  it('renders commit status section with canonical commit labels', () => {
+    expect(source).toContain('Commit Status')
+    expect(source).toContain('Local clone commit')
+    expect(source).toContain('Commit during last extraction')
+    expect(source).toContain('Tracked branch head commit')
+  })
+
+  it('renders visual readiness cue when new commits exist', () => {
+    expect(source).toContain('isMaintenanceReady')
+    expect(source).toContain('New commits available')
+    expect(source).toContain('Up to date')
+  })
+})


### PR DESCRIPTION
Closes #664

## Summary
- add structural tests that pin the commit-status card labels to canonical commit references
- add structural tests that pin readiness cue rendering (`New commits available` / `Up to date`)
- preserve existing UI behavior while making the spec contract explicit and regression-safe

## Testing
- [ ] `pnpm test -- data-sources.test.ts` (command exits non-zero with no output in this environment)
- [x] ReadLints check for changed files

Made with [Cursor](https://cursor.com)