### PR TITLE
feat: add shared conversation panel with clear-confirm + session resume (#668)

### DIFF
--- a/src/dev-ui/app/components/extraction/SharedConversationPanel.vue
+++ b/src/dev-ui/app/components/extraction/SharedConversationPanel.vue
@@ -1,0 +1,155 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from 'vue'
+import { Loader2, RefreshCw } from 'lucide-vue-next'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+
+interface ConversationEntry {
+  role?: string
+  content?: string
+  message?: string
+}
+
+interface ConversationSession {
+  message_history: ConversationEntry[]
+  runtime_context: Record<string, unknown>
+}
+
+const props = withDefaults(defineProps<{
+  modeLabel: string
+  session: ConversationSession | null
+  loading?: boolean
+  clearing?: boolean
+  draftMessage?: string
+  activityLines?: string[]
+}>(), {
+  loading: false,
+  clearing: false,
+  draftMessage: '',
+  activityLines: () => [],
+})
+
+const emit = defineEmits<{
+  refresh: []
+  clearChat: []
+  'update:draftMessage': [value: string]
+}>()
+
+const clearConfirmOpen = ref(false)
+const timelineRef = ref<HTMLElement | null>(null)
+
+const messageHistory = computed(() => props.session?.message_history ?? [])
+const activityTimeline = computed(() => props.activityLines)
+
+const combinedTimelineLength = computed(
+  () => messageHistory.value.length + activityTimeline.value.length,
+)
+
+watch(combinedTimelineLength, async () => {
+  await nextTick()
+  if (timelineRef.value) {
+    timelineRef.value.scrollTop = timelineRef.value.scrollHeight
+  }
+})
+
+function confirmClearChat() {
+  clearConfirmOpen.value = false
+  emit('clearChat')
+}
+</script>
+
+<template>
+  <Card>
+    <CardHeader>
+      <CardTitle class="text-base">Conversation</CardTitle>
+      <CardDescription>
+        Shared conversation feed for {{ modeLabel }} with server-side session resume.
+      </CardDescription>
+    </CardHeader>
+    <CardContent class="space-y-3">
+      <div class="flex items-center justify-between">
+        <p class="text-xs text-muted-foreground">No local cache: conversation state is server-side only.</p>
+        <Button size="sm" variant="ghost" class="h-7 px-2 text-[11px]" :disabled="loading" @click="emit('refresh')">
+          <RefreshCw class="mr-1 size-3.5" />
+          Resume session
+        </Button>
+      </div>
+
+      <div v-if="loading" class="flex items-center gap-2 text-xs text-muted-foreground">
+        <Loader2 class="size-3.5 animate-spin" />
+        Loading active conversation session...
+      </div>
+      <div
+        v-else
+        ref="timelineRef"
+        class="space-y-2 max-h-56 overflow-auto rounded border p-2"
+      >
+        <div
+          v-for="(entry, idx) in messageHistory"
+          :key="`msg-${idx}-${entry.role ?? 'unknown'}`"
+          class="rounded px-2 py-1 text-xs"
+          :class="entry.role === 'assistant' ? 'bg-muted' : 'bg-primary/10'"
+        >
+          <p class="mb-0.5 font-medium">{{ entry.role ?? 'system' }}</p>
+          <p>{{ entry.content ?? entry.message ?? '(empty)' }}</p>
+        </div>
+
+        <div
+          v-for="(line, idx) in activityTimeline"
+          :key="`activity-${idx}`"
+          class="rounded border border-dashed px-2 py-1 text-xs text-muted-foreground"
+        >
+          {{ line }}
+        </div>
+
+        <p
+          v-if="messageHistory.length === 0 && activityTimeline.length === 0"
+          class="text-xs text-muted-foreground"
+        >
+          No messages yet. Use validate/transition actions to drive session activity.
+        </p>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <Input
+          :model-value="draftMessage"
+          disabled
+          placeholder="NDJSON streaming send/receive wiring will attach here."
+          @update:model-value="(value) => emit('update:draftMessage', value)"
+        />
+        <Button variant="outline" :disabled="clearing || loading" @click="clearConfirmOpen = true">
+          <Loader2 v-if="clearing" class="mr-1.5 size-3.5 animate-spin" />
+          Clear chat
+        </Button>
+      </div>
+    </CardContent>
+  </Card>
+
+  <AlertDialog v-model:open="clearConfirmOpen">
+    <AlertDialogContent>
+      <AlertDialogHeader>
+        <AlertDialogTitle>Clear conversation?</AlertDialogTitle>
+        <AlertDialogDescription>
+          This starts a fresh server-side session timeline for the current mode.
+        </AlertDialogDescription>
+      </AlertDialogHeader>
+      <AlertDialogFooter>
+        <AlertDialogCancel>Cancel</AlertDialogCancel>
+        <AlertDialogAction @click="confirmClearChat">
+          Clear chat
+        </AlertDialogAction>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
+</template>

--- a/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
+++ b/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
@@ -6,8 +6,8 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
-import { Input } from '@/components/ui/input'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import SharedConversationPanel from '@/components/extraction/SharedConversationPanel.vue'
 
 interface WorkspaceReadinessStatus {
   has_minimum_entity_types: boolean
@@ -83,6 +83,12 @@ const modeLabel = computed(() =>
     : 'Schema Bootstrap',
 )
 
+const sessionMode = computed<'schema_bootstrap' | 'extraction_operations'>(() =>
+  statusProjection.value?.workspace_mode === 'extraction_operations'
+    ? 'extraction_operations'
+    : 'schema_bootstrap',
+)
+
 const canTransition = computed(() =>
   statusProjection.value?.workspace_mode === 'schema_bootstrap'
   && statusProjection.value?.transition_eligible === true,
@@ -136,6 +142,13 @@ const nextSteps = computed(() => {
     steps.push('Transition is enabled. Use Go to Extraction/Mutations when ready.')
   }
   return steps
+})
+
+const sessionActivityLines = computed(() => {
+  const context = extractionSession.value?.runtime_context ?? {}
+  const candidate = context.activity_lines ?? context.ndjson_activity_lines ?? context.thinking_lines
+  if (!Array.isArray(candidate)) return []
+  return candidate.filter((line): line is string => typeof line === 'string' && line.trim().length > 0)
 })
 
 async function loadWorkspaceStatus() {
@@ -207,7 +220,7 @@ async function loadExtractionSession() {
   sessionLoading.value = true
   try {
     extractionSession.value = await apiFetch<ExtractionSessionResponse>(
-      `/extraction/knowledge-graphs/${kgId.value}/sessions/extraction_operations/active`,
+      `/extraction/knowledge-graphs/${kgId.value}/sessions/${sessionMode.value}/active`,
     )
   } catch (err) {
     extractionSession.value = null
@@ -261,7 +274,7 @@ async function clearChat() {
   clearingChat.value = true
   try {
     extractionSession.value = await apiFetch<ExtractionSessionResponse>(
-      `/extraction/knowledge-graphs/${kgId.value}/sessions/extraction_operations/clear-chat`,
+      `/extraction/knowledge-graphs/${kgId.value}/sessions/${sessionMode.value}/clear-chat`,
       { method: 'POST' },
     )
     toast.success('Extraction chat cleared')
@@ -289,7 +302,7 @@ watch(tenantVersion, () => {
 watch(
   () => statusProjection.value?.workspace_mode,
   (mode) => {
-    if (mode === 'extraction_operations') {
+    if (mode) {
       loadExtractionSession()
     }
   },
@@ -484,48 +497,19 @@ watch(
         </CardContent>
       </Card>
 
-      <div v-if="statusProjection.workspace_mode === 'extraction_operations'" class="space-y-4">
-        <Card>
-          <CardHeader>
-            <CardTitle class="text-base">Extraction Conversation</CardTitle>
-            <CardDescription>
-              Conversation stays visible while you run extraction and manual-mutation operations.
-            </CardDescription>
-          </CardHeader>
-          <CardContent class="space-y-3">
-            <div v-if="sessionLoading" class="flex items-center gap-2 text-xs text-muted-foreground">
-              <Loader2 class="size-3.5 animate-spin" />
-              Loading active extraction session...
-            </div>
-            <div v-else class="space-y-2 max-h-52 overflow-auto rounded border p-2">
-              <div
-                v-for="(entry, idx) in extractionSession?.message_history ?? []"
-                :key="`${idx}-${entry.role ?? 'unknown'}`"
-                class="rounded px-2 py-1 text-xs"
-                :class="entry.role === 'assistant' ? 'bg-muted' : 'bg-primary/10'"
-              >
-                <p class="mb-0.5 font-medium">{{ entry.role ?? 'system' }}</p>
-                <p>{{ entry.content ?? entry.message ?? '(empty)' }}</p>
-              </div>
-              <p v-if="(extractionSession?.message_history?.length ?? 0) === 0" class="text-xs text-muted-foreground">
-                Session is active. Start by drafting extraction or mutation tasks below.
-              </p>
-            </div>
-            <div class="flex items-center gap-2">
-              <Input
-                v-model="draftMessage"
-                disabled
-                placeholder="Streaming conversation input will be enabled in issue #668"
-              />
-              <Button variant="outline" :disabled="clearingChat || sessionLoading" @click="clearChat">
-                <Loader2 v-if="clearingChat" class="mr-1.5 size-3.5 animate-spin" />
-                Clear chat
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+      <div class="space-y-4">
+        <SharedConversationPanel
+          v-model:draft-message="draftMessage"
+          :mode-label="modeLabel"
+          :session="extractionSession"
+          :loading="sessionLoading"
+          :clearing="clearingChat"
+          :activity-lines="sessionActivityLines"
+          @refresh="loadExtractionSession"
+          @clear-chat="clearChat"
+        />
 
-        <Card>
+        <Card v-if="statusProjection.workspace_mode === 'extraction_operations'">
           <CardHeader>
             <CardTitle class="text-base">Operations Workspace</CardTitle>
             <CardDescription>

--- a/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
+++ b/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
@@ -6,6 +6,10 @@ const manageWorkspaceVue = readFileSync(
   resolve(__dirname, '../pages/knowledge-graphs/[kgId]/manage.vue'),
   'utf-8',
 )
+const sharedConversationPanelVue = readFileSync(
+  resolve(__dirname, '../components/extraction/SharedConversationPanel.vue'),
+  'utf-8',
+)
 
 describe('Knowledge Graph Manage Workspace - mode-aware controls', () => {
   it('loads workspace status projection from management API', () => {
@@ -37,15 +41,15 @@ describe('Knowledge Graph Manage Workspace - mode-aware controls', () => {
     expect(manageWorkspaceVue).toContain('active_extraction_operations_session_id')
   })
 
-  it('keeps extraction conversation panel visible in extraction mode', () => {
-    expect(manageWorkspaceVue).toContain('Extraction Conversation')
-    expect(manageWorkspaceVue).toContain('message_history')
-    expect(manageWorkspaceVue).toContain('statusProjection.workspace_mode === \'extraction_operations\'')
+  it('uses shared conversation panel for bootstrap and extraction sessions', () => {
+    expect(manageWorkspaceVue).toContain('SharedConversationPanel')
+    expect(manageWorkspaceVue).toContain('sessionMode')
+    expect(manageWorkspaceVue).toContain('/sessions/${sessionMode.value}/active')
   })
 
   it('supports explicit Clear chat reset for extraction session', () => {
     expect(manageWorkspaceVue).toContain('clearChat')
-    expect(manageWorkspaceVue).toContain('/sessions/extraction_operations/clear-chat')
+    expect(manageWorkspaceVue).toContain('/sessions/${sessionMode.value}/clear-chat')
     expect(manageWorkspaceVue).toContain('Clear chat')
   })
 
@@ -102,5 +106,24 @@ describe('Knowledge Graph Manage Workspace - bootstrap readiness guidance', () =
     expect(manageWorkspaceVue).toContain('Next Steps')
     expect(manageWorkspaceVue).toContain('Run Validate to refresh readiness signals')
     expect(manageWorkspaceVue).toContain('Transition is enabled')
+  })
+})
+
+describe('Shared conversation panel - extraction UX contract', () => {
+  it('renders resume-session action and explicit server-side persistence note', () => {
+    expect(sharedConversationPanelVue).toContain('Resume session')
+    expect(sharedConversationPanelVue).toContain('No local cache: conversation state is server-side only.')
+  })
+
+  it('renders clear-chat confirmation dialog before emitting clear action', () => {
+    expect(sharedConversationPanelVue).toContain('Clear conversation?')
+    expect(sharedConversationPanelVue).toContain('confirmClearChat')
+    expect(sharedConversationPanelVue).toContain("emit('clearChat')")
+  })
+
+  it('renders activity/thinking timeline lines and auto-scrolls timeline updates', () => {
+    expect(sharedConversationPanelVue).toContain('activityTimeline')
+    expect(sharedConversationPanelVue).toContain('timelineRef')
+    expect(sharedConversationPanelVue).toContain('scrollTop = timelineRef.value.scrollHeight')
   })
 })


### PR DESCRIPTION
Closes #668

## Summary
- add a reusable `SharedConversationPanel` component for extraction/bootstrap conversation surfaces
- wire manage workspace to load/clear active sessions by current workspace mode, enabling resume across both bootstrap and extraction modes
- add clear-chat confirmation UX and timeline auto-scroll with activity/thinking line rendering from server session runtime context

## Notes
- This is a tracer-bullet toward full NDJSON message-send streaming: UI feed surfaces and mode-aware session routing are in place, and backend streaming endpoints can now plug into the shared panel without local browser history persistence.

## Testing
- [ ] `pnpm test -- knowledge-graph-manage-workspace.test.ts` (command exits non-zero with no output in this environment)
- [x] ReadLints check for changed files
- [x] Structural coverage updated in `src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts`

Made with [Cursor](https://cursor.com)