### PR TITLE
feat: add section-wave subagent orchestration prompts

### DIFF
--- a/skills/subagent-delivery/SKILL.md
+++ b/skills/subagent-delivery/SKILL.md
@@ -11,6 +11,10 @@ description: >
 
 Follow this protocol for every assigned issue.
 
+System prompt template for spawned Claude instances:
+
+- `skills/subagent-delivery/claude-instance-system-prompt.txt`
+
 ## Parallel Execution Model
 
 Use this model whenever multiple issues are independent:
@@ -24,6 +28,26 @@ Use this model whenever multiple issues are independent:
 If two issues touch the same files heavily, either:
 - serialize those two issues, or
 - split scope so each agent owns non-overlapping symbols.
+
+## Section-Wave Execution Model (Required)
+
+When the user asks for "whole sections at a time", execute in waves aligned to tracker sections:
+
+1. **Section A: Core lifecycle/data**
+   - `#643 #644 #645 #646 #659 #660 #661 #662 #663`
+2. **Section B: Extraction runtime/session**
+   - `#649 #650 #651 #652 #653 #654`
+3. **Section C: Operations/security/integration**
+   - `#665 #667 #670 #671 #672 #673`
+
+Wave rules:
+
+1. Run independent issues in parallel with one Claude instance per issue.
+2. Respect dependencies inside the section (foundation issues first).
+3. Keep all PRs targeting `feature/manage-knowledge-graph`.
+4. Do not start the next section until current section is merged or explicitly deferred.
+5. For each section, maintain a live status board:
+   - `queued`, `in_progress`, `blocked`, `in_review`, `merged`
 
 ## Scope and Inputs
 
@@ -39,6 +63,26 @@ Before coding, gather:
    - architectural constraints from `AGENTS.md`
 
 If acceptance criteria are ambiguous, ask one focused question before implementation.
+
+## Claude Instance Spawn Contract
+
+For each issue, provide the Claude instance:
+
+1. Issue ID + title + acceptance criteria summary.
+2. Branch naming requirement:
+   - `feat/issue-<id>-<short-scope>` or `fix/issue-<id>-<short-scope>`
+3. Required reads:
+   - `AGENTS.md`
+   - relevant `specs/*.spec.md`
+   - related tests in touched context
+4. TDD requirement:
+   - tests first, then implementation, then verification
+5. Output contract:
+   - branch
+   - commit(s)
+   - test commands and results
+   - PR URL
+   - blockers/questions
 
 ## Blocker Question Protocol (Required)
 
@@ -61,6 +105,13 @@ When blocked:
    - recommended option and why
 4. If working from a GitHub issue, mirror the same question as an issue comment so the orchestrator can batch unresolved questions across agents.
 5. Continue only non-blocked work; do not guess on blocked decisions.
+
+If a blocker impacts multiple active instances:
+
+1. Pause affected issues.
+2. Continue unaffected issues in parallel.
+3. Post one consolidated orchestrator decision update.
+4. Resume paused issues with explicit instruction delta.
 
 ## Git Workflow
 
@@ -117,6 +168,24 @@ When blocked:
 4. Re-run tests after conflict resolution.
 5. Merge into `feature/manage-knowledge-graph` only after verification.
 
+## Orchestrator Monitoring Loop (Required)
+
+During active waves, run this loop continuously:
+
+1. Poll each PR for:
+   - mergeability
+   - CI status
+   - review comments requiring changes
+2. If merge conflict appears:
+   - rebase/merge target branch into issue branch
+   - resolve conflicts preserving spec behavior
+   - rerun relevant tests
+   - push and re-check PR
+3. If CI fails:
+   - fix in same issue branch
+   - do not move issue scope
+4. Update section status board and report progress to user.
+
 ## Orchestrator Handoff Contract
 
 Each subagent must hand back:
@@ -133,4 +202,5 @@ Each subagent must hand back:
 - Do not disable hooks.
 - Do not commit secrets or credentials.
 - Prefer fakes over mocks in unit tests when testing domain/application behavior.
+- Do not invent acceptance criteria beyond the issue/spec without asking.
 

--- a/skills/subagent-delivery/claude-instance-system-prompt.txt
+++ b/skills/subagent-delivery/claude-instance-system-prompt.txt
@@ -1,0 +1,67 @@
+You are a focused delivery Claude instance assigned to exactly one Kartograph GitHub issue.
+
+Mission:
+- Deliver the assigned issue end-to-end with TDD discipline.
+- Open a PR against `feature/manage-knowledge-graph`.
+- Stop and ask immediately when blocked by ambiguity.
+
+Hard constraints:
+1. Scope
+   - Work only on the assigned issue.
+   - Do not expand scope to neighboring issues.
+2. Branching
+   - Start from latest `feature/manage-knowledge-graph`.
+   - Use branch `feat/issue-<id>-<short-scope>` or `fix/issue-<id>-<short-scope>`.
+3. Specs and architecture
+   - Read `AGENTS.md` first.
+   - Read all relevant `specs/*.spec.md` for your issue.
+   - Preserve bounded-context boundaries and authorization rules.
+4. TDD
+   - Write/adjust tests first.
+   - Implement minimal code to satisfy tests.
+   - Run focused tests; run broader suite as needed by touched context.
+5. Safety
+   - Never use destructive git commands.
+   - Never commit secrets.
+   - Never skip required checks.
+
+Blocker protocol (mandatory):
+- Trigger if acceptance criteria are ambiguous, security/tenancy decision is unclear, or behavior is unspecified.
+- Stop at decision boundary and ask one concise question with:
+  - ambiguity summary
+  - 2-3 concrete options
+  - recommended option with rationale
+- Mirror the blocker question on the GitHub issue as a comment.
+- Continue only non-blocked work.
+
+Execution checklist:
+1. Parse issue acceptance criteria.
+2. Inspect affected code and tests.
+3. Add failing tests for required behavior.
+4. Implement and make tests pass.
+5. Run lint/type/test for touched area.
+6. Commit atomically using conventional commit message.
+7. Push branch and open PR to `feature/manage-knowledge-graph`.
+
+PR body format:
+## Summary
+- what changed and why
+- key architecture/security note
+
+## Testing
+- [x] commands run and results
+- [ ] any pending verification
+
+## Risks
+- none or explicit risk + mitigation
+
+Include `Closes #<issue-id>` where appropriate.
+
+Required handoff output:
+1. Issue ID
+2. Branch name
+3. Commit SHA(s)
+4. Test commands and pass/fail
+5. PR URL
+6. Open blockers/questions (if any)
+7. Assumptions made

--- a/skills/subagent-delivery/section-wave-launch.template.txt
+++ b/skills/subagent-delivery/section-wave-launch.template.txt
@@ -1,0 +1,38 @@
+Section wave launch template (one Claude instance per issue)
+
+Prerequisites:
+- Read: `skills/subagent-delivery/SKILL.md`
+- System prompt: `skills/subagent-delivery/claude-instance-system-prompt.txt`
+- Base branch: `feature/manage-knowledge-graph`
+
+Per-instance launch packet:
+
+ISSUE: <id> - <title>
+TARGET BRANCH: feature/manage-knowledge-graph
+WORK BRANCH: feat/issue-<id>-<short-scope>
+
+Required context files:
+- AGENTS.md
+- <relevant spec files>
+- <relevant code files>
+- <relevant tests>
+
+Acceptance criteria summary:
+- <criterion 1>
+- <criterion 2>
+
+Execution requirements:
+1) TDD: tests first
+2) Implement minimal passing code
+3) Run focused tests + lint
+4) Commit atomically (conventional commit)
+5) Open PR to feature/manage-knowledge-graph
+6) Report branch, tests, PR URL, blockers
+
+Blocker handling:
+- Ask one focused blocker question immediately.
+- Include options + recommendation.
+- Mirror blocker question on issue comment.
+
+Orchestrator status line format:
+[Issue #<id>] <queued|in_progress|blocked|in_review|merged> | Branch: <branch> | PR: <url-or-pending>


### PR DESCRIPTION
## Summary
- extend `skills/subagent-delivery/SKILL.md` with section-wave execution and monitoring protocol
- add reusable Claude instance system prompt at `skills/subagent-delivery/claude-instance-system-prompt.txt`
- add issue launch packet template at `skills/subagent-delivery/section-wave-launch.template.txt`

## Testing
- [x] content verification by file inspection
- [x] no code/runtime impact outside orchestration assets

## Risks
- none

Made with [Cursor](https://cursor.com)