### PR TITLE
feat: add extraction sticky runtime and ephemeral worker adapters

### DIFF
--- a/src/api/extraction/infrastructure/__init__.py
+++ b/src/api/extraction/infrastructure/__init__.py
@@ -8,11 +8,19 @@ from extraction.infrastructure.repositories import (
 from extraction.infrastructure.runtime_context_builder import (
     FilesystemExtractionRuntimeContextBuilder,
 )
+from extraction.infrastructure.workload_runtime import (
+    InMemoryEphemeralExtractionWorkerLauncher,
+    InMemoryStickySessionRuntimeManager,
+    ScopedWorkloadCredentialIssuer,
+)
 
 __all__ = [
     "ExtractionEventHandler",
     "ExtractionAgentSessionRepository",
     "ExtractionSkillOverrideRepository",
     "FilesystemExtractionRuntimeContextBuilder",
+    "InMemoryStickySessionRuntimeManager",
+    "ScopedWorkloadCredentialIssuer",
+    "InMemoryEphemeralExtractionWorkerLauncher",
 ]
 

--- a/src/api/extraction/infrastructure/workload_runtime.py
+++ b/src/api/extraction/infrastructure/workload_runtime.py
@@ -1,0 +1,145 @@
+"""In-memory runtime adapters for extraction session/workload execution."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+
+from ulid import ULID
+
+from extraction.ports.runtime import (
+    EphemeralWorkerLaunchRequest,
+    EphemeralWorkerLaunchResult,
+    IEphemeralExtractionWorkerLauncher,
+    IStickySessionRuntimeManager,
+    ScopedWorkloadCredentials,
+    StickySessionRuntimeLease,
+)
+
+
+class InMemoryStickySessionRuntimeManager(IStickySessionRuntimeManager):
+    """Sticky runtime manager with session reuse + timeout cleanup semantics."""
+
+    def __init__(self, *, session_ttl: timedelta = timedelta(minutes=30)) -> None:
+        self._session_ttl = session_ttl
+        self._leases: dict[str, StickySessionRuntimeLease] = {}
+
+    def get_or_start_runtime(
+        self,
+        *,
+        session_id: str,
+        user_id: str,
+        knowledge_graph_id: str,
+        mode: str,
+    ) -> StickySessionRuntimeLease:
+        now = datetime.now(UTC)
+        existing = self._leases.get(session_id)
+        if existing is not None and existing.expires_at > now:
+            refreshed = replace(
+                existing,
+                last_activity_at=now,
+                expires_at=now + self._session_ttl,
+                status="active",
+            )
+            self._leases[session_id] = refreshed
+            return refreshed
+
+        lease = StickySessionRuntimeLease(
+            session_id=session_id,
+            container_id=str(ULID()),
+            user_id=user_id,
+            knowledge_graph_id=knowledge_graph_id,
+            mode=mode,
+            status="active",
+            last_activity_at=now,
+            expires_at=now + self._session_ttl,
+        )
+        self._leases[session_id] = lease
+        return lease
+
+    def reset_runtime(
+        self,
+        *,
+        session_id: str,
+        user_id: str,
+        knowledge_graph_id: str,
+        mode: str,
+    ) -> StickySessionRuntimeLease:
+        self._leases.pop(session_id, None)
+        return self.get_or_start_runtime(
+            session_id=session_id,
+            user_id=user_id,
+            knowledge_graph_id=knowledge_graph_id,
+            mode=mode,
+        )
+
+    def cleanup_expired(self, *, now: datetime) -> list[str]:
+        expired_sessions = [
+            session_id
+            for session_id, lease in self._leases.items()
+            if lease.expires_at <= now
+        ]
+        terminated: list[str] = []
+        for session_id in expired_sessions:
+            lease = self._leases.pop(session_id)
+            terminated.append(lease.container_id)
+        return terminated
+
+
+class ScopedWorkloadCredentialIssuer:
+    """Issues short-lived tenant/KG scoped credentials for extraction workers."""
+
+    def __init__(self, *, default_ttl: timedelta = timedelta(minutes=15)) -> None:
+        self._default_ttl = default_ttl
+
+    def issue(self, *, tenant_id: str, knowledge_graph_id: str) -> ScopedWorkloadCredentials:
+        now = datetime.now(UTC)
+        return ScopedWorkloadCredentials(
+            token=str(ULID()),
+            expires_at=now + self._default_ttl,
+            scopes=(
+                f"tenant:{tenant_id}",
+                f"knowledge_graph:{knowledge_graph_id}",
+                "workload:extraction",
+            ),
+        )
+
+
+class InMemoryEphemeralExtractionWorkerLauncher(IEphemeralExtractionWorkerLauncher):
+    """Ephemeral worker launcher that validates scope and tracks active workers."""
+
+    def __init__(self) -> None:
+        self._active_workers: dict[str, EphemeralWorkerLaunchRequest] = {}
+
+    @property
+    def active_worker_count(self) -> int:
+        return len(self._active_workers)
+
+    def launch(
+        self,
+        *,
+        request: EphemeralWorkerLaunchRequest,
+        credentials: ScopedWorkloadCredentials,
+    ) -> EphemeralWorkerLaunchResult:
+        required_scopes = {
+            f"tenant:{request.tenant_id}",
+            f"knowledge_graph:{request.knowledge_graph_id}",
+            "workload:extraction",
+        }
+        available_scopes = set(credentials.scopes)
+        if not required_scopes.issubset(available_scopes):
+            raise ValueError("credentials scope does not satisfy workload requirements")
+        if credentials.expires_at <= datetime.now(UTC):
+            raise ValueError("credentials are expired")
+
+        worker_id = str(ULID())
+        self._active_workers[worker_id] = request
+        return EphemeralWorkerLaunchResult(
+            worker_id=worker_id,
+            status="running",
+            credentials_expires_at=credentials.expires_at,
+        )
+
+    def complete_worker(self, worker_id: str) -> None:
+        self._active_workers.pop(worker_id, None)
+

--- a/src/api/extraction/ports/__init__.py
+++ b/src/api/extraction/ports/__init__.py
@@ -4,11 +4,25 @@ from extraction.ports.repositories import (
     IExtractionAgentSessionRepository,
     IExtractionSkillOverrideRepository,
 )
+from extraction.ports.runtime import (
+    EphemeralWorkerLaunchRequest,
+    EphemeralWorkerLaunchResult,
+    IEphemeralExtractionWorkerLauncher,
+    IStickySessionRuntimeManager,
+    ScopedWorkloadCredentials,
+    StickySessionRuntimeLease,
+)
 from extraction.ports.services import IExtractionService
 
 __all__ = [
     "IExtractionService",
     "IExtractionAgentSessionRepository",
     "IExtractionSkillOverrideRepository",
+    "IStickySessionRuntimeManager",
+    "IEphemeralExtractionWorkerLauncher",
+    "StickySessionRuntimeLease",
+    "ScopedWorkloadCredentials",
+    "EphemeralWorkerLaunchRequest",
+    "EphemeralWorkerLaunchResult",
 ]
 

--- a/src/api/extraction/ports/runtime.py
+++ b/src/api/extraction/ports/runtime.py
@@ -1,0 +1,98 @@
+"""Runtime port contracts for extraction workload execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class StickySessionRuntimeLease:
+    """Represents sticky runtime assignment for an active chat session."""
+
+    session_id: str
+    container_id: str
+    user_id: str
+    knowledge_graph_id: str
+    mode: str
+    status: str
+    last_activity_at: datetime
+    expires_at: datetime
+
+
+@dataclass(frozen=True)
+class ScopedWorkloadCredentials:
+    """Short-lived credentials issued for one extraction workload scope."""
+
+    token: str
+    expires_at: datetime
+    scopes: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class EphemeralWorkerLaunchRequest:
+    """Launch payload for an ephemeral extraction worker."""
+
+    tenant_id: str
+    knowledge_graph_id: str
+    session_id: str
+    sync_run_id: str
+    job_package_id: str
+
+
+@dataclass(frozen=True)
+class EphemeralWorkerLaunchResult:
+    """Safe result returned after worker launch."""
+
+    worker_id: str
+    status: str
+    credentials_expires_at: datetime
+
+
+class IStickySessionRuntimeManager(Protocol):
+    """Manages sticky chat runtime containers for active sessions."""
+
+    def get_or_start_runtime(
+        self,
+        *,
+        session_id: str,
+        user_id: str,
+        knowledge_graph_id: str,
+        mode: str,
+    ) -> StickySessionRuntimeLease:
+        """Return current runtime lease or start a new sticky runtime."""
+        ...
+
+    def reset_runtime(
+        self,
+        *,
+        session_id: str,
+        user_id: str,
+        knowledge_graph_id: str,
+        mode: str,
+    ) -> StickySessionRuntimeLease:
+        """Terminate existing runtime for session and start a clean one."""
+        ...
+
+    def cleanup_expired(self, *, now: datetime) -> list[str]:
+        """Terminate and remove expired sticky runtimes; return container IDs."""
+        ...
+
+
+class IEphemeralExtractionWorkerLauncher(Protocol):
+    """Launches short-lived extraction workers with scoped credentials."""
+
+    def launch(
+        self,
+        *,
+        request: EphemeralWorkerLaunchRequest,
+        credentials: ScopedWorkloadCredentials,
+    ) -> EphemeralWorkerLaunchResult:
+        """Start ephemeral worker; must not expose credential material."""
+        ...
+
+    def complete_worker(self, worker_id: str) -> None:
+        """Mark worker as completed and terminate runtime resources."""
+        ...
+

--- a/src/api/tests/unit/extraction/infrastructure/test_workload_runtime.py
+++ b/src/api/tests/unit/extraction/infrastructure/test_workload_runtime.py
@@ -1,0 +1,150 @@
+"""Unit tests for extraction workload runtime infrastructure adapters."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from extraction.infrastructure.workload_runtime import (
+    InMemoryEphemeralExtractionWorkerLauncher,
+    InMemoryStickySessionRuntimeManager,
+    ScopedWorkloadCredentialIssuer,
+)
+from extraction.ports.runtime import (
+    EphemeralWorkerLaunchRequest,
+)
+
+
+class TestInMemoryStickySessionRuntimeManager:
+    def test_reuses_same_container_while_session_active(self) -> None:
+        manager = InMemoryStickySessionRuntimeManager(session_ttl=timedelta(minutes=30))
+
+        first = manager.get_or_start_runtime(
+            session_id="session-1",
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode="extraction_operations",
+        )
+        second = manager.get_or_start_runtime(
+            session_id="session-1",
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode="extraction_operations",
+        )
+
+        assert first.container_id == second.container_id
+        assert first.status == "active"
+        assert second.status == "active"
+
+    def test_reset_rotates_container_for_same_session(self) -> None:
+        manager = InMemoryStickySessionRuntimeManager(session_ttl=timedelta(minutes=30))
+        original = manager.get_or_start_runtime(
+            session_id="session-1",
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode="schema_bootstrap",
+        )
+
+        rotated = manager.reset_runtime(
+            session_id="session-1",
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode="schema_bootstrap",
+        )
+
+        assert rotated.container_id != original.container_id
+        assert rotated.status == "active"
+
+    def test_cleanup_terminates_expired_sessions(self) -> None:
+        manager = InMemoryStickySessionRuntimeManager(session_ttl=timedelta(minutes=5))
+        lease = manager.get_or_start_runtime(
+            session_id="session-1",
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode="schema_bootstrap",
+        )
+        cleanup_at = lease.last_activity_at + timedelta(minutes=6)
+
+        terminated = manager.cleanup_expired(now=cleanup_at)
+
+        assert terminated == [lease.container_id]
+        replacement = manager.get_or_start_runtime(
+            session_id="session-1",
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode="schema_bootstrap",
+        )
+        assert replacement.container_id != lease.container_id
+
+
+class TestEphemeralWorkerLauncher:
+    def test_launch_requires_credentials_scoped_to_request(self) -> None:
+        issuer = ScopedWorkloadCredentialIssuer(default_ttl=timedelta(minutes=10))
+        launcher = InMemoryEphemeralExtractionWorkerLauncher()
+        wrong_scope = issuer.issue(
+            tenant_id="tenant-2",
+            knowledge_graph_id="kg-2",
+        )
+        request = EphemeralWorkerLaunchRequest(
+            tenant_id="tenant-1",
+            knowledge_graph_id="kg-1",
+            session_id="session-1",
+            sync_run_id="sync-1",
+            job_package_id="pkg-1",
+        )
+
+        with pytest.raises(ValueError, match="scope"):
+            launcher.launch(request=request, credentials=wrong_scope)
+
+    def test_launch_uses_ephemeral_worker_and_hides_credential_material(self) -> None:
+        issuer = ScopedWorkloadCredentialIssuer(default_ttl=timedelta(minutes=10))
+        launcher = InMemoryEphemeralExtractionWorkerLauncher()
+        scoped_credentials = issuer.issue(tenant_id="tenant-1", knowledge_graph_id="kg-1")
+        request = EphemeralWorkerLaunchRequest(
+            tenant_id="tenant-1",
+            knowledge_graph_id="kg-1",
+            session_id="session-1",
+            sync_run_id="sync-1",
+            job_package_id="pkg-1",
+        )
+
+        result = launcher.launch(request=request, credentials=scoped_credentials)
+
+        assert result.worker_id
+        assert result.status == "running"
+        assert result.credentials_expires_at > datetime.now(UTC)
+        assert not hasattr(result, "token")
+        assert launcher.active_worker_count == 1
+
+    def test_complete_worker_terminates_container(self) -> None:
+        issuer = ScopedWorkloadCredentialIssuer(default_ttl=timedelta(minutes=10))
+        launcher = InMemoryEphemeralExtractionWorkerLauncher()
+        scoped_credentials = issuer.issue(tenant_id="tenant-1", knowledge_graph_id="kg-1")
+        request = EphemeralWorkerLaunchRequest(
+            tenant_id="tenant-1",
+            knowledge_graph_id="kg-1",
+            session_id="session-1",
+            sync_run_id="sync-1",
+            job_package_id="pkg-1",
+        )
+        result = launcher.launch(request=request, credentials=scoped_credentials)
+
+        launcher.complete_worker(result.worker_id)
+
+        assert launcher.active_worker_count == 0
+
+
+class TestScopedWorkloadCredentialIssuer:
+    def test_issues_short_lived_credentials_with_least_privilege_scope(self) -> None:
+        issuer = ScopedWorkloadCredentialIssuer(default_ttl=timedelta(minutes=15))
+
+        issued = issuer.issue(tenant_id="tenant-9", knowledge_graph_id="kg-9")
+
+        assert issued.expires_at > datetime.now(UTC)
+        assert issued.scopes == (
+            "tenant:tenant-9",
+            "knowledge_graph:kg-9",
+            "workload:extraction",
+        )
+        assert issued.token


### PR DESCRIPTION
Closes #653
Closes #654

## Summary
- add extraction runtime port contracts for sticky session leases, scoped workload credentials, and ephemeral worker launch requests/results
- implement in-memory tracer-bullet adapters for sticky runtime reuse/reset/timeout cleanup and ephemeral worker launch/termination
- enforce least-privilege scope validation and short-lived credential semantics before worker launch
- add unit tests covering sticky reuse/reset/expiry and scoped credential + worker lifecycle behavior

## Test plan
- [x] `cd src/api && uv run pytest tests/unit/extraction/infrastructure/test_workload_runtime.py tests/unit/extraction/test_architecture.py -q`

## Notes
- this is a tracer-bullet implementation for runtime orchestration contracts; concrete container platform adapters can implement the same ports.

Made with [Cursor](https://cursor.com)