### PR TITLE
Harden ingestion secret handling and validate workspace-to-mutation flow

### DIFF
--- a/src/api/ingestion/infrastructure/event_handler.py
+++ b/src/api/ingestion/infrastructure/event_handler.py
@@ -7,6 +7,7 @@ pipeline and emits either JobPackageProduced or IngestionFailed to the outbox.
 from __future__ import annotations
 
 import asyncio
+import re
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -49,10 +50,29 @@ class IngestionEventHandler:
         """Return event types handled by this handler."""
         return frozenset({"SyncStarted"})
 
+    @staticmethod
+    def _redact_sensitive_error(message: str) -> str:
+        """Redact token-like secrets from error strings before persistence."""
+        patterns = (
+            # GitHub PAT prefixes
+            re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
+            # Generic bearer tokens
+            re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._\-+/=]{16,}\b"),
+            # Common key/value credential leaks
+            re.compile(
+                r"(?i)\b(token|access_token|password|api[_-]?key)\b\s*[:=]\s*['\"]?[^\s,'\"]+"
+            ),
+        )
+        redacted = message
+        for pattern in patterns:
+            redacted = pattern.sub("***REDACTED***", redacted)
+        return redacted
+
     async def handle(
         self,
         event_type: str,
         payload: dict[str, Any],
+        runtime_credentials: dict[str, str] | None = None,
     ) -> None:
         """Process a SyncStarted event by running the ingestion pipeline.
 
@@ -98,7 +118,7 @@ class IngestionEventHandler:
                 adapter_type=payload["adapter_type"],
                 connection_config=payload.get("connection_config", {}),
                 credentials_path=payload.get("credentials_path"),
-                credentials=payload.get("credentials"),
+                credentials=runtime_credentials or payload.get("credentials"),
                 baseline_commit=payload.get("baseline_commit"),
             )
         except asyncio.CancelledError:
@@ -111,7 +131,7 @@ class IngestionEventHandler:
                 payload={
                     "sync_run_id": sync_run_id,
                     "data_source_id": data_source_id,
-                    "error": str(exc),
+                    "error": self._redact_sensitive_error(str(exc)),
                     "occurred_at": now.isoformat(),
                 },
                 occurred_at=now,

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -249,9 +249,6 @@ class _SessionedIngestionEventHandler:
                             )
                         except KeyError:
                             credentials = {}
-                    if credentials:
-                        enriched_payload["credentials"] = credentials
-
                     tracked_head = await self._resolve_github_tracked_head_commit(
                         connection_config=ds.connection_config,
                         credentials=credentials,
@@ -268,7 +265,11 @@ class _SessionedIngestionEventHandler:
                         ):
                             enriched_payload["no_changes_detected"] = True
 
-            await ingestion_handler.handle(event_type, enriched_payload)
+            await ingestion_handler.handle(
+                event_type,
+                enriched_payload,
+                runtime_credentials=credentials,
+            )
             await session.commit()
 
 

--- a/src/api/tests/integration/management/test_workspace_extraction_mutation_flow.py
+++ b/src/api/tests/integration/management/test_workspace_extraction_mutation_flow.py
@@ -1,0 +1,176 @@
+"""Integration test for workspace transition and mutation-log run visibility."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import text
+
+from management.application.services.data_source_service import DataSourceService
+from management.application.services.knowledge_graph_service import KnowledgeGraphService
+from management.domain.aggregates import KnowledgeGraph
+from management.domain.entities.data_source_sync_run import MutationLogRunMetadata
+from management.domain.value_objects import EdgeTypeDefinition, NodeTypeDefinition, OntologyConfig
+from management.presentation.data_sources.models import SyncRunResponse
+from shared_kernel.datasource_types import DataSourceAdapterType
+from tests.fakes.authorization import InMemoryAuthorizationProvider
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_workspace_transition_then_extraction_run_metadata_visibility(
+    async_session,
+    clean_management_data: None,
+    knowledge_graph_repository,
+    data_source_repository,
+    data_source_sync_run_repository,
+    test_tenant: str,
+    test_workspace: str,
+) -> None:
+    """End-to-end flow: validate/transition workspace and project mutation-run metadata."""
+    required_columns = (
+        "maintenance_schedule",
+        "maintenance_run_history",
+    )
+    for column_name in required_columns:
+        column_check = await async_session.execute(
+            text(
+                """
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_name = 'knowledge_graphs'
+                  AND column_name = :column_name
+                """
+            ),
+            {"column_name": column_name},
+        )
+        if column_check.scalar_one_or_none() is None:
+            pytest.skip(
+                f"knowledge_graphs.{column_name} is missing in local integration database"
+            )
+
+    user_id = "user-integration-001"
+    authz = InMemoryAuthorizationProvider()
+
+    kg_service = KnowledgeGraphService(
+        session=async_session,
+        knowledge_graph_repository=knowledge_graph_repository,
+        data_source_repository=data_source_repository,
+        sync_run_repository=data_source_sync_run_repository,
+        secret_store=None,
+        authz=authz,
+        scope_to_tenant=test_tenant,
+    )
+    ds_service = DataSourceService(
+        session=async_session,
+        data_source_repository=data_source_repository,
+        knowledge_graph_repository=knowledge_graph_repository,
+        sync_run_repository=data_source_sync_run_repository,
+        secret_store=None,
+        authz=authz,
+        scope_to_tenant=test_tenant,
+    )
+
+    knowledge_graph = KnowledgeGraph.create(
+        tenant_id=test_tenant,
+        workspace_id=test_workspace,
+        name="Integration Flow KG",
+        description="Workspace transition + extraction run visibility",
+        created_by=user_id,
+    )
+    knowledge_graph.set_ontology(
+        OntologyConfig(
+            node_types=(
+                NodeTypeDefinition(label="Repository"),
+                NodeTypeDefinition(
+                    label="SeedNode",
+                    prepopulated=True,
+                    prepopulated_instance_count=1,
+                ),
+            ),
+            edge_types=(
+                EdgeTypeDefinition(
+                    label="CONTAINS",
+                    source_labels=("Repository",),
+                    target_labels=("SeedNode",),
+                ),
+            ),
+        )
+    )
+    async with async_session.begin():
+        await knowledge_graph_repository.save(knowledge_graph)
+
+    await authz.write_relationship(
+        f"knowledge_graph:{knowledge_graph.id.value}",
+        "admin",
+        f"user:{user_id}",
+    )
+
+    status_before = await kg_service.get_workspace_status(
+        user_id=user_id,
+        kg_id=knowledge_graph.id.value,
+    )
+    assert status_before is not None
+    assert status_before.workspace_mode.value == "schema_bootstrap"
+    assert status_before.transition_eligible is True
+
+    validated = await kg_service.validate_workspace(
+        user_id=user_id,
+        kg_id=knowledge_graph.id.value,
+    )
+    assert validated.transition_eligible is True
+    assert validated.readiness.blocking_reasons == ()
+
+    transitioned = await kg_service.transition_workspace_to_extraction(
+        user_id=user_id,
+        kg_id=knowledge_graph.id.value,
+    )
+    assert transitioned.workspace_mode.value == "extraction_operations"
+    assert transitioned.session_pointers.active_extraction_operations_session_id is not None
+
+    data_source = await ds_service.create(
+        user_id=user_id,
+        kg_id=knowledge_graph.id.value,
+        name="Integration Source",
+        adapter_type=DataSourceAdapterType.GITHUB,
+        connection_config={"repo_url": "https://github.com/example/repo"},
+    )
+    await authz.write_relationship(
+        f"data_source:{data_source.id.value}",
+        "admin",
+        f"user:{user_id}",
+    )
+
+    sync_run = await ds_service.trigger_sync(
+        user_id=user_id,
+        ds_id=data_source.id.value,
+    )
+    assert sync_run.status == "pending"
+
+    sync_run.status = "completed"
+    sync_run.completed_at = datetime.now(UTC)
+    sync_run.mutation_log_run = MutationLogRunMetadata(
+        mutation_log_id="mlog-int-001",
+        knowledge_graph_id=knowledge_graph.id.value,
+        session_id=transitioned.session_pointers.active_extraction_operations_session_id,
+        actor_id=user_id,
+        started_at=sync_run.started_at,
+        completed_at=sync_run.completed_at,
+        token_usage_total=2048,
+        cost_total_usd=1.37,
+        operation_counts={"create_node": 12, "create_edge": 8},
+    )
+    async with async_session.begin():
+        await data_source_sync_run_repository.save(sync_run)
+
+    runs = await data_source_sync_run_repository.find_by_data_source(data_source.id.value)
+    assert len(runs) == 1
+    projected = SyncRunResponse.from_domain(runs[0])
+
+    assert projected.mutation_log_id == "mlog-int-001"
+    assert projected.session_id == transitioned.session_pointers.active_extraction_operations_session_id
+    assert projected.token_usage_total == 2048
+    assert projected.cost_total_usd == pytest.approx(1.37)
+    assert projected.operation_counts == {"create_node": 12, "create_edge": 8}

--- a/src/api/tests/unit/ingestion/infrastructure/test_ingestion_event_handler.py
+++ b/src/api/tests/unit/ingestion/infrastructure/test_ingestion_event_handler.py
@@ -169,6 +169,24 @@ class TestIngestionEventHandlerSuccess:
         assert call["baseline_commit"] == "abc123"
         assert call["credentials"] == {"token": "secret"}
 
+    async def test_prefers_runtime_credentials_over_payload_credentials(
+        self,
+        handler: IngestionEventHandler,
+        ingestion_service: _FakeIngestionService,
+    ):
+        """Runtime credentials override payload credentials to avoid payload leakage."""
+        payload = _sync_started_payload()
+        payload["credentials"] = {"token": "payload-token"}
+
+        await handler.handle(
+            "SyncStarted",
+            payload,
+            runtime_credentials={"token": "runtime-token"},
+        )
+
+        call = ingestion_service.calls[0]
+        assert call["credentials"] == {"token": "runtime-token"}
+
     async def test_emits_job_package_produced_on_success(
         self,
         handler: IngestionEventHandler,
@@ -243,6 +261,48 @@ class TestIngestionEventHandlerFailure:
         assert event["payload"]["sync_run_id"] == "run-002"
         assert event["payload"]["data_source_id"] == "ds-001"
         assert "credentials expired" in event["payload"]["error"]
+
+    async def test_redacts_secret_material_from_failure_payload(
+        self,
+        outbox: _FakeOutboxRepository,
+    ):
+        """Failure payload must redact token-shaped credential values."""
+
+        class _LeakyService(_FakeIngestionService):
+            async def run(  # type: ignore[override]
+                self,
+                sync_run_id: str,
+                data_source_id: str,
+                knowledge_graph_id: str,
+                adapter_type: str,
+                connection_config: dict[str, str],
+                credentials_path: str | None,
+                credentials: dict[str, str] | None = None,
+                baseline_commit: str | None = None,
+            ) -> JobPackageId:
+                raise RuntimeError(
+                    "github auth failed for token ghp_1234567890abcdef1234567890abcdef1234"
+                )
+
+        handler = IngestionEventHandler(
+            ingestion_service=_LeakyService(),
+            outbox=outbox,
+        )
+        payload = _sync_started_payload(sync_run_id="run-redact")
+        await handler.handle(
+            "SyncStarted",
+            payload,
+            runtime_credentials={
+                "token": "ghp_1234567890abcdef1234567890abcdef1234"
+            },
+        )
+
+        event = outbox.appended[0]
+        assert event["event_type"] == "IngestionFailed"
+        assert "ghp_1234567890abcdef1234567890abcdef1234" not in event["payload"][
+            "error"
+        ]
+        assert "***REDACTED***" in event["payload"]["error"]
 
     async def test_ingestion_failed_aggregate_type(
         self,

--- a/src/api/tests/unit/test_sessioned_ingestion_handler.py
+++ b/src/api/tests/unit/test_sessioned_ingestion_handler.py
@@ -101,7 +101,11 @@ async def test_sessioned_ingestion_handler_prepares_commit_context():
     call_payload = ingestion_handler.handle.call_args.args[1]
     assert call_payload["baseline_commit"] == "baseline123"
     assert call_payload["tracked_branch_head_commit"] == "head456"
-    assert call_payload["credentials"] == {"token": "tok"}
+    assert "credentials" not in call_payload
+    assert (
+        ingestion_handler.handle.call_args.kwargs["runtime_credentials"]
+        == {"token": "tok"}
+    )
     ds_repo.save.assert_awaited_once()
     assert data_source.tracked_branch_head_commit == "head456"
 
@@ -169,4 +173,9 @@ async def test_sessioned_ingestion_handler_sets_no_changes_flag_when_heads_match
     assert call_payload["baseline_commit"] == "baseline123"
     assert call_payload["tracked_branch_head_commit"] == "baseline123"
     assert call_payload["no_changes_detected"] is True
+    assert "credentials" not in call_payload
+    assert (
+        ingestion_handler.handle.call_args.kwargs["runtime_credentials"]
+        == {"token": "tok"}
+    )
 


### PR DESCRIPTION
## Summary
- keep runtime credentials out of ingestion event payload propagation by passing secrets through an in-memory runtime argument only
- redact token-like secret material from ingestion failure payloads before persistence to outbox/sync-run surfaces
- add an end-to-end management integration flow test that validates bootstrap readiness, transition to extraction operations, and mutation-run metadata visibility (with schema-aware skip guard for local DB drift)

## Test plan
- [x] `cd src/api && uv run pytest tests/unit/test_sessioned_ingestion_handler.py tests/unit/ingestion/infrastructure/test_ingestion_event_handler.py tests/unit/management/application/test_data_source_service.py tests/unit/management/presentation/test_data_sources_routes.py tests/integration/management/test_workspace_extraction_mutation_flow.py -q`
- [x] `cd src/api && uv run pytest tests/unit/management/application/test_knowledge_graph_service.py tests/unit/management/presentation/test_knowledge_graphs_routes.py -q`
- [ ] `pnpm --dir src/dev-ui exec vitest run app/tests/schema-browser.test.ts app/tests/data-sources.test.ts` *(command currently exits with code 1 and no output in this environment)*

## Issues
- #665
- #667

Made with [Cursor](https://cursor.com)