### PR TITLE
feat(dev-ui): KG Manage workspace overview parity (#722)

### DIFF
--- a/src/dev-ui/app/pages/data-sources/index.vue
+++ b/src/dev-ui/app/pages/data-sources/index.vue
@@ -638,6 +638,8 @@ async function approveOntology() {
 
 const dataSources = ref<DataSourceItem[]>([])
 const loadingDataSources = ref(false)
+const scopedKnowledgeGraphId = ref('')
+const manageReturnKgId = ref('')
 const expandedDiffLists = ref<Record<string, boolean>>({})
 const refreshingCommitRefs = ref<Record<string, boolean>>({})
 const adoptingBaselines = ref<Record<string, boolean>>({})
@@ -646,6 +648,19 @@ function isMaintenanceReady(ds: DataSourceItem): boolean {
   if (!ds.last_extraction_baseline_commit || !ds.tracked_branch_head_commit) return false
   return ds.last_extraction_baseline_commit !== ds.tracked_branch_head_commit
 }
+
+const visibleDataSources = computed(() => {
+  if (!scopedKnowledgeGraphId.value) return dataSources.value
+  return dataSources.value.filter(
+    (ds) => ds.knowledge_graph_id === scopedKnowledgeGraphId.value,
+  )
+})
+
+const manageWorkspaceReturnUrl = computed(() =>
+  manageReturnKgId.value
+    ? `/knowledge-graphs/${manageReturnKgId.value}/manage`
+    : '',
+)
 
 function isDiffExpanded(dsId: string): boolean {
   return expandedDiffLists.value[dsId] === true
@@ -958,10 +973,23 @@ onMounted(async () => {
   // When the user clicks "Add Data Source" from the post-KG-creation toast on
   // /knowledge-graphs, they are sent to /data-sources?kg_id=<new-kg-id>. Reading
   // this param here ensures the wizard opens immediately with the right KG chosen.
+  // Manage workspace navigation contract: ?kg_id=<id>&from=manage preserves graph scope
+  // without auto-opening the creation wizard (see buildDataSourcesStepUrl).
   const preselectedKgId = route.query.kg_id as string | undefined
-  if (preselectedKgId) {
+  const fromManage = route.query.from === 'manage'
+  const focusMaintain = route.query.focus === 'maintain'
+
+  if (fromManage && preselectedKgId) {
+    scopedKnowledgeGraphId.value = preselectedKgId
+    manageReturnKgId.value = preselectedKgId
+    selectedMaintenanceKnowledgeGraphId.value = preselectedKgId
+  } else if (preselectedKgId) {
     await nextTick()
     openWizard(preselectedKgId)
+  }
+
+  if (focusMaintain && preselectedKgId) {
+    selectedMaintenanceKnowledgeGraphId.value = preselectedKgId
   }
 })
 
@@ -1311,10 +1339,19 @@ async function handleDeleteDs() {
           </p>
         </div>
       </div>
-      <Button :disabled="!hasTenant" @click="openWizard">
-        <Plus class="mr-2 size-4" />
-        Add Data Source
-      </Button>
+      <div class="flex items-center gap-2">
+        <Button
+          v-if="manageWorkspaceReturnUrl"
+          variant="outline"
+          @click="navigateTo(manageWorkspaceReturnUrl)"
+        >
+          Back to workspace overview
+        </Button>
+        <Button :disabled="!hasTenant" @click="openWizard(scopedKnowledgeGraphId || undefined)">
+          <Plus class="mr-2 size-4" />
+          Add Data Source
+        </Button>
+      </div>
     </div>
 
     <Separator />
@@ -1504,7 +1541,7 @@ async function handleDeleteDs() {
       </Card>
 
       <!-- Empty state (no data sources yet) -->
-      <div v-if="dataSources.length === 0" class="flex flex-col items-center gap-4 py-16 text-center">
+      <div v-if="visibleDataSources.length === 0" class="flex flex-col items-center gap-4 py-16 text-center">
         <div class="rounded-full bg-muted p-5">
           <Cable class="size-10 text-muted-foreground" />
         </div>
@@ -1524,7 +1561,7 @@ async function handleDeleteDs() {
 
       <!-- Data source list (shown when sources exist) -->
       <div v-else class="space-y-3">
-        <div v-for="ds in dataSources" :key="ds.id" class="rounded-lg border bg-card">
+        <div v-for="ds in visibleDataSources" :key="ds.id" class="rounded-lg border bg-card">
           <div class="flex items-center justify-between p-4">
             <div class="flex items-center gap-3">
               <div class="rounded-md bg-muted p-2">

--- a/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
+++ b/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
@@ -8,6 +8,17 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/com
 import { Separator } from '@/components/ui/separator'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import SharedConversationPanel from '@/components/extraction/SharedConversationPanel.vue'
+import {
+  buildDataSourcesStepUrl,
+  buildMaintainStepUrl,
+  buildManageStepUrl,
+  buildSuggestedNextStep,
+  buildWorkspaceStepCards,
+  parseManageStepQuery,
+  resolveStepDestination,
+  stepStatusTintClass,
+  type WorkspaceStepId,
+} from '@/utils/kgManageWorkspace'
 
 interface WorkspaceReadinessStatus {
   has_minimum_entity_types: boolean
@@ -31,9 +42,17 @@ interface WorkspaceStatusResponse {
   session_pointers: WorkspaceSessionPointers
 }
 
+interface KnowledgeGraphIdentity {
+  id: string
+  name: string
+  description?: string | null
+}
+
 interface DataSourceRef {
   id: string
   name: string
+  last_extraction_baseline_commit?: string | null
+  tracked_branch_head_commit?: string | null
 }
 
 interface MutationLogRunView {
@@ -64,6 +83,9 @@ const { hasTenant, tenantVersion } = useTenant()
 const { extractErrorMessage } = useErrorHandler()
 const { apiFetch } = useApiClient()
 const kgId = computed(() => String(route.params.kgId ?? ''))
+const kgIdentity = ref<KnowledgeGraphIdentity | null>(null)
+const dataSourceCount = ref(0)
+const maintenanceReadyCount = ref(0)
 const loading = ref(false)
 const validating = ref(false)
 const transitioning = ref(false)
@@ -76,6 +98,24 @@ const statusProjection = ref<WorkspaceStatusResponse | null>(null)
 const mutationLogLoading = ref(false)
 const mutationLogRuns = ref<MutationLogRunView[]>([])
 const selectedMutationLogRunId = ref<string | null>(null)
+
+const activeStep = computed(() => parseManageStepQuery(route.query.step))
+const showOverview = computed(() => activeStep.value === null)
+
+const workspaceOverviewInput = computed(() => ({
+  kgId: kgId.value,
+  dataSourceCount: dataSourceCount.value,
+  maintenanceReadyCount: maintenanceReadyCount.value,
+  mutationLogRunCount: mutationLogRuns.value.length,
+  workspaceStatus: statusProjection.value,
+}))
+
+const workspaceStepCards = computed(() => buildWorkspaceStepCards(workspaceOverviewInput.value))
+const suggestedNextStep = computed(() => buildSuggestedNextStep(workspaceOverviewInput.value))
+
+const graphHeaderTitle = computed(() =>
+  kgIdentity.value?.name ?? 'Knowledge Graph Manage Workspace',
+)
 
 const modeLabel = computed(() =>
   statusProjection.value?.workspace_mode === 'extraction_operations'
@@ -150,6 +190,45 @@ const sessionActivityLines = computed(() => {
   if (!Array.isArray(candidate)) return []
   return candidate.filter((line): line is string => typeof line === 'string' && line.trim().length > 0)
 })
+
+async function loadKgIdentity() {
+  if (!hasTenant.value || !kgId.value) return
+  try {
+    kgIdentity.value = await apiFetch<KnowledgeGraphIdentity>(
+      `/management/knowledge-graphs/${kgId.value}`,
+    )
+  } catch (err) {
+    kgIdentity.value = { id: kgId.value, name: kgId.value }
+    toast.error('Failed to load knowledge graph identity', {
+      description: extractErrorMessage(err),
+    })
+  }
+}
+
+async function loadOverviewMetrics() {
+  if (!hasTenant.value || !kgId.value) return
+  try {
+    const dataSources = await apiFetch<DataSourceRef[]>(
+      `/management/knowledge-graphs/${kgId.value}/data-sources`,
+    )
+    dataSourceCount.value = dataSources.length
+    maintenanceReadyCount.value = dataSources.filter((ds) => {
+      if (!ds.last_extraction_baseline_commit || !ds.tracked_branch_head_commit) return false
+      return ds.last_extraction_baseline_commit !== ds.tracked_branch_head_commit
+    }).length
+  } catch {
+    dataSourceCount.value = 0
+    maintenanceReadyCount.value = 0
+  }
+}
+
+function openWorkspaceStep(stepId: WorkspaceStepId) {
+  navigateTo(resolveStepDestination(kgId.value, stepId))
+}
+
+function returnToWorkspaceOverview() {
+  navigateTo(buildManageStepUrl(kgId.value))
+}
 
 async function loadWorkspaceStatus() {
   if (!hasTenant.value || !kgId.value) return
@@ -270,6 +349,7 @@ async function transitionToExtraction() {
 }
 
 async function clearChat() {
+  // Clear chat resets the active extraction session for this knowledge graph.
   if (!kgId.value) return
   clearingChat.value = true
   try {
@@ -288,14 +368,21 @@ async function clearChat() {
 }
 
 onMounted(() => {
+  loadKgIdentity()
   loadWorkspaceStatus()
+  loadOverviewMetrics()
   loadMutationLogRuns()
 })
 
 watch(tenantVersion, () => {
+  kgIdentity.value = null
   statusProjection.value = null
   extractionSession.value = null
+  dataSourceCount.value = 0
+  maintenanceReadyCount.value = 0
+  loadKgIdentity()
   loadWorkspaceStatus()
+  loadOverviewMetrics()
   loadMutationLogRuns()
 })
 
@@ -314,16 +401,25 @@ watch(
     <div class="flex items-center justify-between">
       <div class="space-y-1">
         <div class="flex items-center gap-2">
-          <h1 class="text-2xl font-semibold tracking-tight">Knowledge Graph Manage Workspace</h1>
-          <Badge variant="secondary">{{ modeLabel }}</Badge>
+          <h1 class="text-2xl font-semibold tracking-tight">{{ graphHeaderTitle }}</h1>
+          <Badge v-if="!showOverview" variant="secondary">{{ modeLabel }}</Badge>
         </div>
         <p class="text-sm text-muted-foreground">
-          Validate readiness and move from schema bootstrap to extraction operations.
+          <template v-if="showOverview">
+            Project workspace for knowledge graph {{ kgId }}.
+          </template>
+          <template v-else>
+            Validate readiness and move from schema bootstrap to extraction operations.
+          </template>
         </p>
       </div>
-      <Button variant="outline" size="sm" @click="navigateTo('/knowledge-graphs')">
+      <Button
+        variant="outline"
+        size="sm"
+        @click="showOverview ? navigateTo('/knowledge-graphs') : returnToWorkspaceOverview()"
+      >
         <ArrowLeft class="mr-1.5 size-3.5" />
-        Back to Knowledge Graphs
+        {{ showOverview ? 'Back to Knowledge Graphs' : 'Back to workspace overview' }}
       </Button>
     </div>
 
@@ -339,6 +435,164 @@ watch(
     </div>
 
     <template v-else-if="statusProjection">
+      <section v-if="showOverview" class="space-y-6">
+        <div>
+          <h2 class="text-lg font-semibold tracking-tight">Project workspace</h2>
+          <p class="text-sm text-muted-foreground">
+            Choose a step to continue work on this knowledge graph without re-selecting context.
+          </p>
+        </div>
+
+        <Card class="border-primary/30 bg-primary/5">
+          <CardHeader class="pb-3">
+            <CardTitle class="text-base">Suggested next step</CardTitle>
+            <CardDescription>{{ suggestedNextStep.description }}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button @click="openWorkspaceStep(suggestedNextStep.stepId)">
+              {{ suggestedNextStep.actionLabel }} {{ suggestedNextStep.title }}
+            </Button>
+          </CardContent>
+        </Card>
+
+        <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <!-- Step cards: Data Sources, Graph Management, MutationLogs, Maintain -->
+          <Card
+            v-for="card in workspaceStepCards"
+            :key="card.id"
+            class="flex flex-col"
+            :class="stepStatusTintClass(card.status)"
+          >
+            <CardHeader class="pb-3">
+              <div class="flex items-center justify-between gap-2">
+                <CardTitle class="text-base">{{ card.title }}</CardTitle>
+                <Badge variant="outline">{{ card.status }}</Badge>
+              </div>
+              <CardDescription>{{ card.statusDetail }}</CardDescription>
+            </CardHeader>
+            <CardContent class="mt-auto">
+              <Button
+                class="w-full"
+                variant="outline"
+                @click="openWorkspaceStep(card.id)"
+              >
+                {{ card.actionLabel }}
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      <section v-else-if="activeStep === 'mutation-logs'" class="space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle class="text-base">MutationLogs</CardTitle>
+            <CardDescription>
+              Knowledge-graph scoped mutation runs with per-entry operation previews and run metrics.
+            </CardDescription>
+          </CardHeader>
+          <CardContent class="grid gap-3 xl:grid-cols-[280px_1fr]">
+            <div class="rounded border">
+              <div class="flex items-center justify-between border-b px-3 py-2">
+                <p class="text-xs font-medium text-muted-foreground">Runs</p>
+                <Button size="sm" variant="ghost" class="h-6 px-2 text-[10px]" @click="loadMutationLogRuns">
+                  Refresh
+                </Button>
+              </div>
+              <div v-if="mutationLogLoading" class="flex items-center gap-2 px-3 py-4 text-xs text-muted-foreground">
+                <Loader2 class="size-3.5 animate-spin" />
+                Loading mutation runs...
+              </div>
+              <div v-else-if="mutationLogRuns.length === 0" class="px-3 py-4 text-xs text-muted-foreground">
+                No mutation log runs found for this knowledge graph yet.
+              </div>
+              <div v-else class="max-h-64 overflow-auto p-2 space-y-1.5">
+                <button
+                  v-for="run in mutationLogRuns"
+                  :key="run.id"
+                  class="w-full rounded border px-2 py-1.5 text-left text-xs transition-colors"
+                  :class="selectedMutationLogRunId === run.id ? 'border-primary bg-primary/5' : 'hover:bg-muted/40'"
+                  @click="selectedMutationLogRunId = run.id"
+                >
+                  <p class="font-medium truncate">{{ run.data_source_name }}</p>
+                  <p class="text-muted-foreground truncate">{{ new Date(run.started_at).toLocaleString() }}</p>
+                  <div class="mt-1 flex items-center justify-between">
+                    <Badge variant="outline" class="text-[10px]">{{ run.status }}</Badge>
+                    <span class="font-mono text-[10px] text-muted-foreground">{{ run.mutation_log_id }}</span>
+                  </div>
+                </button>
+              </div>
+            </div>
+
+            <div v-if="selectedMutationLogRun" class="space-y-3 rounded border p-3">
+              <div class="flex flex-wrap items-center gap-2">
+                <Badge>{{ selectedMutationLogRun.status }}</Badge>
+                <p class="text-xs text-muted-foreground">
+                  Data source:
+                  <span class="font-medium text-foreground">{{ selectedMutationLogRun.data_source_name }}</span>
+                </p>
+              </div>
+              <div class="grid gap-2 sm:grid-cols-2">
+                <div class="rounded border px-3 py-2 text-xs">
+                  <p class="text-muted-foreground">MutationLog</p>
+                  <p class="mt-1 font-mono break-all">{{ selectedMutationLogRun.mutation_log_id }}</p>
+                </div>
+                <div class="rounded border px-3 py-2 text-xs">
+                  <p class="text-muted-foreground">Session</p>
+                  <p class="mt-1 font-mono break-all">{{ selectedMutationLogRun.session_id ?? 'None' }}</p>
+                </div>
+                <div class="rounded border px-3 py-2 text-xs">
+                  <p class="text-muted-foreground">Started</p>
+                  <p class="mt-1">{{ new Date(selectedMutationLogRun.started_at).toLocaleString() }}</p>
+                </div>
+                <div class="rounded border px-3 py-2 text-xs">
+                  <p class="text-muted-foreground">Completed</p>
+                  <p class="mt-1">
+                    {{ selectedMutationLogRun.completed_at ? new Date(selectedMutationLogRun.completed_at).toLocaleString() : 'In progress' }}
+                  </p>
+                </div>
+              </div>
+              <div class="grid gap-2 sm:grid-cols-2">
+                <div class="rounded border px-3 py-2 text-xs">
+                  <p class="text-muted-foreground flex items-center gap-1.5">
+                    <Coins class="size-3.5" />
+                    Token usage
+                  </p>
+                  <p class="mt-1 font-medium">{{ (selectedMutationLogRun.token_usage_total ?? 0).toLocaleString() }}</p>
+                </div>
+                <div class="rounded border px-3 py-2 text-xs">
+                  <p class="text-muted-foreground flex items-center gap-1.5">
+                    <DollarSign class="size-3.5" />
+                    Cost (USD)
+                  </p>
+                  <p class="mt-1 font-medium">${{ (selectedMutationLogRun.cost_total_usd ?? 0).toFixed(2) }}</p>
+                </div>
+              </div>
+              <div class="rounded border p-3">
+                <p class="mb-2 text-xs font-medium text-muted-foreground">Per-entry operation previews</p>
+                <div v-if="Object.keys(selectedMutationLogRun.operation_counts).length === 0" class="text-xs text-muted-foreground">
+                  No operation class counts recorded for this run.
+                </div>
+                <div v-else class="space-y-1.5">
+                  <div
+                    v-for="([opClass, count]) in Object.entries(selectedMutationLogRun.operation_counts)"
+                    :key="opClass"
+                    class="flex items-center justify-between rounded border px-2 py-1.5 text-xs"
+                  >
+                    <span class="font-mono">{{ opClass }}</span>
+                    <Badge variant="secondary">{{ count }}</Badge>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div v-else class="rounded border border-dashed p-6 text-sm text-muted-foreground">
+              Select a mutation run to view summary and per-entry previews.
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section v-else class="space-y-6">
       <Card>
         <CardHeader>
           <CardTitle class="text-base">Mode & Transition Controls</CardTitle>
@@ -657,6 +911,7 @@ watch(
           </CardContent>
         </Card>
       </div>
+      </section>
     </template>
   </div>
 </template>

--- a/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
+++ b/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
@@ -1,15 +1,46 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
+import {
+  WORKSPACE_STEP_ORDER,
+  WORKSPACE_STEP_TITLES,
+  buildDataSourcesStepUrl,
+  buildMaintainStepUrl,
+  buildManageStepUrl,
+  buildSuggestedNextStep,
+  buildWorkspaceStepCards,
+  isMaintenanceReady,
+  resolveStepDestination,
+  stepStatusTintClass,
+} from '../utils/kgManageWorkspace'
 
 const manageWorkspaceVue = readFileSync(
   resolve(__dirname, '../pages/knowledge-graphs/[kgId]/manage.vue'),
+  'utf-8',
+)
+const kgIndexVue = readFileSync(
+  resolve(__dirname, '../pages/knowledge-graphs/index.vue'),
+  'utf-8',
+)
+const dataSourcesVue = readFileSync(
+  resolve(__dirname, '../pages/data-sources/index.vue'),
   'utf-8',
 )
 const sharedConversationPanelVue = readFileSync(
   resolve(__dirname, '../components/extraction/SharedConversationPanel.vue'),
   'utf-8',
 )
+
+const baseWorkspaceStatus = {
+  workspace_mode: 'schema_bootstrap' as const,
+  transition_eligible: false,
+  readiness: {
+    has_minimum_entity_types: false,
+    has_minimum_relationship_types: false,
+    prepopulated_types_ready: false,
+    blocking_reasons: ['Missing entity types'],
+  },
+}
 
 describe('Knowledge Graph Manage Workspace - mode-aware controls', () => {
   it('loads workspace status projection from management API', () => {
@@ -106,6 +137,167 @@ describe('Knowledge Graph Manage Workspace - bootstrap readiness guidance', () =
     expect(manageWorkspaceVue).toContain('Next Steps')
     expect(manageWorkspaceVue).toContain('Run Validate to refresh readiness signals')
     expect(manageWorkspaceVue).toContain('Transition is enabled')
+  })
+})
+
+describe('KG-MANAGE-001 - manage entry navigation', () => {
+  it('routes Manage action to graph-scoped manage workspace', () => {
+    expect(kgIndexVue).toContain('navigateTo(`/knowledge-graphs/${kg.id}/manage`)')
+  })
+
+  it('loads graph identity for manage header and back action', () => {
+    expect(manageWorkspaceVue).toContain('/management/knowledge-graphs/${kgId.value}')
+    expect(manageWorkspaceVue).toContain('loadKgIdentity')
+    expect(manageWorkspaceVue).toContain('Back to Knowledge Graphs')
+  })
+})
+
+describe('KG-MANAGE-002 - workspace step card set', () => {
+  it('renders Project workspace section with exactly four step cards', () => {
+    expect(manageWorkspaceVue).toContain('Project workspace')
+    expect(manageWorkspaceVue).toContain('workspaceStepCards')
+    for (const stepId of WORKSPACE_STEP_ORDER) {
+      expect(manageWorkspaceVue).toContain(WORKSPACE_STEP_TITLES[stepId])
+    }
+  })
+
+  it('buildWorkspaceStepCards returns the canonical four-card set', () => {
+    const cards = buildWorkspaceStepCards({
+      kgId: 'kg-1',
+      dataSourceCount: 1,
+      maintenanceReadyCount: 0,
+      mutationLogRunCount: 0,
+      workspaceStatus: baseWorkspaceStatus,
+    })
+
+    expect(cards.map((card) => card.title)).toEqual([
+      'Data Sources',
+      'Graph Management',
+      'MutationLogs',
+      'Maintain',
+    ])
+  })
+})
+
+describe('KG-MANAGE-003 - suggested next step callout', () => {
+  it('renders Suggested next step callout above the card grid', () => {
+    expect(manageWorkspaceVue).toContain('Suggested next step')
+    expect(manageWorkspaceVue).toContain('suggestedNextStep')
+    expect(manageWorkspaceVue).toContain('openWorkspaceStep')
+  })
+
+  it('prioritizes data sources when no sources are connected', () => {
+    const next = buildSuggestedNextStep({
+      kgId: 'kg-1',
+      dataSourceCount: 0,
+      maintenanceReadyCount: 0,
+      mutationLogRunCount: 0,
+      workspaceStatus: baseWorkspaceStatus,
+    })
+
+    expect(next.stepId).toBe('data-sources')
+    expect(next.actionLabel).toBe('Open')
+  })
+
+  it('uses Run action when maintenance is ready', () => {
+    const next = buildSuggestedNextStep({
+      kgId: 'kg-1',
+      dataSourceCount: 2,
+      maintenanceReadyCount: 1,
+      mutationLogRunCount: 3,
+      workspaceStatus: {
+        workspace_mode: 'extraction_operations',
+        transition_eligible: true,
+        readiness: {
+          has_minimum_entity_types: true,
+          has_minimum_relationship_types: true,
+          prepopulated_types_ready: true,
+          blocking_reasons: [],
+        },
+      },
+    })
+
+    expect(next.stepId).toBe('maintain')
+    expect(next.actionLabel).toBe('Run')
+  })
+})
+
+describe('KG-MANAGE-004 - step card status semantics', () => {
+  it('renders status label, tint, detail text, and primary action per card', () => {
+    expect(manageWorkspaceVue).toContain('stepStatusTintClass')
+    expect(manageWorkspaceVue).toContain('card.status')
+    expect(manageWorkspaceVue).toContain('card.statusDetail')
+    expect(manageWorkspaceVue).toContain('card.actionLabel')
+  })
+
+  it('maps each status label to a tint class', () => {
+    expect(stepStatusTintClass('ready')).toContain('emerald')
+    expect(stepStatusTintClass('in_progress')).toContain('blue')
+    expect(stepStatusTintClass('needs_attention')).toContain('amber')
+    expect(stepStatusTintClass('blocked')).toContain('destructive')
+  })
+
+  it('uses Open, Revisit, or Run action labels on cards', () => {
+    const cards = buildWorkspaceStepCards({
+      kgId: 'kg-1',
+      dataSourceCount: 2,
+      maintenanceReadyCount: 1,
+      mutationLogRunCount: 4,
+      workspaceStatus: {
+        workspace_mode: 'extraction_operations',
+        transition_eligible: true,
+        readiness: {
+          has_minimum_entity_types: true,
+          has_minimum_relationship_types: true,
+          prepopulated_types_ready: true,
+          blocking_reasons: [],
+        },
+      },
+    })
+
+    expect(cards.every((card) => ['Open', 'Revisit', 'Run'].includes(card.actionLabel))).toBe(true)
+    expect(cards.find((card) => card.id === 'maintain')?.actionLabel).toBe('Run')
+  })
+})
+
+describe('KG-MANAGE-005 - graph-scoped data sources step', () => {
+  it('routes Data Sources step with kg_id and manage return context', () => {
+    expect(manageWorkspaceVue).toContain('buildDataSourcesStepUrl')
+    expect(buildDataSourcesStepUrl('kg-abc')).toBe('/data-sources?kg_id=kg-abc&from=manage')
+  })
+
+  it('data-sources page preserves manage return path without auto-opening wizard', () => {
+    expect(dataSourcesVue).toContain('from=manage')
+    expect(dataSourcesVue).toContain('scopedKnowledgeGraphId')
+    expect(dataSourcesVue).toContain('Back to workspace overview')
+  })
+})
+
+describe('KG-MANAGE-015 - graph-scoped maintain step and round trip', () => {
+  it('routes Maintain step with graph scope and maintenance focus', () => {
+    expect(manageWorkspaceVue).toContain('buildMaintainStepUrl')
+    expect(buildMaintainStepUrl('kg-abc')).toBe(
+      '/data-sources?kg_id=kg-abc&from=manage&focus=maintain',
+    )
+  })
+
+  it('returns to manage overview from in-page steps', () => {
+    expect(manageWorkspaceVue).toContain('returnToWorkspaceOverview')
+    expect(buildManageStepUrl('kg-abc')).toBe('/knowledge-graphs/kg-abc/manage')
+    expect(resolveStepDestination('kg-abc', 'graph-management')).toBe(
+      '/knowledge-graphs/kg-abc/manage?step=graph-management',
+    )
+  })
+
+  it('detects maintenance readiness from commit diff semantics', () => {
+    expect(isMaintenanceReady({
+      last_extraction_baseline_commit: 'abc',
+      tracked_branch_head_commit: 'def',
+    })).toBe(true)
+    expect(isMaintenanceReady({
+      last_extraction_baseline_commit: 'abc',
+      tracked_branch_head_commit: 'abc',
+    })).toBe(false)
   })
 })
 

--- a/src/dev-ui/app/utils/kgManageWorkspace.ts
+++ b/src/dev-ui/app/utils/kgManageWorkspace.ts
@@ -1,0 +1,319 @@
+export type WorkspaceStepId = 'data-sources' | 'graph-management' | 'mutation-logs' | 'maintain'
+
+export type StepStatusLabel = 'ready' | 'in_progress' | 'needs_attention' | 'blocked'
+
+export type StepActionLabel = 'Open' | 'Revisit' | 'Run'
+
+export const WORKSPACE_STEP_TITLES: Record<WorkspaceStepId, string> = {
+  'data-sources': 'Data Sources',
+  'graph-management': 'Graph Management',
+  'mutation-logs': 'MutationLogs',
+  maintain: 'Maintain',
+}
+
+export const WORKSPACE_STEP_ORDER: WorkspaceStepId[] = [
+  'data-sources',
+  'graph-management',
+  'mutation-logs',
+  'maintain',
+]
+
+export interface WorkspaceReadinessSnapshot {
+  has_minimum_entity_types: boolean
+  has_minimum_relationship_types: boolean
+  prepopulated_types_ready: boolean
+  blocking_reasons: string[]
+}
+
+export interface WorkspaceStatusSnapshot {
+  workspace_mode: 'schema_bootstrap' | 'extraction_operations'
+  transition_eligible: boolean
+  readiness: WorkspaceReadinessSnapshot
+}
+
+export interface WorkspaceOverviewInputs {
+  kgId: string
+  dataSourceCount: number
+  maintenanceReadyCount: number
+  mutationLogRunCount: number
+  workspaceStatus: WorkspaceStatusSnapshot | null
+}
+
+export interface WorkspaceStepCardView {
+  id: WorkspaceStepId
+  title: string
+  status: StepStatusLabel
+  statusDetail: string
+  actionLabel: StepActionLabel
+}
+
+export interface SuggestedNextStepView {
+  stepId: WorkspaceStepId
+  title: string
+  description: string
+  actionLabel: StepActionLabel
+}
+
+export function isMaintenanceReady(ds: {
+  last_extraction_baseline_commit?: string | null
+  tracked_branch_head_commit?: string | null
+}): boolean {
+  if (!ds.last_extraction_baseline_commit || !ds.tracked_branch_head_commit) return false
+  return ds.last_extraction_baseline_commit !== ds.tracked_branch_head_commit
+}
+
+export function buildDataSourcesStepUrl(kgId: string): string {
+  return `/data-sources?kg_id=${encodeURIComponent(kgId)}&from=manage`
+}
+
+export function buildMaintainStepUrl(kgId: string): string {
+  return `/data-sources?kg_id=${encodeURIComponent(kgId)}&from=manage&focus=maintain`
+}
+
+export function buildManageStepUrl(kgId: string, step?: WorkspaceStepId): string {
+  if (!step) {
+    return `/knowledge-graphs/${encodeURIComponent(kgId)}/manage`
+  }
+  return `/knowledge-graphs/${encodeURIComponent(kgId)}/manage?step=${step}`
+}
+
+export function parseManageStepQuery(step: unknown): WorkspaceStepId | null {
+  if (step === 'graph-management' || step === 'mutation-logs') {
+    return step
+  }
+  return null
+}
+
+export function stepStatusTintClass(status: StepStatusLabel): string {
+  switch (status) {
+    case 'ready':
+      return 'border-emerald-500/40 bg-emerald-50/30 dark:bg-emerald-950/20'
+    case 'in_progress':
+      return 'border-blue-500/40 bg-blue-50/30 dark:bg-blue-950/20'
+    case 'needs_attention':
+      return 'border-amber-500/40 bg-amber-50/30 dark:bg-amber-950/20'
+    case 'blocked':
+      return 'border-destructive/50 bg-destructive/5'
+  }
+}
+
+function buildDataSourcesCard(input: WorkspaceOverviewInputs): WorkspaceStepCardView {
+  if (input.dataSourceCount === 0) {
+    return {
+      id: 'data-sources',
+      title: WORKSPACE_STEP_TITLES['data-sources'],
+      status: 'needs_attention',
+      statusDetail: 'No data sources connected yet.',
+      actionLabel: 'Open',
+    }
+  }
+
+  return {
+    id: 'data-sources',
+    title: WORKSPACE_STEP_TITLES['data-sources'],
+    status: 'ready',
+    statusDetail: `${input.dataSourceCount} data source${input.dataSourceCount === 1 ? '' : 's'} connected.`,
+    actionLabel: 'Revisit',
+  }
+}
+
+function buildGraphManagementCard(input: WorkspaceOverviewInputs): WorkspaceStepCardView {
+  const status = input.workspaceStatus
+
+  if (!status) {
+    return {
+      id: 'graph-management',
+      title: WORKSPACE_STEP_TITLES['graph-management'],
+      status: 'in_progress',
+      statusDetail: 'Loading workspace readiness signals.',
+      actionLabel: 'Open',
+    }
+  }
+
+  if (status.workspace_mode === 'schema_bootstrap') {
+    if (status.readiness.blocking_reasons.length > 0) {
+      return {
+        id: 'graph-management',
+        title: WORKSPACE_STEP_TITLES['graph-management'],
+        status: 'needs_attention',
+        statusDetail: `${status.readiness.blocking_reasons.length} blocking reason${status.readiness.blocking_reasons.length === 1 ? '' : 's'} before extraction.`,
+        actionLabel: 'Open',
+      }
+    }
+
+    if (status.transition_eligible) {
+      return {
+        id: 'graph-management',
+        title: WORKSPACE_STEP_TITLES['graph-management'],
+        status: 'ready',
+        statusDetail: 'Schema bootstrap is ready to transition to extraction.',
+        actionLabel: 'Run',
+      }
+    }
+
+    return {
+      id: 'graph-management',
+      title: WORKSPACE_STEP_TITLES['graph-management'],
+      status: 'in_progress',
+      statusDetail: 'Continue schema bootstrap and validation work.',
+      actionLabel: 'Open',
+    }
+  }
+
+  return {
+    id: 'graph-management',
+    title: WORKSPACE_STEP_TITLES['graph-management'],
+    status: 'ready',
+    statusDetail: 'Extraction operations mode is active.',
+    actionLabel: 'Revisit',
+  }
+}
+
+function buildMutationLogsCard(input: WorkspaceOverviewInputs): WorkspaceStepCardView {
+  if (input.dataSourceCount === 0) {
+    return {
+      id: 'mutation-logs',
+      title: WORKSPACE_STEP_TITLES['mutation-logs'],
+      status: 'blocked',
+      statusDetail: 'Connect a data source before reviewing mutation runs.',
+      actionLabel: 'Open',
+    }
+  }
+
+  if (input.mutationLogRunCount === 0) {
+    return {
+      id: 'mutation-logs',
+      title: WORKSPACE_STEP_TITLES['mutation-logs'],
+      status: input.workspaceStatus?.workspace_mode === 'extraction_operations'
+        ? 'needs_attention'
+        : 'ready',
+      statusDetail: 'No mutation log runs recorded for this graph yet.',
+      actionLabel: 'Open',
+    }
+  }
+
+  return {
+    id: 'mutation-logs',
+    title: WORKSPACE_STEP_TITLES['mutation-logs'],
+    status: 'ready',
+    statusDetail: `${input.mutationLogRunCount} mutation run${input.mutationLogRunCount === 1 ? '' : 's'} available.`,
+    actionLabel: 'Revisit',
+  }
+}
+
+function buildMaintainCard(input: WorkspaceOverviewInputs): WorkspaceStepCardView {
+  if (input.dataSourceCount === 0) {
+    return {
+      id: 'maintain',
+      title: WORKSPACE_STEP_TITLES.maintain,
+      status: 'blocked',
+      statusDetail: 'Add a data source before maintenance can run.',
+      actionLabel: 'Open',
+    }
+  }
+
+  if (input.maintenanceReadyCount > 0) {
+    return {
+      id: 'maintain',
+      title: WORKSPACE_STEP_TITLES.maintain,
+      status: 'needs_attention',
+      statusDetail: `${input.maintenanceReadyCount} source${input.maintenanceReadyCount === 1 ? '' : 's'} have new commits ready for maintenance.`,
+      actionLabel: 'Run',
+    }
+  }
+
+  return {
+    id: 'maintain',
+    title: WORKSPACE_STEP_TITLES.maintain,
+    status: 'ready',
+    statusDetail: 'All tracked sources are up to date.',
+    actionLabel: 'Revisit',
+  }
+}
+
+export function buildWorkspaceStepCards(input: WorkspaceOverviewInputs): WorkspaceStepCardView[] {
+  return [
+    buildDataSourcesCard(input),
+    buildGraphManagementCard(input),
+    buildMutationLogsCard(input),
+    buildMaintainCard(input),
+  ]
+}
+
+export function buildSuggestedNextStep(input: WorkspaceOverviewInputs): SuggestedNextStepView {
+  const cards = buildWorkspaceStepCards(input)
+
+  if (input.dataSourceCount === 0) {
+    const card = cards.find((item) => item.id === 'data-sources')!
+    return {
+      stepId: 'data-sources',
+      title: card.title,
+      description: 'Connect a data source to start schema bootstrap and extraction.',
+      actionLabel: card.actionLabel,
+    }
+  }
+
+  const maintainCard = cards.find((item) => item.id === 'maintain')!
+  if (maintainCard.status === 'needs_attention' && maintainCard.actionLabel === 'Run') {
+    return {
+      stepId: 'maintain',
+      title: maintainCard.title,
+      description: maintainCard.statusDetail,
+      actionLabel: 'Run',
+    }
+  }
+
+  const graphCard = cards.find((item) => item.id === 'graph-management')!
+  if (
+    input.workspaceStatus?.workspace_mode === 'schema_bootstrap'
+    && input.workspaceStatus.transition_eligible
+  ) {
+    return {
+      stepId: 'graph-management',
+      title: graphCard.title,
+      description: 'Validate readiness and transition into extraction operations.',
+      actionLabel: 'Run',
+    }
+  }
+
+  if (
+    graphCard.status === 'needs_attention'
+    || graphCard.status === 'in_progress'
+  ) {
+    return {
+      stepId: 'graph-management',
+      title: graphCard.title,
+      description: graphCard.statusDetail,
+      actionLabel: graphCard.actionLabel,
+    }
+  }
+
+  const mutationCard = cards.find((item) => item.id === 'mutation-logs')!
+  if (mutationCard.status === 'needs_attention') {
+    return {
+      stepId: 'mutation-logs',
+      title: mutationCard.title,
+      description: mutationCard.statusDetail,
+      actionLabel: mutationCard.actionLabel,
+    }
+  }
+
+  return {
+    stepId: 'graph-management',
+    title: graphCard.title,
+    description: graphCard.statusDetail,
+    actionLabel: 'Revisit',
+  }
+}
+
+export function resolveStepDestination(kgId: string, stepId: WorkspaceStepId): string {
+  switch (stepId) {
+    case 'data-sources':
+      return buildDataSourcesStepUrl(kgId)
+    case 'maintain':
+      return buildMaintainStepUrl(kgId)
+    case 'graph-management':
+    case 'mutation-logs':
+      return buildManageStepUrl(kgId, stepId)
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a project-workspace overview shell on `/knowledge-graphs/{kgId}/manage` with four step cards (Data Sources, Graph Management, MutationLogs, Maintain), status tint/label/detail semantics, and a suggested next-step CTA.
- Introduces `kgManageWorkspace.ts` to centralize step-card projection, next-step selection, and graph-scoped destination URLs.
- Preserves existing graph-management, conversation, readiness, and mutation-log flows behind in-page steps; Data Sources and Maintain navigate with `kg_id` + `from=manage` and round-trip back to the workspace overview.

Closes #722

## Test plan
- [x] `cd src/dev-ui && npm test -- app/tests/knowledge-graph-manage-workspace.test.ts` — 33 passed
- [x] `cd src/dev-ui && npm test -- app/tests/knowledge-graphs.test.ts` — 75 passed (manage entry regression check)
- [ ] Manual: open Knowledge Graphs list → Manage → verify overview cards + suggested next step
- [ ] Manual: open Data Sources / Maintain cards → confirm graph scope + Back to workspace overview
- [ ] Manual: open Graph Management / MutationLogs steps → confirm existing manage functionality remains available

## Commands run
```bash
cd /tmp/kartograph-dev-ui-test && npm test -- app/tests/knowledge-graph-manage-workspace.test.ts
cd /tmp/kartograph-dev-ui-test && npm test -- app/tests/knowledge-graphs.test.ts
```

Made with [Cursor](https://cursor.com)