### PR TITLE
feat(dev-ui): Graph Management parity with shared chat and hybrid panel (#723)

### DIFF
--- a/src/dev-ui/app/components/extraction/SharedConversationPanel.vue
+++ b/src/dev-ui/app/components/extraction/SharedConversationPanel.vue
@@ -33,11 +33,15 @@ const props = withDefaults(defineProps<{
   clearing?: boolean
   draftMessage?: string
   activityLines?: string[]
+  inputPlaceholder?: string
+  sessionStatusLabel?: string
 }>(), {
   loading: false,
   clearing: false,
   draftMessage: '',
   activityLines: () => [],
+  inputPlaceholder: 'Describe what you want to do in this graph management session…',
+  sessionStatusLabel: 'No active session',
 })
 
 const emit = defineEmits<{
@@ -72,10 +76,17 @@ function confirmClearChat() {
 <template>
   <Card>
     <CardHeader>
-      <CardTitle class="text-base">Conversation</CardTitle>
-      <CardDescription>
-        Shared conversation feed for {{ modeLabel }} with server-side session resume.
-      </CardDescription>
+      <div class="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <CardTitle class="text-base">Conversation</CardTitle>
+          <CardDescription>
+            Shared conversation feed for {{ modeLabel }} with server-side session resume.
+          </CardDescription>
+        </div>
+        <p class="text-xs text-muted-foreground">
+          Session: <span class="font-medium text-foreground">{{ sessionStatusLabel }}</span>
+        </p>
+      </div>
     </CardHeader>
     <CardContent class="space-y-3">
       <div class="flex items-center justify-between">
@@ -125,7 +136,7 @@ function confirmClearChat() {
         <Input
           :model-value="draftMessage"
           disabled
-          placeholder="NDJSON streaming send/receive wiring will attach here."
+          :placeholder="inputPlaceholder"
           @update:model-value="(value) => emit('update:draftMessage', value)"
         />
         <Button variant="outline" :disabled="clearing || loading" @click="clearConfirmOpen = true">
@@ -141,7 +152,7 @@ function confirmClearChat() {
       <AlertDialogHeader>
         <AlertDialogTitle>Clear conversation?</AlertDialogTitle>
         <AlertDialogDescription>
-          This starts a fresh server-side session timeline for the current mode.
+          This starts a fresh server-side session timeline while keeping the selected graph management mode.
         </AlertDialogDescription>
       </AlertDialogHeader>
       <AlertDialogFooter>

--- a/src/dev-ui/app/pages/data-sources/index.vue
+++ b/src/dev-ui/app/pages/data-sources/index.vue
@@ -638,6 +638,8 @@ async function approveOntology() {
 
 const dataSources = ref<DataSourceItem[]>([])
 const loadingDataSources = ref(false)
+const scopedKnowledgeGraphId = ref('')
+const manageReturnKgId = ref('')
 const expandedDiffLists = ref<Record<string, boolean>>({})
 const refreshingCommitRefs = ref<Record<string, boolean>>({})
 const adoptingBaselines = ref<Record<string, boolean>>({})
@@ -646,6 +648,19 @@ function isMaintenanceReady(ds: DataSourceItem): boolean {
   if (!ds.last_extraction_baseline_commit || !ds.tracked_branch_head_commit) return false
   return ds.last_extraction_baseline_commit !== ds.tracked_branch_head_commit
 }
+
+const visibleDataSources = computed(() => {
+  if (!scopedKnowledgeGraphId.value) return dataSources.value
+  return dataSources.value.filter(
+    (ds) => ds.knowledge_graph_id === scopedKnowledgeGraphId.value,
+  )
+})
+
+const manageWorkspaceReturnUrl = computed(() =>
+  manageReturnKgId.value
+    ? `/knowledge-graphs/${manageReturnKgId.value}/manage`
+    : '',
+)
 
 function isDiffExpanded(dsId: string): boolean {
   return expandedDiffLists.value[dsId] === true
@@ -958,10 +973,23 @@ onMounted(async () => {
   // When the user clicks "Add Data Source" from the post-KG-creation toast on
   // /knowledge-graphs, they are sent to /data-sources?kg_id=<new-kg-id>. Reading
   // this param here ensures the wizard opens immediately with the right KG chosen.
+  // Manage workspace navigation contract: ?kg_id=<id>&from=manage preserves graph scope
+  // without auto-opening the creation wizard (see buildDataSourcesStepUrl).
   const preselectedKgId = route.query.kg_id as string | undefined
-  if (preselectedKgId) {
+  const fromManage = route.query.from === 'manage'
+  const focusMaintain = route.query.focus === 'maintain'
+
+  if (fromManage && preselectedKgId) {
+    scopedKnowledgeGraphId.value = preselectedKgId
+    manageReturnKgId.value = preselectedKgId
+    selectedMaintenanceKnowledgeGraphId.value = preselectedKgId
+  } else if (preselectedKgId) {
     await nextTick()
     openWizard(preselectedKgId)
+  }
+
+  if (focusMaintain && preselectedKgId) {
+    selectedMaintenanceKnowledgeGraphId.value = preselectedKgId
   }
 })
 
@@ -1311,10 +1339,19 @@ async function handleDeleteDs() {
           </p>
         </div>
       </div>
-      <Button :disabled="!hasTenant" @click="openWizard">
-        <Plus class="mr-2 size-4" />
-        Add Data Source
-      </Button>
+      <div class="flex items-center gap-2">
+        <Button
+          v-if="manageWorkspaceReturnUrl"
+          variant="outline"
+          @click="navigateTo(manageWorkspaceReturnUrl)"
+        >
+          Back to workspace overview
+        </Button>
+        <Button :disabled="!hasTenant" @click="openWizard(scopedKnowledgeGraphId || undefined)">
+          <Plus class="mr-2 size-4" />
+          Add Data Source
+        </Button>
+      </div>
     </div>
 
     <Separator />
@@ -1504,7 +1541,7 @@ async function handleDeleteDs() {
       </Card>
 
       <!-- Empty state (no data sources yet) -->
-      <div v-if="dataSources.length === 0" class="flex flex-col items-center gap-4 py-16 text-center">
+      <div v-if="visibleDataSources.length === 0" class="flex flex-col items-center gap-4 py-16 text-center">
         <div class="rounded-full bg-muted p-5">
           <Cable class="size-10 text-muted-foreground" />
         </div>
@@ -1524,7 +1561,7 @@ async function handleDeleteDs() {
 
       <!-- Data source list (shown when sources exist) -->
       <div v-else class="space-y-3">
-        <div v-for="ds in dataSources" :key="ds.id" class="rounded-lg border bg-card">
+        <div v-for="ds in visibleDataSources" :key="ds.id" class="rounded-lg border bg-card">
           <div class="flex items-center justify-between p-4">
             <div class="flex items-center gap-3">
               <div class="rounded-md bg-muted p-2">

--- a/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
+++ b/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
@@ -6,8 +6,21 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import SharedConversationPanel from '@/components/extraction/SharedConversationPanel.vue'
+import {
+  GRAPH_MANAGEMENT_INPUT_PLACEHOLDERS,
+  GRAPH_MANAGEMENT_MODE_LABELS,
+  GRAPH_MANAGEMENT_MODE_ORDER,
+  buildGraphManagementRailItems,
+  buildGraphManagementStepUrl,
+  filterRailItemsForMode,
+  parseGraphManagementModeQuery,
+  resolveDefaultGraphManagementMode,
+  resolveRailSelectionForMode,
+  resolveSharedSessionMode,
+  type GraphManagementMode,
+  type GraphManagementRailItemId,
+} from '@/utils/kgGraphManagement'
 import {
   buildDataSourcesStepUrl,
   buildMaintainStepUrl,
@@ -92,12 +105,13 @@ const transitioning = ref(false)
 const sessionLoading = ref(false)
 const clearingChat = ref(false)
 const extractionSession = ref<ExtractionSessionResponse | null>(null)
-const extractionTab = ref('extraction-jobs')
 const draftMessage = ref('')
 const statusProjection = ref<WorkspaceStatusResponse | null>(null)
 const mutationLogLoading = ref(false)
 const mutationLogRuns = ref<MutationLogRunView[]>([])
 const selectedMutationLogRunId = ref<string | null>(null)
+const graphManagementMode = ref<GraphManagementMode>('initial-schema-design')
+const selectedRailItemId = ref<GraphManagementRailItemId | null>(null)
 
 const activeStep = computed(() => parseManageStepQuery(route.query.step))
 const showOverview = computed(() => activeStep.value === null)
@@ -123,10 +137,54 @@ const modeLabel = computed(() =>
     : 'Schema Bootstrap',
 )
 
-const sessionMode = computed<'schema_bootstrap' | 'extraction_operations'>(() =>
-  statusProjection.value?.workspace_mode === 'extraction_operations'
-    ? 'extraction_operations'
-    : 'schema_bootstrap',
+const stepBadgeLabel = computed(() => {
+  if (activeStep.value === 'graph-management') {
+    return graphManagementModeLabel.value
+  }
+  return modeLabel.value
+})
+
+const sharedSessionMode = computed<'schema_bootstrap' | 'extraction_operations'>(() =>
+  resolveSharedSessionMode(
+    statusProjection.value?.workspace_mode ?? 'schema_bootstrap',
+  ),
+)
+
+const graphManagementModeLabel = computed(
+  () => GRAPH_MANAGEMENT_MODE_LABELS[graphManagementMode.value],
+)
+
+const graphManagementInputPlaceholder = computed(
+  () => GRAPH_MANAGEMENT_INPUT_PLACEHOLDERS[graphManagementMode.value],
+)
+
+const sessionStatusLabel = computed(() => {
+  if (sessionLoading.value) return 'Loading session'
+  if (clearingChat.value) return 'Resetting chat'
+  if (extractionSession.value?.id) {
+    return `Active · ${extractionSession.value.id.slice(0, 8)}`
+  }
+  return 'No active session'
+})
+
+const graphManagementRailItems = computed(() => {
+  if (!statusProjection.value) return []
+  return buildGraphManagementRailItems({
+    workspaceMode: statusProjection.value.workspace_mode,
+    transitionEligible: statusProjection.value.transition_eligible,
+    blockingReasonCount: statusProjection.value.readiness.blocking_reasons.length,
+    prepopulatedGapCount: statusProjection.value.readiness.prepopulated_types_without_instances.length,
+    sessionUpdatedAt: extractionSession.value?.updated_at ?? null,
+    hasActiveSession: Boolean(extractionSession.value?.id),
+  })
+})
+
+const visibleRailItems = computed(() =>
+  filterRailItemsForMode(graphManagementRailItems.value, graphManagementMode.value),
+)
+
+const selectedRailItem = computed(() =>
+  visibleRailItems.value.find((item) => item.id === selectedRailItemId.value) ?? null,
 )
 
 const canTransition = computed(() =>
@@ -295,11 +353,11 @@ async function loadMutationLogRuns() {
 }
 
 async function loadExtractionSession() {
-  if (!kgId.value) return
+  if (!kgId.value || activeStep.value !== 'graph-management') return
   sessionLoading.value = true
   try {
     extractionSession.value = await apiFetch<ExtractionSessionResponse>(
-      `/extraction/knowledge-graphs/${kgId.value}/sessions/${sessionMode.value}/active`,
+      `/extraction/knowledge-graphs/${kgId.value}/sessions/${sharedSessionMode.value}/active`,
     )
   } catch (err) {
     extractionSession.value = null
@@ -308,6 +366,41 @@ async function loadExtractionSession() {
     })
   } finally {
     sessionLoading.value = false
+  }
+}
+
+function syncGraphManagementState() {
+  if (activeStep.value !== 'graph-management') return
+  const fromQuery = parseGraphManagementModeQuery(route.query.gm_mode)
+  graphManagementMode.value = fromQuery
+    ?? resolveDefaultGraphManagementMode(
+      statusProjection.value?.workspace_mode ?? 'schema_bootstrap',
+    )
+  selectedRailItemId.value = resolveRailSelectionForMode(
+    selectedRailItemId.value,
+    graphManagementMode.value,
+    graphManagementRailItems.value,
+  )
+}
+
+function setGraphManagementMode(mode: GraphManagementMode) {
+  graphManagementMode.value = mode
+  selectedRailItemId.value = resolveRailSelectionForMode(
+    selectedRailItemId.value,
+    mode,
+    graphManagementRailItems.value,
+  )
+  navigateTo(buildGraphManagementStepUrl(kgId.value, mode), { replace: true })
+}
+
+function selectRailItem(itemId: GraphManagementRailItemId) {
+  selectedRailItemId.value = itemId
+}
+
+function onRailKeydown(event: KeyboardEvent, itemId: GraphManagementRailItemId) {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    selectRailItem(itemId)
   }
 }
 
@@ -354,7 +447,7 @@ async function clearChat() {
   clearingChat.value = true
   try {
     extractionSession.value = await apiFetch<ExtractionSessionResponse>(
-      `/extraction/knowledge-graphs/${kgId.value}/sessions/${sessionMode.value}/clear-chat`,
+      `/extraction/knowledge-graphs/${kgId.value}/sessions/${sharedSessionMode.value}/clear-chat`,
       { method: 'POST' },
     )
     toast.success('Extraction chat cleared')
@@ -388,8 +481,19 @@ watch(tenantVersion, () => {
 
 watch(
   () => statusProjection.value?.workspace_mode,
-  (mode) => {
-    if (mode) {
+  () => {
+    if (activeStep.value === 'graph-management') {
+      syncGraphManagementState()
+      loadExtractionSession()
+    }
+  },
+)
+
+watch(
+  () => [activeStep.value, route.query.gm_mode] as const,
+  () => {
+    if (activeStep.value === 'graph-management') {
+      syncGraphManagementState()
       loadExtractionSession()
     }
   },
@@ -402,14 +506,17 @@ watch(
       <div class="space-y-1">
         <div class="flex items-center gap-2">
           <h1 class="text-2xl font-semibold tracking-tight">{{ graphHeaderTitle }}</h1>
-          <Badge v-if="!showOverview" variant="secondary">{{ modeLabel }}</Badge>
+          <Badge v-if="!showOverview" variant="secondary">{{ stepBadgeLabel }}</Badge>
         </div>
         <p class="text-sm text-muted-foreground">
           <template v-if="showOverview">
             Project workspace for knowledge graph {{ kgId }}.
           </template>
+          <template v-else-if="activeStep === 'graph-management'">
+            Conversation-first graph management with shared session and mode-specific workspace panels.
+          </template>
           <template v-else>
-            Validate readiness and move from schema bootstrap to extraction operations.
+            Knowledge-graph scoped mutation run visibility and run metrics.
           </template>
         </p>
       </div>
@@ -592,169 +699,50 @@ watch(
         </Card>
       </section>
 
-      <section v-else class="space-y-6">
-      <Card>
-        <CardHeader>
-          <CardTitle class="text-base">Mode & Transition Controls</CardTitle>
-          <CardDescription>
-            Validate current readiness and transition when eligible.
-          </CardDescription>
-        </CardHeader>
-        <CardContent class="flex flex-wrap gap-2">
-          <Button variant="outline" :disabled="validating || transitioning" @click="validateWorkspace">
-            <Loader2 v-if="validating" class="mr-1.5 size-3.5 animate-spin" />
-            <CheckCircle2 v-else class="mr-1.5 size-3.5" />
-            Validate
-          </Button>
-          <Button
-            :disabled="!canTransition || transitioning || validating"
-            @click="transitionToExtraction"
-          >
-            <Loader2 v-if="transitioning" class="mr-1.5 size-3.5 animate-spin" />
-            <PlayCircle v-else class="mr-1.5 size-3.5" />
-            Go to Extraction/Mutations
-          </Button>
-          <Badge :variant="canTransition ? 'default' : 'secondary'">
-            {{ canTransition ? 'Transition eligible' : 'Transition blocked' }}
-          </Badge>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle class="text-base">Readiness Results</CardTitle>
-          <CardDescription>
-            Bootstrap readiness requirements from workspace validation.
-          </CardDescription>
-        </CardHeader>
-        <CardContent class="space-y-4 text-sm">
-          <div class="rounded border p-3">
-            <p class="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Bootstrap Progress Checklist
-            </p>
-            <div class="space-y-2">
-              <div
-                v-for="item in progressChecklist"
-                :key="item.id"
-                class="rounded border px-3 py-2"
+      <section v-else-if="activeStep === 'graph-management'" class="space-y-4">
+        <Card class="graph-management-controls">
+          <CardHeader class="pb-3">
+            <CardTitle class="text-base">Graph Management</CardTitle>
+            <CardDescription>
+              Shared chat session with mode-specific assistant framing and workspace panels.
+            </CardDescription>
+          </CardHeader>
+          <CardContent class="space-y-3">
+            <div class="flex flex-wrap gap-2">
+              <Button
+                v-for="mode in GRAPH_MANAGEMENT_MODE_ORDER"
+                :key="mode"
+                size="sm"
+                :variant="graphManagementMode === mode ? 'default' : 'outline'"
+                @click="setGraphManagementMode(mode)"
               >
-                <div class="flex items-center justify-between">
-                  <p class="font-medium">{{ item.label }}</p>
-                  <Badge :variant="item.passed ? 'default' : 'destructive'">
-                    {{ item.passed ? 'Pass' : 'Fail' }}
-                  </Badge>
-                </div>
-                <p class="mt-1 text-xs text-muted-foreground">
-                  {{ item.passed ? item.passDetail : item.failDetail }}
-                </p>
-              </div>
+                {{ GRAPH_MANAGEMENT_MODE_LABELS[mode] }}
+              </Button>
             </div>
-          </div>
-
-          <div class="flex items-center justify-between rounded border px-3 py-2">
-            <span>Has minimum entity types</span>
-            <Badge :variant="statusProjection.readiness.has_minimum_entity_types ? 'default' : 'destructive'">
-              {{ statusProjection.readiness.has_minimum_entity_types ? 'Yes' : 'No' }}
-            </Badge>
-          </div>
-          <div class="flex items-center justify-between rounded border px-3 py-2">
-            <span>Has minimum relationship types</span>
-            <Badge :variant="statusProjection.readiness.has_minimum_relationship_types ? 'default' : 'destructive'">
-              {{ statusProjection.readiness.has_minimum_relationship_types ? 'Yes' : 'No' }}
-            </Badge>
-          </div>
-          <div class="flex items-center justify-between rounded border px-3 py-2">
-            <span>Prepopulated types ready</span>
-            <Badge :variant="statusProjection.readiness.prepopulated_types_ready ? 'default' : 'destructive'">
-              {{ statusProjection.readiness.prepopulated_types_ready ? 'Yes' : 'No' }}
-            </Badge>
-          </div>
-
-          <div class="rounded border p-3">
-            <p class="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Validation Diagnostics
-            </p>
-            <div
-              v-if="statusProjection.readiness.prepopulated_types_without_instances.length > 0"
-              class="rounded border border-amber-400/60 bg-amber-50/60 p-2 text-xs dark:border-amber-800 dark:bg-amber-950/20"
-            >
-              <p class="font-medium text-amber-800 dark:text-amber-300">
-                Prepopulated types missing instances
-              </p>
-              <ul class="mt-1 list-disc space-y-1 pl-4 text-muted-foreground">
-                <li
-                  v-for="typeLabel in statusProjection.readiness.prepopulated_types_without_instances"
-                  :key="typeLabel"
-                >
-                  {{ typeLabel }}
-                </li>
-              </ul>
+            <div class="flex flex-wrap items-center gap-2">
+              <Badge variant="outline">{{ sessionStatusLabel }}</Badge>
+              <Button
+                variant="outline"
+                size="sm"
+                :disabled="validating || transitioning"
+                @click="validateWorkspace"
+              >
+                <Loader2 v-if="validating" class="mr-1.5 size-3.5 animate-spin" />
+                <CheckCircle2 v-else class="mr-1.5 size-3.5" />
+                Validate
+              </Button>
+              <Badge :variant="canTransition ? 'default' : 'secondary'">
+                {{ canTransition ? 'Transition eligible' : 'Transition blocked' }}
+              </Badge>
             </div>
+          </CardContent>
+        </Card>
 
-            <div v-if="statusProjection.readiness.blocking_reasons.length > 0" class="mt-2 rounded border border-destructive/50 p-3">
-              <p class="mb-1 text-xs font-medium text-destructive flex items-center gap-1.5">
-                <ShieldAlert class="size-3.5" />
-                Blocking reasons
-              </p>
-              <ul class="list-disc pl-4 text-xs text-muted-foreground space-y-1">
-                <li v-for="reason in statusProjection.readiness.blocking_reasons" :key="reason">
-                  {{ reason }}
-                </li>
-              </ul>
-            </div>
-            <p
-              v-else-if="statusProjection.readiness.prepopulated_types_without_instances.length === 0"
-              class="text-xs text-muted-foreground"
-            >
-              No validation diagnostics are currently blocking transition.
-            </p>
-          </div>
-
-          <div class="rounded border p-3">
-            <p class="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Next Steps
-            </p>
-            <ul class="list-disc pl-4 text-xs text-muted-foreground space-y-1">
-              <li v-for="step in nextSteps" :key="step">{{ step }}</li>
-            </ul>
-          </div>
-
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle class="text-base">Session Pointers</CardTitle>
-          <CardDescription>
-            Active and recent extraction session references for this knowledge graph.
-          </CardDescription>
-        </CardHeader>
-        <CardContent class="grid gap-2 md:grid-cols-3 text-xs">
-          <div class="rounded border px-3 py-2">
-            <p class="text-muted-foreground">Active schema bootstrap session</p>
-            <p class="font-mono break-all mt-1">
-              {{ statusProjection.session_pointers.active_schema_bootstrap_session_id ?? 'None' }}
-            </p>
-          </div>
-          <div class="rounded border px-3 py-2">
-            <p class="text-muted-foreground">Active extraction operations session</p>
-            <p class="font-mono break-all mt-1">
-              {{ statusProjection.session_pointers.active_extraction_operations_session_id ?? 'None' }}
-            </p>
-          </div>
-          <div class="rounded border px-3 py-2">
-            <p class="text-muted-foreground">Most recent completed session</p>
-            <p class="font-mono break-all mt-1">
-              {{ statusProjection.session_pointers.most_recent_completed_session_id ?? 'None' }}
-            </p>
-          </div>
-        </CardContent>
-      </Card>
-
-      <div class="space-y-4">
         <SharedConversationPanel
           v-model:draft-message="draftMessage"
-          :mode-label="modeLabel"
+          :mode-label="graphManagementModeLabel"
+          :input-placeholder="graphManagementInputPlaceholder"
+          :session-status-label="sessionStatusLabel"
           :session="extractionSession"
           :loading="sessionLoading"
           :clearing="clearingChat"
@@ -763,154 +751,206 @@ watch(
           @clear-chat="clearChat"
         />
 
-        <Card v-if="statusProjection.workspace_mode === 'extraction_operations'">
-          <CardHeader>
-            <CardTitle class="text-base">Operations Workspace</CardTitle>
-            <CardDescription>
-              Tabbed controls for extraction jobs, manual mutations, and run/log visibility.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Tabs v-model="extractionTab" class="w-full">
-              <TabsList class="grid w-full grid-cols-3">
-                <TabsTrigger value="extraction-jobs">Extraction Jobs</TabsTrigger>
-                <TabsTrigger value="manual-mutations">Manual Mutations</TabsTrigger>
-                <TabsTrigger value="run-logs">Run/Logs</TabsTrigger>
-              </TabsList>
-              <TabsContent value="extraction-jobs" class="mt-3 space-y-2 text-sm">
+        <div class="grid gap-4 xl:grid-cols-[280px_1fr]">
+          <div
+            class="graph-management-rail rounded border"
+            role="listbox"
+            aria-label="Graph management status and artifacts"
+          >
+            <div class="border-b px-3 py-2">
+              <p class="text-xs font-medium text-muted-foreground">Status &amp; artifacts</p>
+            </div>
+            <div class="space-y-1.5 p-2">
+              <button
+                v-for="item in visibleRailItems"
+                :key="item.id"
+                type="button"
+                role="option"
+                :aria-selected="selectedRailItemId === item.id"
+                tabindex="0"
+                class="w-full rounded border px-2 py-2 text-left text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                :class="[
+                  stepStatusTintClass(item.status),
+                  selectedRailItemId === item.id ? 'border-primary ring-1 ring-primary/30' : 'hover:bg-muted/40',
+                ]"
+                @click="selectRailItem(item.id)"
+                @keydown="onRailKeydown($event, item.id)"
+              >
+                <div class="flex items-center justify-between gap-2">
+                  <p class="font-medium">{{ item.label }}</p>
+                  <Badge variant="outline" class="text-[10px]">{{ item.status }}</Badge>
+                </div>
+                <p class="mt-1 text-muted-foreground">{{ item.detailHint }}</p>
+                <p class="mt-1 text-[10px] text-muted-foreground">Updated {{ item.lastUpdated }}</p>
+              </button>
+            </div>
+          </div>
+
+          <Card class="graph-management-detail">
+            <CardHeader class="pb-3">
+              <CardTitle class="text-base">
+                {{ selectedRailItem?.label ?? 'Workspace detail' }}
+              </CardTitle>
+              <CardDescription>
+                Mode:
+                <span class="font-medium text-foreground">{{ graphManagementModeLabel }}</span>
+              </CardDescription>
+            </CardHeader>
+            <CardContent class="space-y-4 text-sm">
+              <template v-if="selectedRailItemId === 'schema-readiness'">
+                <div class="rounded border p-3">
+                  <p class="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Bootstrap Progress Checklist
+                  </p>
+                  <div class="space-y-2">
+                    <div
+                      v-for="item in progressChecklist"
+                      :key="item.id"
+                      class="rounded border px-3 py-2"
+                    >
+                      <div class="flex items-center justify-between">
+                        <p class="font-medium">{{ item.label }}</p>
+                        <Badge :variant="item.passed ? 'default' : 'destructive'">
+                          {{ item.passed ? 'Pass' : 'Fail' }}
+                        </Badge>
+                      </div>
+                      <p class="mt-1 text-xs text-muted-foreground">
+                        {{ item.passed ? item.passDetail : item.failDetail }}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div class="flex flex-wrap gap-2">
+                  <Button variant="outline" :disabled="validating || transitioning" @click="validateWorkspace">
+                    <Loader2 v-if="validating" class="mr-1.5 size-3.5 animate-spin" />
+                    <CheckCircle2 v-else class="mr-1.5 size-3.5" />
+                    Validate
+                  </Button>
+                  <Button
+                    :disabled="!canTransition || transitioning || validating"
+                    @click="transitionToExtraction"
+                  >
+                    <Loader2 v-if="transitioning" class="mr-1.5 size-3.5 animate-spin" />
+                    <PlayCircle v-else class="mr-1.5 size-3.5" />
+                    Go to Extraction/Mutations
+                  </Button>
+                </div>
+              </template>
+
+              <template v-else-if="selectedRailItemId === 'validation-diagnostics'">
+                <div class="rounded border p-3">
+                  <p class="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Validation Diagnostics
+                  </p>
+                  <div
+                    v-if="statusProjection.readiness.prepopulated_types_without_instances.length > 0"
+                    class="rounded border border-amber-400/60 bg-amber-50/60 p-2 text-xs dark:border-amber-800 dark:bg-amber-950/20"
+                  >
+                    <p class="font-medium text-amber-800 dark:text-amber-300">
+                      Prepopulated types missing instances
+                    </p>
+                    <ul class="mt-1 list-disc space-y-1 pl-4 text-muted-foreground">
+                      <li
+                        v-for="typeLabel in statusProjection.readiness.prepopulated_types_without_instances"
+                        :key="typeLabel"
+                      >
+                        {{ typeLabel }}
+                      </li>
+                    </ul>
+                  </div>
+                  <div
+                    v-if="statusProjection.readiness.blocking_reasons.length > 0"
+                    class="mt-2 rounded border border-destructive/50 p-3"
+                  >
+                    <p class="mb-1 flex items-center gap-1.5 text-xs font-medium text-destructive">
+                      <ShieldAlert class="size-3.5" />
+                      Blocking reasons
+                    </p>
+                    <ul class="list-disc space-y-1 pl-4 text-xs text-muted-foreground">
+                      <li v-for="reason in statusProjection.readiness.blocking_reasons" :key="reason">
+                        {{ reason }}
+                      </li>
+                    </ul>
+                  </div>
+                  <p
+                    v-else-if="statusProjection.readiness.prepopulated_types_without_instances.length === 0"
+                    class="text-xs text-muted-foreground"
+                  >
+                    No validation diagnostics are currently blocking transition.
+                  </p>
+                </div>
+                <div class="rounded border p-3">
+                  <p class="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Next Steps
+                  </p>
+                  <ul class="list-disc space-y-1 pl-4 text-xs text-muted-foreground">
+                    <li v-for="step in nextSteps" :key="step">{{ step }}</li>
+                  </ul>
+                </div>
+              </template>
+
+              <template v-else-if="selectedRailItemId === 'session-pointers'">
+                <div class="grid gap-2 md:grid-cols-3 text-xs">
+                  <div class="rounded border px-3 py-2">
+                    <p class="text-muted-foreground">Active schema bootstrap session</p>
+                    <p class="mt-1 break-all font-mono">
+                      {{ statusProjection.session_pointers.active_schema_bootstrap_session_id ?? 'None' }}
+                    </p>
+                  </div>
+                  <div class="rounded border px-3 py-2">
+                    <p class="text-muted-foreground">Active extraction operations session</p>
+                    <p class="mt-1 break-all font-mono">
+                      {{ statusProjection.session_pointers.active_extraction_operations_session_id ?? 'None' }}
+                    </p>
+                  </div>
+                  <div class="rounded border px-3 py-2">
+                    <p class="text-muted-foreground">Most recent completed session</p>
+                    <p class="mt-1 break-all font-mono">
+                      {{ statusProjection.session_pointers.most_recent_completed_session_id ?? 'None' }}
+                    </p>
+                  </div>
+                </div>
+              </template>
+
+              <template v-else-if="graphManagementMode === 'extraction-jobs'">
                 <p class="text-muted-foreground">
                   Trigger extraction and maintenance controls from the data sources operations panel.
                 </p>
-                <Button size="sm" variant="outline" @click="navigateTo('/data-sources')">
-                  Open Data Source Operations
-                </Button>
-              </TabsContent>
-              <TabsContent value="manual-mutations" class="mt-3 space-y-2 text-sm">
+                <div class="flex flex-wrap gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    @click="navigateTo(buildDataSourcesStepUrl(kgId))"
+                  >
+                    Open Data Source Operations
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    @click="navigateTo(buildMaintainStepUrl(kgId))"
+                  >
+                    Open Maintain Step
+                  </Button>
+                </div>
+              </template>
+
+              <template v-else-if="graphManagementMode === 'one-off-mutations'">
                 <p class="text-muted-foreground">
                   Open the mutation editor scoped to this knowledge graph for minor direct edits.
                 </p>
                 <Button size="sm" @click="navigateTo(`/graph/mutations?kg_id=${kgId}&view=editor`)">
                   Open Manual Mutations
                 </Button>
-              </TabsContent>
-              <TabsContent value="run-logs" class="mt-3 space-y-2 text-sm">
-                <p class="text-muted-foreground">
-                  Review sync run history, maintenance outcomes, and operational logs.
-                </p>
-                <Button size="sm" variant="outline" @click="navigateTo('/data-sources')">
-                  Open Run and Log Views
-                </Button>
-                <Card class="mt-2">
-                  <CardHeader>
-                    <CardTitle class="text-sm">MutationLog Browser</CardTitle>
-                    <CardDescription>
-                      Knowledge-graph scoped mutation runs with per-entry operation previews and run metrics.
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent class="grid gap-3 xl:grid-cols-[280px_1fr]">
-                    <div class="rounded border">
-                      <div class="flex items-center justify-between border-b px-3 py-2">
-                        <p class="text-xs font-medium text-muted-foreground">Runs</p>
-                        <Button size="sm" variant="ghost" class="h-6 px-2 text-[10px]" @click="loadMutationLogRuns">
-                          Refresh
-                        </Button>
-                      </div>
-                      <div v-if="mutationLogLoading" class="flex items-center gap-2 px-3 py-4 text-xs text-muted-foreground">
-                        <Loader2 class="size-3.5 animate-spin" />
-                        Loading mutation runs...
-                      </div>
-                      <div v-else-if="mutationLogRuns.length === 0" class="px-3 py-4 text-xs text-muted-foreground">
-                        No mutation log runs found for this knowledge graph yet.
-                      </div>
-                      <div v-else class="max-h-64 overflow-auto p-2 space-y-1.5">
-                        <button
-                          v-for="run in mutationLogRuns"
-                          :key="run.id"
-                          class="w-full rounded border px-2 py-1.5 text-left text-xs transition-colors"
-                          :class="selectedMutationLogRunId === run.id ? 'border-primary bg-primary/5' : 'hover:bg-muted/40'"
-                          @click="selectedMutationLogRunId = run.id"
-                        >
-                          <p class="font-medium truncate">{{ run.data_source_name }}</p>
-                          <p class="text-muted-foreground truncate">{{ new Date(run.started_at).toLocaleString() }}</p>
-                          <div class="mt-1 flex items-center justify-between">
-                            <Badge variant="outline" class="text-[10px]">{{ run.status }}</Badge>
-                            <span class="font-mono text-[10px] text-muted-foreground">{{ run.mutation_log_id }}</span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
+              </template>
 
-                    <div v-if="selectedMutationLogRun" class="space-y-3 rounded border p-3">
-                      <div class="flex flex-wrap items-center gap-2">
-                        <Badge>{{ selectedMutationLogRun.status }}</Badge>
-                        <p class="text-xs text-muted-foreground">
-                          Data source:
-                          <span class="font-medium text-foreground">{{ selectedMutationLogRun.data_source_name }}</span>
-                        </p>
-                      </div>
-                      <div class="grid gap-2 sm:grid-cols-2">
-                        <div class="rounded border px-3 py-2 text-xs">
-                          <p class="text-muted-foreground">MutationLog</p>
-                          <p class="mt-1 font-mono break-all">{{ selectedMutationLogRun.mutation_log_id }}</p>
-                        </div>
-                        <div class="rounded border px-3 py-2 text-xs">
-                          <p class="text-muted-foreground">Session</p>
-                          <p class="mt-1 font-mono break-all">{{ selectedMutationLogRun.session_id ?? 'None' }}</p>
-                        </div>
-                        <div class="rounded border px-3 py-2 text-xs">
-                          <p class="text-muted-foreground">Started</p>
-                          <p class="mt-1">{{ new Date(selectedMutationLogRun.started_at).toLocaleString() }}</p>
-                        </div>
-                        <div class="rounded border px-3 py-2 text-xs">
-                          <p class="text-muted-foreground">Completed</p>
-                          <p class="mt-1">
-                            {{ selectedMutationLogRun.completed_at ? new Date(selectedMutationLogRun.completed_at).toLocaleString() : 'In progress' }}
-                          </p>
-                        </div>
-                      </div>
-                      <div class="grid gap-2 sm:grid-cols-2">
-                        <div class="rounded border px-3 py-2 text-xs">
-                          <p class="text-muted-foreground flex items-center gap-1.5">
-                            <Coins class="size-3.5" />
-                            Token usage
-                          </p>
-                          <p class="mt-1 font-medium">{{ (selectedMutationLogRun.token_usage_total ?? 0).toLocaleString() }}</p>
-                        </div>
-                        <div class="rounded border px-3 py-2 text-xs">
-                          <p class="text-muted-foreground flex items-center gap-1.5">
-                            <DollarSign class="size-3.5" />
-                            Cost (USD)
-                          </p>
-                          <p class="mt-1 font-medium">${{ (selectedMutationLogRun.cost_total_usd ?? 0).toFixed(2) }}</p>
-                        </div>
-                      </div>
-                      <div class="rounded border p-3">
-                        <p class="mb-2 text-xs font-medium text-muted-foreground">Per-entry operation previews</p>
-                        <div v-if="Object.keys(selectedMutationLogRun.operation_counts).length === 0" class="text-xs text-muted-foreground">
-                          No operation class counts recorded for this run.
-                        </div>
-                        <div v-else class="space-y-1.5">
-                          <div
-                            v-for="([opClass, count]) in Object.entries(selectedMutationLogRun.operation_counts)"
-                            :key="opClass"
-                            class="flex items-center justify-between rounded border px-2 py-1.5 text-xs"
-                          >
-                            <span class="font-mono">{{ opClass }}</span>
-                            <Badge variant="secondary">{{ count }}</Badge>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <div v-else class="rounded border border-dashed p-6 text-sm text-muted-foreground">
-                      Select a mutation run to view summary and per-entry previews.
-                    </div>
-                  </CardContent>
-                </Card>
-              </TabsContent>
-            </Tabs>
-          </CardContent>
-        </Card>
-      </div>
+              <template v-else>
+                <p class="text-xs text-muted-foreground">
+                  Select a status or artifact item to inspect mode-specific workspace content.
+                </p>
+              </template>
+            </CardContent>
+          </Card>
+        </div>
       </section>
     </template>
   </div>

--- a/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
+++ b/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
@@ -8,6 +8,17 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/com
 import { Separator } from '@/components/ui/separator'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import SharedConversationPanel from '@/components/extraction/SharedConversationPanel.vue'
+import {
+  buildDataSourcesStepUrl,
+  buildMaintainStepUrl,
+  buildManageStepUrl,
+  buildSuggestedNextStep,
+  buildWorkspaceStepCards,
+  parseManageStepQuery,
+  resolveStepDestination,
+  stepStatusTintClass,
+  type WorkspaceStepId,
+} from '@/utils/kgManageWorkspace'
 
 interface WorkspaceReadinessStatus {
   has_minimum_entity_types: boolean
@@ -31,9 +42,17 @@ interface WorkspaceStatusResponse {
   session_pointers: WorkspaceSessionPointers
 }
 
+interface KnowledgeGraphIdentity {
+  id: string
+  name: string
+  description?: string | null
+}
+
 interface DataSourceRef {
   id: string
   name: string
+  last_extraction_baseline_commit?: string | null
+  tracked_branch_head_commit?: string | null
 }
 
 interface MutationLogRunView {
@@ -64,6 +83,9 @@ const { hasTenant, tenantVersion } = useTenant()
 const { extractErrorMessage } = useErrorHandler()
 const { apiFetch } = useApiClient()
 const kgId = computed(() => String(route.params.kgId ?? ''))
+const kgIdentity = ref<KnowledgeGraphIdentity | null>(null)
+const dataSourceCount = ref(0)
+const maintenanceReadyCount = ref(0)
 const loading = ref(false)
 const validating = ref(false)
 const transitioning = ref(false)
@@ -76,6 +98,24 @@ const statusProjection = ref<WorkspaceStatusResponse | null>(null)
 const mutationLogLoading = ref(false)
 const mutationLogRuns = ref<MutationLogRunView[]>([])
 const selectedMutationLogRunId = ref<string | null>(null)
+
+const activeStep = computed(() => parseManageStepQuery(route.query.step))
+const showOverview = computed(() => activeStep.value === null)
+
+const workspaceOverviewInput = computed(() => ({
+  kgId: kgId.value,
+  dataSourceCount: dataSourceCount.value,
+  maintenanceReadyCount: maintenanceReadyCount.value,
+  mutationLogRunCount: mutationLogRuns.value.length,
+  workspaceStatus: statusProjection.value,
+}))
+
+const workspaceStepCards = computed(() => buildWorkspaceStepCards(workspaceOverviewInput.value))
+const suggestedNextStep = computed(() => buildSuggestedNextStep(workspaceOverviewInput.value))
+
+const graphHeaderTitle = computed(() =>
+  kgIdentity.value?.name ?? 'Knowledge Graph Manage Workspace',
+)
 
 const modeLabel = computed(() =>
   statusProjection.value?.workspace_mode === 'extraction_operations'
@@ -150,6 +190,45 @@ const sessionActivityLines = computed(() => {
   if (!Array.isArray(candidate)) return []
   return candidate.filter((line): line is string => typeof line === 'string' && line.trim().length > 0)
 })
+
+async function loadKgIdentity() {
+  if (!hasTenant.value || !kgId.value) return
+  try {
+    kgIdentity.value = await apiFetch<KnowledgeGraphIdentity>(
+      `/management/knowledge-graphs/${kgId.value}`,
+    )
+  } catch (err) {
+    kgIdentity.value = { id: kgId.value, name: kgId.value }
+    toast.error('Failed to load knowledge graph identity', {
+      description: extractErrorMessage(err),
+    })
+  }
+}
+
+async function loadOverviewMetrics() {
+  if (!hasTenant.value || !kgId.value) return
+  try {
+    const dataSources = await apiFetch<DataSourceRef[]>(
+      `/management/knowledge-graphs/${kgId.value}/data-sources`,
+    )
+    dataSourceCount.value = dataSources.length
+    maintenanceReadyCount.value = dataSources.filter((ds) => {
+      if (!ds.last_extraction_baseline_commit || !ds.tracked_branch_head_commit) return false
+      return ds.last_extraction_baseline_commit !== ds.tracked_branch_head_commit
+    }).length
+  } catch {
+    dataSourceCount.value = 0
+    maintenanceReadyCount.value = 0
+  }
+}
+
+function openWorkspaceStep(stepId: WorkspaceStepId) {
+  navigateTo(resolveStepDestination(kgId.value, stepId))
+}
+
+function returnToWorkspaceOverview() {
+  navigateTo(buildManageStepUrl(kgId.value))
+}
 
 async function loadWorkspaceStatus() {
   if (!hasTenant.value || !kgId.value) return
@@ -270,6 +349,7 @@ async function transitionToExtraction() {
 }
 
 async function clearChat() {
+  // Clear chat resets the active extraction session for this knowledge graph.
   if (!kgId.value) return
   clearingChat.value = true
   try {
@@ -288,14 +368,21 @@ async function clearChat() {
 }
 
 onMounted(() => {
+  loadKgIdentity()
   loadWorkspaceStatus()
+  loadOverviewMetrics()
   loadMutationLogRuns()
 })
 
 watch(tenantVersion, () => {
+  kgIdentity.value = null
   statusProjection.value = null
   extractionSession.value = null
+  dataSourceCount.value = 0
+  maintenanceReadyCount.value = 0
+  loadKgIdentity()
   loadWorkspaceStatus()
+  loadOverviewMetrics()
   loadMutationLogRuns()
 })
 
@@ -314,16 +401,25 @@ watch(
     <div class="flex items-center justify-between">
       <div class="space-y-1">
         <div class="flex items-center gap-2">
-          <h1 class="text-2xl font-semibold tracking-tight">Knowledge Graph Manage Workspace</h1>
-          <Badge variant="secondary">{{ modeLabel }}</Badge>
+          <h1 class="text-2xl font-semibold tracking-tight">{{ graphHeaderTitle }}</h1>
+          <Badge v-if="!showOverview" variant="secondary">{{ modeLabel }}</Badge>
         </div>
         <p class="text-sm text-muted-foreground">
-          Validate readiness and move from schema bootstrap to extraction operations.
+          <template v-if="showOverview">
+            Project workspace for knowledge graph {{ kgId }}.
+          </template>
+          <template v-else>
+            Validate readiness and move from schema bootstrap to extraction operations.
+          </template>
         </p>
       </div>
-      <Button variant="outline" size="sm" @click="navigateTo('/knowledge-graphs')">
+      <Button
+        variant="outline"
+        size="sm"
+        @click="showOverview ? navigateTo('/knowledge-graphs') : returnToWorkspaceOverview()"
+      >
         <ArrowLeft class="mr-1.5 size-3.5" />
-        Back to Knowledge Graphs
+        {{ showOverview ? 'Back to Knowledge Graphs' : 'Back to workspace overview' }}
       </Button>
     </div>
 
@@ -339,6 +435,164 @@ watch(
     </div>
 
     <template v-else-if="statusProjection">
+      <section v-if="showOverview" class="space-y-6">
+        <div>
+          <h2 class="text-lg font-semibold tracking-tight">Project workspace</h2>
+          <p class="text-sm text-muted-foreground">
+            Choose a step to continue work on this knowledge graph without re-selecting context.
+          </p>
+        </div>
+
+        <Card class="border-primary/30 bg-primary/5">
+          <CardHeader class="pb-3">
+            <CardTitle class="text-base">Suggested next step</CardTitle>
+            <CardDescription>{{ suggestedNextStep.description }}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button @click="openWorkspaceStep(suggestedNextStep.stepId)">
+              {{ suggestedNextStep.actionLabel }} {{ suggestedNextStep.title }}
+            </Button>
+          </CardContent>
+        </Card>
+
+        <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <!-- Step cards: Data Sources, Graph Management, MutationLogs, Maintain -->
+          <Card
+            v-for="card in workspaceStepCards"
+            :key="card.id"
+            class="flex flex-col"
+            :class="stepStatusTintClass(card.status)"
+          >
+            <CardHeader class="pb-3">
+              <div class="flex items-center justify-between gap-2">
+                <CardTitle class="text-base">{{ card.title }}</CardTitle>
+                <Badge variant="outline">{{ card.status }}</Badge>
+              </div>
+              <CardDescription>{{ card.statusDetail }}</CardDescription>
+            </CardHeader>
+            <CardContent class="mt-auto">
+              <Button
+                class="w-full"
+                variant="outline"
+                @click="openWorkspaceStep(card.id)"
+              >
+                {{ card.actionLabel }}
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      <section v-else-if="activeStep === 'mutation-logs'" class="space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle class="text-base">MutationLogs</CardTitle>
+            <CardDescription>
+              Knowledge-graph scoped mutation runs with per-entry operation previews and run metrics.
+            </CardDescription>
+          </CardHeader>
+          <CardContent class="grid gap-3 xl:grid-cols-[280px_1fr]">
+            <div class="rounded border">
+              <div class="flex items-center justify-between border-b px-3 py-2">
+                <p class="text-xs font-medium text-muted-foreground">Runs</p>
+                <Button size="sm" variant="ghost" class="h-6 px-2 text-[10px]" @click="loadMutationLogRuns">
+                  Refresh
+                </Button>
+              </div>
+              <div v-if="mutationLogLoading" class="flex items-center gap-2 px-3 py-4 text-xs text-muted-foreground">
+                <Loader2 class="size-3.5 animate-spin" />
+                Loading mutation runs...
+              </div>
+              <div v-else-if="mutationLogRuns.length === 0" class="px-3 py-4 text-xs text-muted-foreground">
+                No mutation log runs found for this knowledge graph yet.
+              </div>
+              <div v-else class="max-h-64 overflow-auto p-2 space-y-1.5">
+                <button
+                  v-for="run in mutationLogRuns"
+                  :key="run.id"
+                  class="w-full rounded border px-2 py-1.5 text-left text-xs transition-colors"
+                  :class="selectedMutationLogRunId === run.id ? 'border-primary bg-primary/5' : 'hover:bg-muted/40'"
+                  @click="selectedMutationLogRunId = run.id"
+                >
+                  <p class="font-medium truncate">{{ run.data_source_name }}</p>
+                  <p class="text-muted-foreground truncate">{{ new Date(run.started_at).toLocaleString() }}</p>
+                  <div class="mt-1 flex items-center justify-between">
+                    <Badge variant="outline" class="text-[10px]">{{ run.status }}</Badge>
+                    <span class="font-mono text-[10px] text-muted-foreground">{{ run.mutation_log_id }}</span>
+                  </div>
+                </button>
+              </div>
+            </div>
+
+            <div v-if="selectedMutationLogRun" class="space-y-3 rounded border p-3">
+              <div class="flex flex-wrap items-center gap-2">
+                <Badge>{{ selectedMutationLogRun.status }}</Badge>
+                <p class="text-xs text-muted-foreground">
+                  Data source:
+                  <span class="font-medium text-foreground">{{ selectedMutationLogRun.data_source_name }}</span>
+                </p>
+              </div>
+              <div class="grid gap-2 sm:grid-cols-2">
+                <div class="rounded border px-3 py-2 text-xs">
+                  <p class="text-muted-foreground">MutationLog</p>
+                  <p class="mt-1 font-mono break-all">{{ selectedMutationLogRun.mutation_log_id }}</p>
+                </div>
+                <div class="rounded border px-3 py-2 text-xs">
+                  <p class="text-muted-foreground">Session</p>
+                  <p class="mt-1 font-mono break-all">{{ selectedMutationLogRun.session_id ?? 'None' }}</p>
+                </div>
+                <div class="rounded border px-3 py-2 text-xs">
+                  <p class="text-muted-foreground">Started</p>
+                  <p class="mt-1">{{ new Date(selectedMutationLogRun.started_at).toLocaleString() }}</p>
+                </div>
+                <div class="rounded border px-3 py-2 text-xs">
+                  <p class="text-muted-foreground">Completed</p>
+                  <p class="mt-1">
+                    {{ selectedMutationLogRun.completed_at ? new Date(selectedMutationLogRun.completed_at).toLocaleString() : 'In progress' }}
+                  </p>
+                </div>
+              </div>
+              <div class="grid gap-2 sm:grid-cols-2">
+                <div class="rounded border px-3 py-2 text-xs">
+                  <p class="text-muted-foreground flex items-center gap-1.5">
+                    <Coins class="size-3.5" />
+                    Token usage
+                  </p>
+                  <p class="mt-1 font-medium">{{ (selectedMutationLogRun.token_usage_total ?? 0).toLocaleString() }}</p>
+                </div>
+                <div class="rounded border px-3 py-2 text-xs">
+                  <p class="text-muted-foreground flex items-center gap-1.5">
+                    <DollarSign class="size-3.5" />
+                    Cost (USD)
+                  </p>
+                  <p class="mt-1 font-medium">${{ (selectedMutationLogRun.cost_total_usd ?? 0).toFixed(2) }}</p>
+                </div>
+              </div>
+              <div class="rounded border p-3">
+                <p class="mb-2 text-xs font-medium text-muted-foreground">Per-entry operation previews</p>
+                <div v-if="Object.keys(selectedMutationLogRun.operation_counts).length === 0" class="text-xs text-muted-foreground">
+                  No operation class counts recorded for this run.
+                </div>
+                <div v-else class="space-y-1.5">
+                  <div
+                    v-for="([opClass, count]) in Object.entries(selectedMutationLogRun.operation_counts)"
+                    :key="opClass"
+                    class="flex items-center justify-between rounded border px-2 py-1.5 text-xs"
+                  >
+                    <span class="font-mono">{{ opClass }}</span>
+                    <Badge variant="secondary">{{ count }}</Badge>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div v-else class="rounded border border-dashed p-6 text-sm text-muted-foreground">
+              Select a mutation run to view summary and per-entry previews.
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section v-else class="space-y-6">
       <Card>
         <CardHeader>
           <CardTitle class="text-base">Mode & Transition Controls</CardTitle>
@@ -657,6 +911,7 @@ watch(
           </CardContent>
         </Card>
       </div>
+      </section>
     </template>
   </div>
 </template>

--- a/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
+++ b/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
@@ -1,15 +1,46 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
+import {
+  WORKSPACE_STEP_ORDER,
+  WORKSPACE_STEP_TITLES,
+  buildDataSourcesStepUrl,
+  buildMaintainStepUrl,
+  buildManageStepUrl,
+  buildSuggestedNextStep,
+  buildWorkspaceStepCards,
+  isMaintenanceReady,
+  resolveStepDestination,
+  stepStatusTintClass,
+} from '../utils/kgManageWorkspace'
 
 const manageWorkspaceVue = readFileSync(
   resolve(__dirname, '../pages/knowledge-graphs/[kgId]/manage.vue'),
+  'utf-8',
+)
+const kgIndexVue = readFileSync(
+  resolve(__dirname, '../pages/knowledge-graphs/index.vue'),
+  'utf-8',
+)
+const dataSourcesVue = readFileSync(
+  resolve(__dirname, '../pages/data-sources/index.vue'),
   'utf-8',
 )
 const sharedConversationPanelVue = readFileSync(
   resolve(__dirname, '../components/extraction/SharedConversationPanel.vue'),
   'utf-8',
 )
+
+const baseWorkspaceStatus = {
+  workspace_mode: 'schema_bootstrap' as const,
+  transition_eligible: false,
+  readiness: {
+    has_minimum_entity_types: false,
+    has_minimum_relationship_types: false,
+    prepopulated_types_ready: false,
+    blocking_reasons: ['Missing entity types'],
+  },
+}
 
 describe('Knowledge Graph Manage Workspace - mode-aware controls', () => {
   it('loads workspace status projection from management API', () => {
@@ -106,6 +137,167 @@ describe('Knowledge Graph Manage Workspace - bootstrap readiness guidance', () =
     expect(manageWorkspaceVue).toContain('Next Steps')
     expect(manageWorkspaceVue).toContain('Run Validate to refresh readiness signals')
     expect(manageWorkspaceVue).toContain('Transition is enabled')
+  })
+})
+
+describe('KG-MANAGE-001 - manage entry navigation', () => {
+  it('routes Manage action to graph-scoped manage workspace', () => {
+    expect(kgIndexVue).toContain('navigateTo(`/knowledge-graphs/${kg.id}/manage`)')
+  })
+
+  it('loads graph identity for manage header and back action', () => {
+    expect(manageWorkspaceVue).toContain('/management/knowledge-graphs/${kgId.value}')
+    expect(manageWorkspaceVue).toContain('loadKgIdentity')
+    expect(manageWorkspaceVue).toContain('Back to Knowledge Graphs')
+  })
+})
+
+describe('KG-MANAGE-002 - workspace step card set', () => {
+  it('renders Project workspace section with exactly four step cards', () => {
+    expect(manageWorkspaceVue).toContain('Project workspace')
+    expect(manageWorkspaceVue).toContain('workspaceStepCards')
+    for (const stepId of WORKSPACE_STEP_ORDER) {
+      expect(manageWorkspaceVue).toContain(WORKSPACE_STEP_TITLES[stepId])
+    }
+  })
+
+  it('buildWorkspaceStepCards returns the canonical four-card set', () => {
+    const cards = buildWorkspaceStepCards({
+      kgId: 'kg-1',
+      dataSourceCount: 1,
+      maintenanceReadyCount: 0,
+      mutationLogRunCount: 0,
+      workspaceStatus: baseWorkspaceStatus,
+    })
+
+    expect(cards.map((card) => card.title)).toEqual([
+      'Data Sources',
+      'Graph Management',
+      'MutationLogs',
+      'Maintain',
+    ])
+  })
+})
+
+describe('KG-MANAGE-003 - suggested next step callout', () => {
+  it('renders Suggested next step callout above the card grid', () => {
+    expect(manageWorkspaceVue).toContain('Suggested next step')
+    expect(manageWorkspaceVue).toContain('suggestedNextStep')
+    expect(manageWorkspaceVue).toContain('openWorkspaceStep')
+  })
+
+  it('prioritizes data sources when no sources are connected', () => {
+    const next = buildSuggestedNextStep({
+      kgId: 'kg-1',
+      dataSourceCount: 0,
+      maintenanceReadyCount: 0,
+      mutationLogRunCount: 0,
+      workspaceStatus: baseWorkspaceStatus,
+    })
+
+    expect(next.stepId).toBe('data-sources')
+    expect(next.actionLabel).toBe('Open')
+  })
+
+  it('uses Run action when maintenance is ready', () => {
+    const next = buildSuggestedNextStep({
+      kgId: 'kg-1',
+      dataSourceCount: 2,
+      maintenanceReadyCount: 1,
+      mutationLogRunCount: 3,
+      workspaceStatus: {
+        workspace_mode: 'extraction_operations',
+        transition_eligible: true,
+        readiness: {
+          has_minimum_entity_types: true,
+          has_minimum_relationship_types: true,
+          prepopulated_types_ready: true,
+          blocking_reasons: [],
+        },
+      },
+    })
+
+    expect(next.stepId).toBe('maintain')
+    expect(next.actionLabel).toBe('Run')
+  })
+})
+
+describe('KG-MANAGE-004 - step card status semantics', () => {
+  it('renders status label, tint, detail text, and primary action per card', () => {
+    expect(manageWorkspaceVue).toContain('stepStatusTintClass')
+    expect(manageWorkspaceVue).toContain('card.status')
+    expect(manageWorkspaceVue).toContain('card.statusDetail')
+    expect(manageWorkspaceVue).toContain('card.actionLabel')
+  })
+
+  it('maps each status label to a tint class', () => {
+    expect(stepStatusTintClass('ready')).toContain('emerald')
+    expect(stepStatusTintClass('in_progress')).toContain('blue')
+    expect(stepStatusTintClass('needs_attention')).toContain('amber')
+    expect(stepStatusTintClass('blocked')).toContain('destructive')
+  })
+
+  it('uses Open, Revisit, or Run action labels on cards', () => {
+    const cards = buildWorkspaceStepCards({
+      kgId: 'kg-1',
+      dataSourceCount: 2,
+      maintenanceReadyCount: 1,
+      mutationLogRunCount: 4,
+      workspaceStatus: {
+        workspace_mode: 'extraction_operations',
+        transition_eligible: true,
+        readiness: {
+          has_minimum_entity_types: true,
+          has_minimum_relationship_types: true,
+          prepopulated_types_ready: true,
+          blocking_reasons: [],
+        },
+      },
+    })
+
+    expect(cards.every((card) => ['Open', 'Revisit', 'Run'].includes(card.actionLabel))).toBe(true)
+    expect(cards.find((card) => card.id === 'maintain')?.actionLabel).toBe('Run')
+  })
+})
+
+describe('KG-MANAGE-005 - graph-scoped data sources step', () => {
+  it('routes Data Sources step with kg_id and manage return context', () => {
+    expect(manageWorkspaceVue).toContain('buildDataSourcesStepUrl')
+    expect(buildDataSourcesStepUrl('kg-abc')).toBe('/data-sources?kg_id=kg-abc&from=manage')
+  })
+
+  it('data-sources page preserves manage return path without auto-opening wizard', () => {
+    expect(dataSourcesVue).toContain('from=manage')
+    expect(dataSourcesVue).toContain('scopedKnowledgeGraphId')
+    expect(dataSourcesVue).toContain('Back to workspace overview')
+  })
+})
+
+describe('KG-MANAGE-015 - graph-scoped maintain step and round trip', () => {
+  it('routes Maintain step with graph scope and maintenance focus', () => {
+    expect(manageWorkspaceVue).toContain('buildMaintainStepUrl')
+    expect(buildMaintainStepUrl('kg-abc')).toBe(
+      '/data-sources?kg_id=kg-abc&from=manage&focus=maintain',
+    )
+  })
+
+  it('returns to manage overview from in-page steps', () => {
+    expect(manageWorkspaceVue).toContain('returnToWorkspaceOverview')
+    expect(buildManageStepUrl('kg-abc')).toBe('/knowledge-graphs/kg-abc/manage')
+    expect(resolveStepDestination('kg-abc', 'graph-management')).toBe(
+      '/knowledge-graphs/kg-abc/manage?step=graph-management',
+    )
+  })
+
+  it('detects maintenance readiness from commit diff semantics', () => {
+    expect(isMaintenanceReady({
+      last_extraction_baseline_commit: 'abc',
+      tracked_branch_head_commit: 'def',
+    })).toBe(true)
+    expect(isMaintenanceReady({
+      last_extraction_baseline_commit: 'abc',
+      tracked_branch_head_commit: 'abc',
+    })).toBe(false)
   })
 })
 

--- a/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
+++ b/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
@@ -13,6 +13,18 @@ import {
   resolveStepDestination,
   stepStatusTintClass,
 } from '../utils/kgManageWorkspace'
+import {
+  GRAPH_MANAGEMENT_MODE_LABELS,
+  GRAPH_MANAGEMENT_MODE_ORDER,
+  buildGraphManagementRailItems,
+  buildGraphManagementStepUrl,
+  filterRailItemsForMode,
+  isRailItemValidInMode,
+  parseGraphManagementModeQuery,
+  resolveDefaultGraphManagementMode,
+  resolveRailSelectionForMode,
+  resolveSharedSessionMode,
+} from '../utils/kgGraphManagement'
 
 const manageWorkspaceVue = readFileSync(
   resolve(__dirname, '../pages/knowledge-graphs/[kgId]/manage.vue'),
@@ -42,7 +54,7 @@ const baseWorkspaceStatus = {
   },
 }
 
-describe('Knowledge Graph Manage Workspace - mode-aware controls', () => {
+describe('Knowledge Graph Manage Workspace - graph management controls', () => {
   it('loads workspace status projection from management API', () => {
     expect(manageWorkspaceVue).toContain('/workspace-status')
     expect(manageWorkspaceVue).toContain('loadWorkspaceStatus')
@@ -59,42 +71,11 @@ describe('Knowledge Graph Manage Workspace - mode-aware controls', () => {
     expect(manageWorkspaceVue).toContain('/workspace/transition-to-extraction')
     expect(manageWorkspaceVue).toContain('Go to Extraction/Mutations')
   })
-
-  it('renders readiness result blocks and blocking reasons list', () => {
-    expect(manageWorkspaceVue).toContain('Readiness Results')
-    expect(manageWorkspaceVue).toContain('blocking_reasons')
-    expect(manageWorkspaceVue).toContain('prepopulated_types_ready')
-  })
-
-  it('renders session pointer references for bootstrap and extraction modes', () => {
-    expect(manageWorkspaceVue).toContain('Session Pointers')
-    expect(manageWorkspaceVue).toContain('active_schema_bootstrap_session_id')
-    expect(manageWorkspaceVue).toContain('active_extraction_operations_session_id')
-  })
-
-  it('uses shared conversation panel for bootstrap and extraction sessions', () => {
-    expect(manageWorkspaceVue).toContain('SharedConversationPanel')
-    expect(manageWorkspaceVue).toContain('sessionMode')
-    expect(manageWorkspaceVue).toContain('/sessions/${sessionMode.value}/active')
-  })
-
-  it('supports explicit Clear chat reset for extraction session', () => {
-    expect(manageWorkspaceVue).toContain('clearChat')
-    expect(manageWorkspaceVue).toContain('/sessions/${sessionMode.value}/clear-chat')
-    expect(manageWorkspaceVue).toContain('Clear chat')
-  })
-
-  it('provides tabbed lower operations area for extraction workflows', () => {
-    expect(manageWorkspaceVue).toContain('Operations Workspace')
-    expect(manageWorkspaceVue).toContain('TabsTrigger value="extraction-jobs"')
-    expect(manageWorkspaceVue).toContain('TabsTrigger value="manual-mutations"')
-    expect(manageWorkspaceVue).toContain('TabsTrigger value="run-logs"')
-  })
 })
 
 describe('Knowledge Graph Manage Workspace - mutation log browser', () => {
-  it('renders mutation log browser card and scoped run listing', () => {
-    expect(manageWorkspaceVue).toContain('MutationLog Browser')
+  it('renders mutation log step with scoped run listing', () => {
+    expect(manageWorkspaceVue).toContain('MutationLogs')
     expect(manageWorkspaceVue).toContain('loadMutationLogRuns')
     expect(manageWorkspaceVue).toContain('/management/knowledge-graphs/${kgId.value}/data-sources')
   })
@@ -317,5 +298,172 @@ describe('Shared conversation panel - extraction UX contract', () => {
     expect(sharedConversationPanelVue).toContain('activityTimeline')
     expect(sharedConversationPanelVue).toContain('timelineRef')
     expect(sharedConversationPanelVue).toContain('scrollTop = timelineRef.value.scrollHeight')
+  })
+
+  it('accepts mode-aware input placeholder and session status props', () => {
+    expect(sharedConversationPanelVue).toContain('inputPlaceholder')
+    expect(sharedConversationPanelVue).toContain('sessionStatusLabel')
+  })
+})
+
+describe('KG-MANAGE-006 - graph management conversation-first layout', () => {
+  it('renders graph management step with shared conversation panel', () => {
+    expect(manageWorkspaceVue).toContain("activeStep === 'graph-management'")
+    expect(manageWorkspaceVue).toContain('SharedConversationPanel')
+    expect(manageWorkspaceVue).toContain('graph-management-controls')
+  })
+
+  it('uses one shared session endpoint across UI mode changes', () => {
+    expect(manageWorkspaceVue).toContain('sharedSessionMode')
+    expect(manageWorkspaceVue).toContain('/sessions/${sharedSessionMode.value}/active')
+    expect(manageWorkspaceVue).not.toContain('watch(graphManagementMode')
+  })
+})
+
+describe('KG-MANAGE-007 - graph management modes', () => {
+  it('supports the three canonical graph management modes', () => {
+    for (const mode of GRAPH_MANAGEMENT_MODE_ORDER) {
+      expect(GRAPH_MANAGEMENT_MODE_LABELS[mode]).toBeTruthy()
+      expect(manageWorkspaceVue).toContain(mode)
+    }
+    expect(manageWorkspaceVue).toContain('graphManagementMode')
+    expect(manageWorkspaceVue).toContain('parseGraphManagementModeQuery')
+  })
+
+  it('defaults mode from workspace lifecycle state', () => {
+    expect(resolveDefaultGraphManagementMode('schema_bootstrap')).toBe('initial-schema-design')
+    expect(resolveDefaultGraphManagementMode('extraction_operations')).toBe('extraction-jobs')
+  })
+
+  it('updates chat placeholder by mode without changing session scope', () => {
+    expect(manageWorkspaceVue).toContain('graphManagementInputPlaceholder')
+    expect(manageWorkspaceVue).toContain('GRAPH_MANAGEMENT_INPUT_PLACEHOLDERS')
+  })
+})
+
+describe('KG-MANAGE-008 - hybrid lower panel shared rail', () => {
+  it('renders persistent status and artifact rail with keyboard selection', () => {
+    expect(manageWorkspaceVue).toContain('graph-management-rail')
+    expect(manageWorkspaceVue).toContain('buildGraphManagementRailItems')
+    expect(manageWorkspaceVue).toContain('role="listbox"')
+    expect(manageWorkspaceVue).toContain('@keydown')
+  })
+
+  it('builds rail items with status and last-updated metadata', () => {
+    const items = buildGraphManagementRailItems({
+      workspaceMode: 'schema_bootstrap',
+      transitionEligible: false,
+      blockingReasonCount: 1,
+      prepopulatedGapCount: 0,
+      sessionUpdatedAt: '2026-05-22T12:00:00Z',
+      hasActiveSession: true,
+    })
+
+    expect(items.every((item) => item.status && item.lastUpdated && item.label)).toBe(true)
+    expect(items.find((item) => item.id === 'session-pointers')?.modes).toEqual(
+      GRAPH_MANAGEMENT_MODE_ORDER,
+    )
+  })
+})
+
+describe('KG-MANAGE-009 - hybrid lower panel mode-specific detail', () => {
+  it('renders mode-specific detail panel content regions', () => {
+    expect(manageWorkspaceVue).toContain('graph-management-detail')
+    expect(manageWorkspaceVue).toContain('selectedRailItemId')
+    expect(manageWorkspaceVue).toContain("selectedRailItemId === 'schema-readiness'")
+    expect(manageWorkspaceVue).toContain("graphManagementMode === 'extraction-jobs'")
+    expect(manageWorkspaceVue).toContain("graphManagementMode === 'one-off-mutations'")
+  })
+
+  it('filters rail items to the active mode', () => {
+    const items = buildGraphManagementRailItems({
+      workspaceMode: 'extraction_operations',
+      transitionEligible: true,
+      blockingReasonCount: 0,
+      prepopulatedGapCount: 0,
+      sessionUpdatedAt: null,
+      hasActiveSession: true,
+    })
+
+    expect(filterRailItemsForMode(items, 'extraction-jobs').map((item) => item.id)).toContain(
+      'extraction-jobs-setup',
+    )
+    expect(filterRailItemsForMode(items, 'one-off-mutations').map((item) => item.id)).toContain(
+      'mutation-authoring',
+    )
+  })
+})
+
+describe('KG-MANAGE-010 - schema design parity behavior', () => {
+  it('exposes schema readiness and validation detail in initial schema design mode', () => {
+    expect(manageWorkspaceVue).toContain('progressChecklist')
+    expect(manageWorkspaceVue).toContain('Bootstrap Progress Checklist')
+    expect(manageWorkspaceVue).toContain('blocking_reasons')
+    expect(manageWorkspaceVue).toContain('prepopulated_types_without_instances')
+  })
+
+  it('keeps validate and transition controls available for schema design work', () => {
+    expect(manageWorkspaceVue).toContain('validateWorkspace')
+    expect(manageWorkspaceVue).toContain('transitionToExtraction')
+    expect(manageWorkspaceVue).toContain('canTransition')
+  })
+})
+
+describe('KG-MANAGE-011 - session reset behavior', () => {
+  it('supports explicit clear chat reset on the shared session', () => {
+    expect(manageWorkspaceVue).toContain('clearChat')
+    expect(manageWorkspaceVue).toContain('/sessions/${sharedSessionMode.value}/clear-chat')
+    expect(sharedConversationPanelVue).toContain('Clear chat')
+  })
+
+  it('keeps graph management mode unchanged after clear chat', () => {
+    const clearChatBlock = manageWorkspaceVue.match(
+      /async function clearChat\(\) \{[\s\S]*?\n\}/,
+    )?.[0] ?? ''
+    expect(clearChatBlock).toContain('clearChat')
+    expect(clearChatBlock).not.toContain('graphManagementMode')
+  })
+})
+
+describe('KG-MANAGE-016 - graph management top controls', () => {
+  it('renders mode switcher, session status, and validation affordance without scrolling', () => {
+    expect(manageWorkspaceVue).toContain('graph-management-controls')
+    expect(manageWorkspaceVue).toContain('graphManagementModeLabel')
+    expect(manageWorkspaceVue).toContain('sessionStatusLabel')
+    expect(manageWorkspaceVue).toContain('validateWorkspace')
+    expect(manageWorkspaceVue).toContain('Clear chat')
+  })
+
+  it('maps shared session mode from workspace lifecycle without UI mode coupling', () => {
+    expect(resolveSharedSessionMode('schema_bootstrap')).toBe('schema_bootstrap')
+    expect(resolveSharedSessionMode('extraction_operations')).toBe('extraction_operations')
+  })
+
+  it('preserves rail selection across mode changes when still valid', () => {
+    const items = buildGraphManagementRailItems({
+      workspaceMode: 'extraction_operations',
+      transitionEligible: true,
+      blockingReasonCount: 0,
+      prepopulatedGapCount: 0,
+      sessionUpdatedAt: '2026-05-22T12:00:00Z',
+      hasActiveSession: true,
+    })
+
+    expect(
+      resolveRailSelectionForMode('session-pointers', 'extraction-jobs', items),
+    ).toBe('session-pointers')
+    expect(
+      isRailItemValidInMode('schema-readiness', 'extraction-jobs', items),
+    ).toBe(false)
+    expect(
+      resolveRailSelectionForMode('schema-readiness', 'extraction-jobs', items),
+    ).toBe('session-pointers')
+  })
+
+  it('builds graph management URLs with mode query for keyboard navigation', () => {
+    expect(buildGraphManagementStepUrl('kg-abc', 'one-off-mutations')).toBe(
+      '/knowledge-graphs/kg-abc/manage?step=graph-management&gm_mode=one-off-mutations',
+    )
+    expect(parseGraphManagementModeQuery('initial-schema-design')).toBe('initial-schema-design')
   })
 })

--- a/src/dev-ui/app/utils/kgGraphManagement.ts
+++ b/src/dev-ui/app/utils/kgGraphManagement.ts
@@ -1,0 +1,167 @@
+import type { StepStatusLabel } from './kgManageWorkspace'
+
+export type GraphManagementMode =
+  | 'initial-schema-design'
+  | 'extraction-jobs'
+  | 'one-off-mutations'
+
+export type GraphManagementRailItemId =
+  | 'schema-readiness'
+  | 'validation-diagnostics'
+  | 'session-pointers'
+  | 'extraction-jobs-setup'
+  | 'mutation-authoring'
+
+export const GRAPH_MANAGEMENT_MODE_ORDER: GraphManagementMode[] = [
+  'initial-schema-design',
+  'extraction-jobs',
+  'one-off-mutations',
+]
+
+export const GRAPH_MANAGEMENT_MODE_LABELS: Record<GraphManagementMode, string> = {
+  'initial-schema-design': 'Initial Schema Design',
+  'extraction-jobs': 'Extraction Jobs',
+  'one-off-mutations': 'One-off Mutations',
+}
+
+export const GRAPH_MANAGEMENT_INPUT_PLACEHOLDERS: Record<GraphManagementMode, string> = {
+  'initial-schema-design':
+    'Describe schema goals, entity types, or relationship constraints for this knowledge graph…',
+  'extraction-jobs':
+    'Ask about extraction job setup, sync runs, or maintenance execution for this graph…',
+  'one-off-mutations':
+    'Author or preview one-off graph mutations scoped to this knowledge graph…',
+}
+
+export interface GraphManagementRailItem {
+  id: GraphManagementRailItemId
+  label: string
+  status: StepStatusLabel
+  lastUpdated: string
+  detailHint: string
+  modes: GraphManagementMode[]
+}
+
+export interface GraphManagementRailInputs {
+  workspaceMode: 'schema_bootstrap' | 'extraction_operations'
+  transitionEligible: boolean
+  blockingReasonCount: number
+  prepopulatedGapCount: number
+  sessionUpdatedAt: string | null
+  hasActiveSession: boolean
+}
+
+export function parseGraphManagementModeQuery(mode: unknown): GraphManagementMode | null {
+  if (
+    mode === 'initial-schema-design'
+    || mode === 'extraction-jobs'
+    || mode === 'one-off-mutations'
+  ) {
+    return mode
+  }
+  return null
+}
+
+export function resolveDefaultGraphManagementMode(
+  workspaceMode: 'schema_bootstrap' | 'extraction_operations',
+): GraphManagementMode {
+  return workspaceMode === 'extraction_operations' ? 'extraction-jobs' : 'initial-schema-design'
+}
+
+export function resolveSharedSessionMode(
+  workspaceMode: 'schema_bootstrap' | 'extraction_operations',
+): 'schema_bootstrap' | 'extraction_operations' {
+  return workspaceMode === 'extraction_operations' ? 'extraction_operations' : 'schema_bootstrap'
+}
+
+export function buildGraphManagementRailItems(
+  input: GraphManagementRailInputs,
+): GraphManagementRailItem[] {
+  const sessionStamp = input.sessionUpdatedAt ?? 'Not loaded'
+  const readinessStatus: StepStatusLabel = input.blockingReasonCount > 0
+    ? 'needs_attention'
+    : input.transitionEligible
+      ? 'ready'
+      : 'in_progress'
+
+  return [
+    {
+      id: 'schema-readiness',
+      label: 'Schema readiness',
+      status: readinessStatus,
+      lastUpdated: sessionStamp,
+      detailHint: 'Bootstrap checklist, validate, and transition controls.',
+      modes: ['initial-schema-design'],
+    },
+    {
+      id: 'validation-diagnostics',
+      label: 'Validation diagnostics',
+      status: input.prepopulatedGapCount > 0 || input.blockingReasonCount > 0
+        ? 'needs_attention'
+        : 'ready',
+      lastUpdated: sessionStamp,
+      detailHint: 'Blocking reasons and prepopulated type gaps.',
+      modes: ['initial-schema-design'],
+    },
+    {
+      id: 'session-pointers',
+      label: 'Session pointers',
+      status: input.hasActiveSession ? 'ready' : 'in_progress',
+      lastUpdated: sessionStamp,
+      detailHint: 'Active bootstrap, extraction, and completed session references.',
+      modes: GRAPH_MANAGEMENT_MODE_ORDER,
+    },
+    {
+      id: 'extraction-jobs-setup',
+      label: 'Extraction jobs setup',
+      status: input.workspaceMode === 'extraction_operations' ? 'ready' : 'blocked',
+      lastUpdated: sessionStamp,
+      detailHint: 'Job setup, execution controls, and run context.',
+      modes: ['extraction-jobs'],
+    },
+    {
+      id: 'mutation-authoring',
+      label: 'Mutation authoring',
+      status: input.workspaceMode === 'extraction_operations' ? 'ready' : 'blocked',
+      lastUpdated: sessionStamp,
+      detailHint: 'One-off mutation preview and submit context.',
+      modes: ['one-off-mutations'],
+    },
+  ]
+}
+
+export function filterRailItemsForMode(
+  items: GraphManagementRailItem[],
+  mode: GraphManagementMode,
+): GraphManagementRailItem[] {
+  return items.filter((item) => item.modes.includes(mode))
+}
+
+export function isRailItemValidInMode(
+  itemId: GraphManagementRailItemId,
+  mode: GraphManagementMode,
+  items: GraphManagementRailItem[],
+): boolean {
+  const item = items.find((candidate) => candidate.id === itemId)
+  return item?.modes.includes(mode) ?? false
+}
+
+export function resolveRailSelectionForMode(
+  selectedId: GraphManagementRailItemId | null,
+  mode: GraphManagementMode,
+  items: GraphManagementRailItem[],
+): GraphManagementRailItemId | null {
+  const modeItems = filterRailItemsForMode(items, mode)
+  if (modeItems.length === 0) return null
+  if (selectedId && isRailItemValidInMode(selectedId, mode, items)) {
+    return selectedId
+  }
+  return modeItems[0]?.id ?? null
+}
+
+export function buildGraphManagementStepUrl(
+  kgId: string,
+  mode: GraphManagementMode,
+): string {
+  return `/knowledge-graphs/${encodeURIComponent(kgId)}/manage?step=graph-management&gm_mode=${mode}`
+}

--- a/src/dev-ui/app/utils/kgManageWorkspace.ts
+++ b/src/dev-ui/app/utils/kgManageWorkspace.ts
@@ -1,0 +1,319 @@
+export type WorkspaceStepId = 'data-sources' | 'graph-management' | 'mutation-logs' | 'maintain'
+
+export type StepStatusLabel = 'ready' | 'in_progress' | 'needs_attention' | 'blocked'
+
+export type StepActionLabel = 'Open' | 'Revisit' | 'Run'
+
+export const WORKSPACE_STEP_TITLES: Record<WorkspaceStepId, string> = {
+  'data-sources': 'Data Sources',
+  'graph-management': 'Graph Management',
+  'mutation-logs': 'MutationLogs',
+  maintain: 'Maintain',
+}
+
+export const WORKSPACE_STEP_ORDER: WorkspaceStepId[] = [
+  'data-sources',
+  'graph-management',
+  'mutation-logs',
+  'maintain',
+]
+
+export interface WorkspaceReadinessSnapshot {
+  has_minimum_entity_types: boolean
+  has_minimum_relationship_types: boolean
+  prepopulated_types_ready: boolean
+  blocking_reasons: string[]
+}
+
+export interface WorkspaceStatusSnapshot {
+  workspace_mode: 'schema_bootstrap' | 'extraction_operations'
+  transition_eligible: boolean
+  readiness: WorkspaceReadinessSnapshot
+}
+
+export interface WorkspaceOverviewInputs {
+  kgId: string
+  dataSourceCount: number
+  maintenanceReadyCount: number
+  mutationLogRunCount: number
+  workspaceStatus: WorkspaceStatusSnapshot | null
+}
+
+export interface WorkspaceStepCardView {
+  id: WorkspaceStepId
+  title: string
+  status: StepStatusLabel
+  statusDetail: string
+  actionLabel: StepActionLabel
+}
+
+export interface SuggestedNextStepView {
+  stepId: WorkspaceStepId
+  title: string
+  description: string
+  actionLabel: StepActionLabel
+}
+
+export function isMaintenanceReady(ds: {
+  last_extraction_baseline_commit?: string | null
+  tracked_branch_head_commit?: string | null
+}): boolean {
+  if (!ds.last_extraction_baseline_commit || !ds.tracked_branch_head_commit) return false
+  return ds.last_extraction_baseline_commit !== ds.tracked_branch_head_commit
+}
+
+export function buildDataSourcesStepUrl(kgId: string): string {
+  return `/data-sources?kg_id=${encodeURIComponent(kgId)}&from=manage`
+}
+
+export function buildMaintainStepUrl(kgId: string): string {
+  return `/data-sources?kg_id=${encodeURIComponent(kgId)}&from=manage&focus=maintain`
+}
+
+export function buildManageStepUrl(kgId: string, step?: WorkspaceStepId): string {
+  if (!step) {
+    return `/knowledge-graphs/${encodeURIComponent(kgId)}/manage`
+  }
+  return `/knowledge-graphs/${encodeURIComponent(kgId)}/manage?step=${step}`
+}
+
+export function parseManageStepQuery(step: unknown): WorkspaceStepId | null {
+  if (step === 'graph-management' || step === 'mutation-logs') {
+    return step
+  }
+  return null
+}
+
+export function stepStatusTintClass(status: StepStatusLabel): string {
+  switch (status) {
+    case 'ready':
+      return 'border-emerald-500/40 bg-emerald-50/30 dark:bg-emerald-950/20'
+    case 'in_progress':
+      return 'border-blue-500/40 bg-blue-50/30 dark:bg-blue-950/20'
+    case 'needs_attention':
+      return 'border-amber-500/40 bg-amber-50/30 dark:bg-amber-950/20'
+    case 'blocked':
+      return 'border-destructive/50 bg-destructive/5'
+  }
+}
+
+function buildDataSourcesCard(input: WorkspaceOverviewInputs): WorkspaceStepCardView {
+  if (input.dataSourceCount === 0) {
+    return {
+      id: 'data-sources',
+      title: WORKSPACE_STEP_TITLES['data-sources'],
+      status: 'needs_attention',
+      statusDetail: 'No data sources connected yet.',
+      actionLabel: 'Open',
+    }
+  }
+
+  return {
+    id: 'data-sources',
+    title: WORKSPACE_STEP_TITLES['data-sources'],
+    status: 'ready',
+    statusDetail: `${input.dataSourceCount} data source${input.dataSourceCount === 1 ? '' : 's'} connected.`,
+    actionLabel: 'Revisit',
+  }
+}
+
+function buildGraphManagementCard(input: WorkspaceOverviewInputs): WorkspaceStepCardView {
+  const status = input.workspaceStatus
+
+  if (!status) {
+    return {
+      id: 'graph-management',
+      title: WORKSPACE_STEP_TITLES['graph-management'],
+      status: 'in_progress',
+      statusDetail: 'Loading workspace readiness signals.',
+      actionLabel: 'Open',
+    }
+  }
+
+  if (status.workspace_mode === 'schema_bootstrap') {
+    if (status.readiness.blocking_reasons.length > 0) {
+      return {
+        id: 'graph-management',
+        title: WORKSPACE_STEP_TITLES['graph-management'],
+        status: 'needs_attention',
+        statusDetail: `${status.readiness.blocking_reasons.length} blocking reason${status.readiness.blocking_reasons.length === 1 ? '' : 's'} before extraction.`,
+        actionLabel: 'Open',
+      }
+    }
+
+    if (status.transition_eligible) {
+      return {
+        id: 'graph-management',
+        title: WORKSPACE_STEP_TITLES['graph-management'],
+        status: 'ready',
+        statusDetail: 'Schema bootstrap is ready to transition to extraction.',
+        actionLabel: 'Run',
+      }
+    }
+
+    return {
+      id: 'graph-management',
+      title: WORKSPACE_STEP_TITLES['graph-management'],
+      status: 'in_progress',
+      statusDetail: 'Continue schema bootstrap and validation work.',
+      actionLabel: 'Open',
+    }
+  }
+
+  return {
+    id: 'graph-management',
+    title: WORKSPACE_STEP_TITLES['graph-management'],
+    status: 'ready',
+    statusDetail: 'Extraction operations mode is active.',
+    actionLabel: 'Revisit',
+  }
+}
+
+function buildMutationLogsCard(input: WorkspaceOverviewInputs): WorkspaceStepCardView {
+  if (input.dataSourceCount === 0) {
+    return {
+      id: 'mutation-logs',
+      title: WORKSPACE_STEP_TITLES['mutation-logs'],
+      status: 'blocked',
+      statusDetail: 'Connect a data source before reviewing mutation runs.',
+      actionLabel: 'Open',
+    }
+  }
+
+  if (input.mutationLogRunCount === 0) {
+    return {
+      id: 'mutation-logs',
+      title: WORKSPACE_STEP_TITLES['mutation-logs'],
+      status: input.workspaceStatus?.workspace_mode === 'extraction_operations'
+        ? 'needs_attention'
+        : 'ready',
+      statusDetail: 'No mutation log runs recorded for this graph yet.',
+      actionLabel: 'Open',
+    }
+  }
+
+  return {
+    id: 'mutation-logs',
+    title: WORKSPACE_STEP_TITLES['mutation-logs'],
+    status: 'ready',
+    statusDetail: `${input.mutationLogRunCount} mutation run${input.mutationLogRunCount === 1 ? '' : 's'} available.`,
+    actionLabel: 'Revisit',
+  }
+}
+
+function buildMaintainCard(input: WorkspaceOverviewInputs): WorkspaceStepCardView {
+  if (input.dataSourceCount === 0) {
+    return {
+      id: 'maintain',
+      title: WORKSPACE_STEP_TITLES.maintain,
+      status: 'blocked',
+      statusDetail: 'Add a data source before maintenance can run.',
+      actionLabel: 'Open',
+    }
+  }
+
+  if (input.maintenanceReadyCount > 0) {
+    return {
+      id: 'maintain',
+      title: WORKSPACE_STEP_TITLES.maintain,
+      status: 'needs_attention',
+      statusDetail: `${input.maintenanceReadyCount} source${input.maintenanceReadyCount === 1 ? '' : 's'} have new commits ready for maintenance.`,
+      actionLabel: 'Run',
+    }
+  }
+
+  return {
+    id: 'maintain',
+    title: WORKSPACE_STEP_TITLES.maintain,
+    status: 'ready',
+    statusDetail: 'All tracked sources are up to date.',
+    actionLabel: 'Revisit',
+  }
+}
+
+export function buildWorkspaceStepCards(input: WorkspaceOverviewInputs): WorkspaceStepCardView[] {
+  return [
+    buildDataSourcesCard(input),
+    buildGraphManagementCard(input),
+    buildMutationLogsCard(input),
+    buildMaintainCard(input),
+  ]
+}
+
+export function buildSuggestedNextStep(input: WorkspaceOverviewInputs): SuggestedNextStepView {
+  const cards = buildWorkspaceStepCards(input)
+
+  if (input.dataSourceCount === 0) {
+    const card = cards.find((item) => item.id === 'data-sources')!
+    return {
+      stepId: 'data-sources',
+      title: card.title,
+      description: 'Connect a data source to start schema bootstrap and extraction.',
+      actionLabel: card.actionLabel,
+    }
+  }
+
+  const maintainCard = cards.find((item) => item.id === 'maintain')!
+  if (maintainCard.status === 'needs_attention' && maintainCard.actionLabel === 'Run') {
+    return {
+      stepId: 'maintain',
+      title: maintainCard.title,
+      description: maintainCard.statusDetail,
+      actionLabel: 'Run',
+    }
+  }
+
+  const graphCard = cards.find((item) => item.id === 'graph-management')!
+  if (
+    input.workspaceStatus?.workspace_mode === 'schema_bootstrap'
+    && input.workspaceStatus.transition_eligible
+  ) {
+    return {
+      stepId: 'graph-management',
+      title: graphCard.title,
+      description: 'Validate readiness and transition into extraction operations.',
+      actionLabel: 'Run',
+    }
+  }
+
+  if (
+    graphCard.status === 'needs_attention'
+    || graphCard.status === 'in_progress'
+  ) {
+    return {
+      stepId: 'graph-management',
+      title: graphCard.title,
+      description: graphCard.statusDetail,
+      actionLabel: graphCard.actionLabel,
+    }
+  }
+
+  const mutationCard = cards.find((item) => item.id === 'mutation-logs')!
+  if (mutationCard.status === 'needs_attention') {
+    return {
+      stepId: 'mutation-logs',
+      title: mutationCard.title,
+      description: mutationCard.statusDetail,
+      actionLabel: mutationCard.actionLabel,
+    }
+  }
+
+  return {
+    stepId: 'graph-management',
+    title: graphCard.title,
+    description: graphCard.statusDetail,
+    actionLabel: 'Revisit',
+  }
+}
+
+export function resolveStepDestination(kgId: string, stepId: WorkspaceStepId): string {
+  switch (stepId) {
+    case 'data-sources':
+      return buildDataSourcesStepUrl(kgId)
+    case 'maintain':
+      return buildMaintainStepUrl(kgId)
+    case 'graph-management':
+    case 'mutation-logs':
+      return buildManageStepUrl(kgId, stepId)
+  }
+}


### PR DESCRIPTION
## Summary

Closes #723

- Refactors the Graph Management step into a conversation-first layout with a three-mode switcher (Initial Schema Design, Extraction Jobs, One-off Mutations).
- Keeps one shared extraction session per workspace lifecycle mode while updating chat framing/placeholders on UI mode changes.
- Adds a hybrid lower panel with a persistent status/artifact rail and mode-specific detail content, preserving schema validation/transition workflows.

## Test plan

- [x] `cd src/dev-ui/local_modules && npx vitest run --config vitest.config.ts app/tests/knowledge-graph-manage-workspace.test.ts`
- Result: **46 passed** (includes KG-MANAGE-006/007/008/009/010/011/016 coverage)


Made with [Cursor](https://cursor.com)