### PR TITLE
feat(dev-ui): MutationLogs step hardening and fallback states (#724)

### DIFF
--- a/src/api/management/presentation/data_sources/models.py
+++ b/src/api/management/presentation/data_sources/models.py
@@ -246,6 +246,33 @@ class SyncRunLogsResponse(BaseModel):
     )
 
 
+class MutationLogEntryPreviewResponse(BaseModel):
+    """Single mutation-log entry preview for a sync run."""
+
+    line_number: int = Field(..., description="1-based line number in the mutation log")
+    operation_class: str = Field(..., description="Operation class for this entry")
+    summary: str = Field(..., description="Human-readable preview summary for this entry")
+
+
+class MutationLogEntryPreviewPageResponse(BaseModel):
+    """Paginated mutation-log entry previews for a sync run."""
+
+    entries: list[MutationLogEntryPreviewResponse] = Field(
+        default_factory=list,
+        description="Preview entries for the requested page",
+    )
+    total: int = Field(..., description="Total preview entries available for this run")
+    offset: int = Field(..., description="Zero-based offset of this page")
+    limit: int = Field(..., description="Maximum entries requested for this page")
+    preview_available: bool = Field(
+        ...,
+        description=(
+            "False when detailed mutation-log entry previews are not yet stored "
+            "or cannot be retrieved for this run"
+        ),
+    )
+
+
 class DiffChangedFileResponse(BaseModel):
     """Single changed file entry in a commit diff summary."""
 
@@ -299,6 +326,10 @@ class SyncRunResponse(BaseModel):
     mutation_log_id: str | None = Field(
         None, description="Associated mutation log run ID when available"
     )
+    knowledge_graph_id: str | None = Field(
+        None,
+        description="Knowledge graph scope for this mutation run when available",
+    )
     session_id: str | None = Field(
         None, description="Extraction session ID associated with this mutation run"
     )
@@ -338,6 +369,11 @@ class SyncRunResponse(BaseModel):
             error=run.error,
             mutation_log_id=(
                 run.mutation_log_run.mutation_log_id
+                if run.mutation_log_run is not None
+                else None
+            ),
+            knowledge_graph_id=(
+                run.mutation_log_run.knowledge_graph_id
                 if run.mutation_log_run is not None
                 else None
             ),

--- a/src/api/management/presentation/data_sources/routes.py
+++ b/src/api/management/presentation/data_sources/routes.py
@@ -29,6 +29,7 @@ from management.presentation.data_sources.models import (
     DataSourceWithSyncResponse,
     RunControlAction,
     RunControlResponse,
+    MutationLogEntryPreviewPageResponse,
     SyncRunLogsResponse,
     SyncRunResponse,
     UpdateDataSourceRequest,
@@ -703,4 +704,70 @@ async def get_sync_run_logs(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to fetch sync run logs",
+        )
+
+
+@router.get(
+    "/data-sources/{ds_id}/sync-runs/{run_id}/mutation-log-entries",
+    status_code=status.HTTP_200_OK,
+)
+async def list_mutation_log_entry_previews(
+    ds_id: str,
+    run_id: str,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    service: Annotated[DataSourceService, Depends(get_data_source_service)],
+    sync_run_repo: Annotated[
+        IDataSourceSyncRunRepository, Depends(get_sync_run_repository)
+    ],
+    offset: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+) -> MutationLogEntryPreviewPageResponse:
+    """List paginated mutation-log entry previews for a sync run.
+
+    Returns an empty page with ``preview_available=false`` until mutation-log
+    storage is wired for per-entry retrieval (#721 follow-on).
+    """
+    try:
+        ds = await service.get(
+            user_id=current_user.user_id.value,
+            ds_id=ds_id,
+        )
+
+        if ds is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Data source not found",
+            )
+
+        sync_run = await sync_run_repo.get_by_id(run_id)
+
+        if sync_run is None or sync_run.data_source_id != ds_id:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Sync run not found",
+            )
+
+        if sync_run.mutation_log_run is None:
+            return MutationLogEntryPreviewPageResponse(
+                entries=[],
+                total=0,
+                offset=offset,
+                limit=limit,
+                preview_available=False,
+            )
+
+        return MutationLogEntryPreviewPageResponse(
+            entries=[],
+            total=0,
+            offset=offset,
+            limit=limit,
+            preview_available=False,
+        )
+
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to fetch mutation log entry previews",
         )

--- a/src/api/tests/unit/management/presentation/test_data_sources_routes.py
+++ b/src/api/tests/unit/management/presentation/test_data_sources_routes.py
@@ -509,6 +509,7 @@ class TestListSyncRunsRoute:
         assert response.status_code == status.HTTP_200_OK
         payload = response.json()[0]
         assert payload["mutation_log_id"] == "mlog-preview-1"
+        assert payload["knowledge_graph_id"] == sample_data_source.knowledge_graph_id
         assert payload["session_id"] == "sess-preview-1"
         assert payload["actor_id"] == "actor-preview-1"
         assert payload["operation_counts"] == {
@@ -532,6 +533,61 @@ class TestListSyncRunsRoute:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         mock_sync_run_repo.find_by_data_source.assert_not_called()
+
+
+class TestMutationLogEntryPreviewRoutes:
+    """Tests for GET /management/data-sources/{ds_id}/sync-runs/{run_id}/mutation-log-entries."""
+
+    def test_list_mutation_log_entries_returns_paginated_skeleton_when_storage_unavailable(
+        self,
+        test_client: TestClient,
+        mock_ds_service: AsyncMock,
+        mock_sync_run_repo: AsyncMock,
+        sample_data_source: DataSource,
+        sample_sync_run: DataSourceSyncRun,
+    ) -> None:
+        sample_sync_run.mutation_log_run = MutationLogRunMetadata(
+            mutation_log_id="mlog-preview-1",
+            knowledge_graph_id=sample_data_source.knowledge_graph_id,
+            session_id="sess-preview-1",
+            actor_id="actor-preview-1",
+            started_at=sample_sync_run.started_at,
+            operation_counts={"create_node": 3},
+        )
+        mock_ds_service.get.return_value = sample_data_source
+        mock_sync_run_repo.get_by_id.return_value = sample_sync_run
+
+        response = test_client.get(
+            f"/management/data-sources/{sample_data_source.id.value}/sync-runs/"
+            f"{sample_sync_run.id}/mutation-log-entries?offset=0&limit=20"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        payload = response.json()
+        assert payload == {
+            "entries": [],
+            "total": 0,
+            "offset": 0,
+            "limit": 20,
+            "preview_available": False,
+        }
+
+    def test_list_mutation_log_entries_returns_404_when_run_missing(
+        self,
+        test_client: TestClient,
+        mock_ds_service: AsyncMock,
+        mock_sync_run_repo: AsyncMock,
+        sample_data_source: DataSource,
+    ) -> None:
+        mock_ds_service.get.return_value = sample_data_source
+        mock_sync_run_repo.get_by_id.return_value = None
+
+        response = test_client.get(
+            f"/management/data-sources/{sample_data_source.id.value}/sync-runs/"
+            "missing-run/mutation-log-entries"
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 class TestRunControlRoutes:

--- a/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
+++ b/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
@@ -41,6 +41,16 @@ import {
   resolveSectionState,
   shouldApplyMutationResult,
 } from '@/utils/kgManageState'
+import {
+  buildMutationLogEntryPreviewUrl,
+  collectScopedMutationLogRuns,
+  hasMutationLogEntryPreviewPage,
+  MUTATION_LOG_ENTRY_PREVIEW_PAGE_SIZE,
+  MUTATION_LOG_NO_PREVIEW_MESSAGE,
+  resolveDefaultSelectedMutationLogRunId,
+  type MutationLogEntryPreviewPage,
+  type MutationLogRunRecord,
+} from '@/utils/kgMutationLogs'
 
 interface WorkspaceReadinessStatus {
   has_minimum_entity_types: boolean
@@ -77,20 +87,8 @@ interface DataSourceRef {
   tracked_branch_head_commit?: string | null
 }
 
-interface MutationLogRunView {
-  id: string
-  data_source_id: string
+interface MutationLogRunView extends MutationLogRunRecord {
   data_source_name: string
-  status: string
-  started_at: string
-  completed_at: string | null
-  mutation_log_id: string | null
-  session_id: string | null
-  actor_id: string | null
-  operation_counts: Record<string, number>
-  token_usage_total: number | null
-  cost_total_usd: number | null
-  error: string | null
 }
 
 interface ExtractionSessionResponse {
@@ -152,6 +150,9 @@ const mutationLogRuns = ref<MutationLogRunView[]>([])
 const selectedMutationLogRunId = ref<string | null>(null)
 const graphManagementMode = ref<GraphManagementMode>('initial-schema-design')
 const selectedRailItemId = ref<GraphManagementRailItemId | null>(null)
+const mutationLogEntryPreviewLoading = ref(false)
+const mutationLogEntryPreviewPage = ref<MutationLogEntryPreviewPage | null>(null)
+const mutationLogEntryPreviewOffset = ref(0)
 
 const activeStep = computed(() => parseManageStepQuery(route.query.step))
 const showOverview = computed(() => activeStep.value === null)
@@ -410,34 +411,28 @@ async function loadMutationLogRuns() {
       `/management/knowledge-graphs/${kgId.value}/data-sources`,
     )
 
-    const collected: MutationLogRunView[] = []
+    const runsByDataSourceId: Record<string, MutationLogRunRecord[]> = {}
     for (const ds of dataSources) {
       try {
-        const runs = await apiFetch<MutationLogRunView[]>(
+        runsByDataSourceId[ds.id] = await apiFetch<MutationLogRunRecord[]>(
           `/management/data-sources/${ds.id}/sync-runs`,
         )
-        for (const run of runs) {
-          if (!run.mutation_log_id) continue
-          collected.push({
-            ...run,
-            data_source_name: ds.name,
-          })
-        }
       } catch {
-        // Keep page resilient when one data source run list fails.
+        runsByDataSourceId[ds.id] = []
       }
     }
 
-    collected.sort(
-      (a, b) => new Date(b.started_at).getTime() - new Date(a.started_at).getTime(),
-    )
+    const collected = collectScopedMutationLogRuns(
+      kgId.value,
+      dataSources,
+      runsByDataSourceId,
+    ) as MutationLogRunView[]
+
     mutationLogRuns.value = collected
-    if (
-      !selectedMutationLogRunId.value
-      || !collected.some((run) => run.id === selectedMutationLogRunId.value)
-    ) {
-      selectedMutationLogRunId.value = collected[0]?.id ?? null
-    }
+    selectedMutationLogRunId.value = resolveDefaultSelectedMutationLogRunId(
+      collected,
+      selectedMutationLogRunId.value,
+    )
   } catch (err) {
     if (isForbiddenHttpError(err)) {
       mutationLogLoadError.value = resolveForbiddenReason(
@@ -452,8 +447,45 @@ async function loadMutationLogRuns() {
     }
     mutationLogRuns.value = []
     selectedMutationLogRunId.value = null
+    mutationLogEntryPreviewPage.value = null
   } finally {
     mutationLogLoading.value = false
+  }
+}
+
+async function loadMutationLogEntryPreviews(offset = 0) {
+  const run = selectedMutationLogRun.value
+  if (!run) {
+    mutationLogEntryPreviewPage.value = null
+    mutationLogEntryPreviewOffset.value = 0
+    return
+  }
+
+  mutationLogEntryPreviewLoading.value = true
+  try {
+    mutationLogEntryPreviewPage.value = await apiFetch<MutationLogEntryPreviewPage>(
+      buildMutationLogEntryPreviewUrl(
+        run.data_source_id,
+        run.id,
+        offset,
+        MUTATION_LOG_ENTRY_PREVIEW_PAGE_SIZE,
+      ),
+    )
+    mutationLogEntryPreviewOffset.value = offset
+  } catch (err) {
+    mutationLogEntryPreviewPage.value = {
+      entries: [],
+      total: 0,
+      offset,
+      limit: MUTATION_LOG_ENTRY_PREVIEW_PAGE_SIZE,
+      preview_available: false,
+    }
+    mutationLogEntryPreviewOffset.value = offset
+    toast.error('Failed to load mutation log entry previews', {
+      description: extractErrorMessage(err),
+    })
+  } finally {
+    mutationLogEntryPreviewLoading.value = false
   }
 }
 
@@ -702,6 +734,10 @@ watch(
     }
   },
 )
+
+watch(selectedMutationLogRunId, () => {
+  loadMutationLogEntryPreviews(0)
+})
 </script>
 
 <template>
@@ -891,6 +927,7 @@ watch(
             </div>
 
             <div v-if="selectedMutationLogRun" class="space-y-3 rounded border p-3">
+              <p class="text-xs font-medium text-muted-foreground">Run summary</p>
               <div class="flex flex-wrap items-center gap-2">
                 <Badge>{{ selectedMutationLogRun.status }}</Badge>
                 <p class="text-xs text-muted-foreground">
@@ -935,7 +972,7 @@ watch(
                 </div>
               </div>
               <div class="rounded border p-3">
-                <p class="mb-2 text-xs font-medium text-muted-foreground">Per-entry operation previews</p>
+                <p class="mb-2 text-xs font-medium text-muted-foreground">Operation class counts</p>
                 <div v-if="Object.keys(selectedMutationLogRun.operation_counts).length === 0" class="text-xs text-muted-foreground">
                   No operation class counts recorded for this run.
                 </div>
@@ -947,6 +984,57 @@ watch(
                   >
                     <span class="font-mono">{{ opClass }}</span>
                     <Badge variant="secondary">{{ count }}</Badge>
+                  </div>
+                </div>
+              </div>
+              <div class="rounded border p-3">
+                <div class="mb-2 flex items-center justify-between gap-2">
+                  <p class="text-xs font-medium text-muted-foreground">Per-entry operation previews</p>
+                  <div
+                    v-if="hasMutationLogEntryPreviewPage(mutationLogEntryPreviewPage)"
+                    class="flex items-center gap-1"
+                  >
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      class="h-6 px-2 text-[10px]"
+                      :disabled="mutationLogEntryPreviewLoading || mutationLogEntryPreviewOffset === 0"
+                      @click="loadMutationLogEntryPreviews(mutationLogEntryPreviewOffset - MUTATION_LOG_ENTRY_PREVIEW_PAGE_SIZE)"
+                    >
+                      Previous
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      class="h-6 px-2 text-[10px]"
+                      :disabled="mutationLogEntryPreviewLoading || (mutationLogEntryPreviewPage?.offset ?? 0) + (mutationLogEntryPreviewPage?.entries.length ?? 0) >= (mutationLogEntryPreviewPage?.total ?? 0)"
+                      @click="loadMutationLogEntryPreviews(mutationLogEntryPreviewOffset + MUTATION_LOG_ENTRY_PREVIEW_PAGE_SIZE)"
+                    >
+                      Next
+                    </Button>
+                  </div>
+                </div>
+                <div v-if="mutationLogEntryPreviewLoading" class="flex items-center gap-2 text-xs text-muted-foreground">
+                  <Loader2 class="size-3.5 animate-spin" />
+                  Loading entry previews...
+                </div>
+                <div
+                  v-else-if="!hasMutationLogEntryPreviewPage(mutationLogEntryPreviewPage)"
+                  class="rounded border border-dashed px-3 py-4 text-xs text-muted-foreground"
+                >
+                  {{ MUTATION_LOG_NO_PREVIEW_MESSAGE }}
+                </div>
+                <div v-else class="space-y-1.5">
+                  <div
+                    v-for="entry in mutationLogEntryPreviewPage?.entries ?? []"
+                    :key="`${entry.line_number}-${entry.operation_class}`"
+                    class="rounded border px-2 py-1.5 text-xs"
+                  >
+                    <div class="flex items-center justify-between gap-2">
+                      <span class="font-mono">{{ entry.operation_class }}</span>
+                      <span class="text-[10px] text-muted-foreground">Line {{ entry.line_number }}</span>
+                    </div>
+                    <p class="mt-1 text-muted-foreground">{{ entry.summary }}</p>
                   </div>
                 </div>
               </div>

--- a/src/dev-ui/app/tests/kgMutationLogs.test.ts
+++ b/src/dev-ui/app/tests/kgMutationLogs.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MUTATION_LOG_NO_PREVIEW_MESSAGE,
+  buildMutationLogEntryPreviewUrl,
+  collectScopedMutationLogRuns,
+  hasMutationLogEntryPreviewPage,
+  isMutationLogRunForKnowledgeGraph,
+  resolveDefaultSelectedMutationLogRunId,
+  sortMutationLogRunsNewestFirst,
+} from '../utils/kgMutationLogs'
+
+const kgId = 'kg-target'
+
+function makeRun(overrides: Partial<ReturnType<typeof baseRun>> = {}) {
+  return { ...baseRun(), ...overrides }
+}
+
+function baseRun() {
+  return {
+    id: 'run-1',
+    data_source_id: 'ds-1',
+    status: 'completed',
+    started_at: '2026-05-20T10:00:00Z',
+    completed_at: '2026-05-20T10:05:00Z',
+    mutation_log_id: 'mlog-1',
+    knowledge_graph_id: kgId,
+    session_id: 'sess-1',
+    actor_id: 'actor-1',
+    operation_counts: { create_node: 2 },
+    token_usage_total: 100,
+    cost_total_usd: 0.5,
+    error: null,
+  }
+}
+
+describe('KG-MANAGE-012 - graph-scoped mutation run list', () => {
+  it('includes only runs with mutation logs scoped to the selected knowledge graph', () => {
+    const runs = collectScopedMutationLogRuns(
+      kgId,
+      [{ id: 'ds-1', name: 'Source A' }],
+      {
+        'ds-1': [
+          makeRun({ id: 'run-a', mutation_log_id: 'mlog-a' }),
+          makeRun({ id: 'run-b', mutation_log_id: 'mlog-b', knowledge_graph_id: 'kg-other' }),
+          makeRun({ id: 'run-c', mutation_log_id: null }),
+        ],
+      },
+    )
+
+    expect(runs.map((run) => run.id)).toEqual(['run-a'])
+    expect(runs[0]?.data_source_name).toBe('Source A')
+  })
+
+  it('orders runs newest-first by started_at', () => {
+    const runs = sortMutationLogRunsNewestFirst([
+      makeRun({ id: 'older', started_at: '2026-05-01T10:00:00Z' }),
+      makeRun({ id: 'newer', started_at: '2026-05-22T10:00:00Z' }),
+    ])
+
+    expect(runs.map((run) => run.id)).toEqual(['newer', 'older'])
+  })
+
+  it('keeps current selection when still present otherwise selects newest run', () => {
+    const runs = [
+      makeRun({ id: 'newest', started_at: '2026-05-22T10:00:00Z' }),
+      makeRun({ id: 'selected', started_at: '2026-05-21T10:00:00Z' }),
+    ]
+
+    expect(resolveDefaultSelectedMutationLogRunId(runs, 'selected')).toBe('selected')
+    expect(resolveDefaultSelectedMutationLogRunId(runs, 'missing')).toBe('newest')
+  })
+
+  it('allows legacy runs without knowledge_graph_id when loaded from graph data sources', () => {
+    expect(
+      isMutationLogRunForKnowledgeGraph(
+        { mutation_log_id: 'mlog-legacy', knowledge_graph_id: null },
+        kgId,
+      ),
+    ).toBe(true)
+  })
+})
+
+describe('KG-MANAGE-013 - run detail richness helpers', () => {
+  it('builds paginated mutation-log entry preview URLs', () => {
+    expect(buildMutationLogEntryPreviewUrl('ds-1', 'run-1')).toBe(
+      '/management/data-sources/ds-1/sync-runs/run-1/mutation-log-entries?offset=0&limit=20',
+    )
+    expect(buildMutationLogEntryPreviewUrl('ds-1', 'run-1', 20, 10)).toBe(
+      '/management/data-sources/ds-1/sync-runs/run-1/mutation-log-entries?offset=20&limit=10',
+    )
+  })
+})
+
+describe('KG-MANAGE-014 - no-preview fallback helpers', () => {
+  it('uses explicit no-preview messaging constant', () => {
+    expect(MUTATION_LOG_NO_PREVIEW_MESSAGE).toContain('not available')
+  })
+
+  it('detects when entry preview pages are unavailable', () => {
+    expect(hasMutationLogEntryPreviewPage(null)).toBe(false)
+    expect(
+      hasMutationLogEntryPreviewPage({
+        entries: [],
+        total: 0,
+        offset: 0,
+        limit: 20,
+        preview_available: false,
+      }),
+    ).toBe(false)
+    expect(
+      hasMutationLogEntryPreviewPage({
+        entries: [{ line_number: 1, operation_class: 'create_node', summary: 'Create Person' }],
+        total: 1,
+        offset: 0,
+        limit: 20,
+        preview_available: true,
+      }),
+    ).toBe(true)
+  })
+})

--- a/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
+++ b/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
@@ -90,7 +90,7 @@ describe('Knowledge Graph Manage Workspace - mutation log browser', () => {
 
   it('loads sync runs per data source and filters to mutation-log runs', () => {
     expect(manageWorkspaceVue).toContain('/management/data-sources/${ds.id}/sync-runs')
-    expect(manageWorkspaceVue).toContain('if (!run.mutation_log_id) continue')
+    expect(manageWorkspaceVue).toContain('collectScopedMutationLogRuns')
   })
 
   it('renders run detail summary with token and cost metrics', () => {
@@ -100,10 +100,53 @@ describe('Knowledge Graph Manage Workspace - mutation log browser', () => {
     expect(manageWorkspaceVue).toContain('cost_total_usd')
   })
 
-  it('renders per-entry operation preview rows from operation_counts', () => {
+  it('separates operation class counts from per-entry previews', () => {
+    expect(manageWorkspaceVue).toContain('Operation class counts')
     expect(manageWorkspaceVue).toContain('Per-entry operation previews')
-    expect(manageWorkspaceVue).toContain('operation_counts')
     expect(manageWorkspaceVue).toContain('Object.entries(selectedMutationLogRun.operation_counts)')
+    expect(manageWorkspaceVue).toContain('loadMutationLogEntryPreviews')
+  })
+})
+
+describe('KG-MANAGE-012 - graph-scoped mutation run list', () => {
+  it('loads runs only from graph-scoped data sources with KG metadata filtering', () => {
+    expect(manageWorkspaceVue).toContain('collectScopedMutationLogRuns')
+    expect(manageWorkspaceVue).toContain('knowledge_graph_id')
+  })
+
+  it('defaults run list ordering to newest-first', () => {
+    expect(manageWorkspaceVue).toContain('collectScopedMutationLogRuns')
+    expect(manageWorkspaceVue).toContain('resolveDefaultSelectedMutationLogRunId')
+  })
+
+  it('shows status, timestamp, source, and run identifier in run list items', () => {
+    expect(manageWorkspaceVue).toContain('run.data_source_name')
+    expect(manageWorkspaceVue).toContain('run.started_at')
+    expect(manageWorkspaceVue).toContain('run.status')
+    expect(manageWorkspaceVue).toContain('run.mutation_log_id')
+  })
+})
+
+describe('KG-MANAGE-013 - run detail richness', () => {
+  it('renders run summary, session reference, token/cost metrics, and operation counts', () => {
+    expect(manageWorkspaceVue).toContain('Run summary')
+    expect(manageWorkspaceVue).toContain('Session')
+    expect(manageWorkspaceVue).toContain('Token usage')
+    expect(manageWorkspaceVue).toContain('Cost (USD)')
+    expect(manageWorkspaceVue).toContain('Operation class counts')
+  })
+
+  it('loads paginated per-entry previews from mutation-log-entries API', () => {
+    expect(manageWorkspaceVue).toContain('buildMutationLogEntryPreviewUrl')
+    expect(manageWorkspaceVue).toContain('loadMutationLogEntryPreviews')
+    expect(manageWorkspaceVue).toContain('mutationLogEntryPreviewPage')
+  })
+})
+
+describe('KG-MANAGE-014 - no-preview fallback state', () => {
+  it('shows explicit fallback when entry previews are unavailable', () => {
+    expect(manageWorkspaceVue).toContain('MUTATION_LOG_NO_PREVIEW_MESSAGE')
+    expect(manageWorkspaceVue).toContain('hasMutationLogEntryPreviewPage')
   })
 })
 

--- a/src/dev-ui/app/utils/kgMutationLogs.ts
+++ b/src/dev-ui/app/utils/kgMutationLogs.ts
@@ -1,0 +1,100 @@
+export interface MutationLogRunRecord {
+  id: string
+  data_source_id: string
+  data_source_name?: string
+  status: string
+  started_at: string
+  completed_at: string | null
+  mutation_log_id: string | null
+  knowledge_graph_id: string | null
+  session_id: string | null
+  actor_id: string | null
+  operation_counts: Record<string, number>
+  token_usage_total: number | null
+  cost_total_usd: number | null
+  error: string | null
+}
+
+export interface MutationLogEntryPreview {
+  line_number: number
+  operation_class: string
+  summary: string
+}
+
+export interface MutationLogEntryPreviewPage {
+  entries: MutationLogEntryPreview[]
+  total: number
+  offset: number
+  limit: number
+  preview_available: boolean
+}
+
+export const MUTATION_LOG_ENTRY_PREVIEW_PAGE_SIZE = 20
+
+export const MUTATION_LOG_NO_PREVIEW_MESSAGE =
+  'Detailed entry previews are not available for this run yet.'
+
+export function isMutationLogRunForKnowledgeGraph(
+  run: Pick<MutationLogRunRecord, 'mutation_log_id' | 'knowledge_graph_id'>,
+  kgId: string,
+): boolean {
+  if (!run.mutation_log_id) return false
+  if (run.knowledge_graph_id != null && run.knowledge_graph_id !== kgId) return false
+  return true
+}
+
+export function sortMutationLogRunsNewestFirst<T extends { started_at: string }>(
+  runs: T[],
+): T[] {
+  return [...runs].sort(
+    (a, b) => new Date(b.started_at).getTime() - new Date(a.started_at).getTime(),
+  )
+}
+
+export function resolveDefaultSelectedMutationLogRunId(
+  runs: Array<{ id: string }>,
+  currentId: string | null,
+): string | null {
+  if (currentId && runs.some((run) => run.id === currentId)) return currentId
+  return runs[0]?.id ?? null
+}
+
+export function collectScopedMutationLogRuns(
+  kgId: string,
+  dataSources: Array<{ id: string; name: string }>,
+  runsByDataSourceId: Record<string, MutationLogRunRecord[]>,
+): MutationLogRunRecord[] {
+  const collected: MutationLogRunRecord[] = []
+
+  for (const ds of dataSources) {
+    const runs = runsByDataSourceId[ds.id] ?? []
+    for (const run of runs) {
+      if (!isMutationLogRunForKnowledgeGraph(run, kgId)) continue
+      collected.push({
+        ...run,
+        data_source_name: ds.name,
+      })
+    }
+  }
+
+  return sortMutationLogRunsNewestFirst(collected)
+}
+
+export function buildMutationLogEntryPreviewUrl(
+  dataSourceId: string,
+  runId: string,
+  offset = 0,
+  limit = MUTATION_LOG_ENTRY_PREVIEW_PAGE_SIZE,
+): string {
+  const params = new URLSearchParams({
+    offset: String(offset),
+    limit: String(limit),
+  })
+  return `/management/data-sources/${encodeURIComponent(dataSourceId)}/sync-runs/${encodeURIComponent(runId)}/mutation-log-entries?${params}`
+}
+
+export function hasMutationLogEntryPreviewPage(
+  page: MutationLogEntryPreviewPage | null,
+): boolean {
+  return page?.preview_available === true && page.entries.length > 0
+}


### PR DESCRIPTION
## Summary
- Hardens the manage workspace MutationLog browser per KG-MANAGE-012/013/014: KG-scoped newest-first run listing, rich run detail panel (summary/session/token/cost/op counts), and explicit no-preview fallback when entry previews are unavailable.
- Adds test-backed `kgMutationLogs` utilities plus a paginated `GET /management/data-sources/{ds_id}/sync-runs/{run_id}/mutation-log-entries` API/UI skeleton for per-entry preview plumbing.

Closes #724

## Relation to #721
This PR wires the API contract, pagination controls, and UI loading path for per-entry mutation-log previews. Storage/backing retrieval is not yet implemented, so the endpoint returns an empty page with `preview_available=false` and the UI shows the explicit fallback state. **#721 remains partially open** until mutation-log entry storage is connected and preview rows render from real JSONL entries.

## Test plan
- [x] `cd src/dev-ui/local_modules && ./node_modules/.bin/vitest run app/tests/kgMutationLogs.test.ts app/tests/knowledge-graph-manage-workspace.test.ts -t "KG-MANAGE-012|KG-MANAGE-013|KG-MANAGE-014|mutation log browser|kgMutationLogs"` — 17 passed
- [x] `cd src/api && uv run pytest tests/unit/management/presentation/test_data_sources_routes.py::TestListSyncRunsRoute::test_list_sync_runs_includes_mutation_log_run_preview_fields tests/unit/management/presentation/test_data_sources_routes.py::TestMutationLogEntryPreviewRoutes -v` — 3 passed


Made with [Cursor](https://cursor.com)