### PR TITLE
feat(dev-ui): KG Manage accessibility and state contracts (#725)

### DIFF
--- a/src/dev-ui/app/components/extraction/SharedConversationPanel.vue
+++ b/src/dev-ui/app/components/extraction/SharedConversationPanel.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from 'vue'
-import { Loader2, RefreshCw } from 'lucide-vue-next'
+import { Loader2, RefreshCw, SendHorizontal } from 'lucide-vue-next'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -14,6 +14,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
+import { handleChatInputKeydown } from '@/utils/kgManageState'
 
 interface ConversationEntry {
   role?: string
@@ -31,22 +32,33 @@ const props = withDefaults(defineProps<{
   session: ConversationSession | null
   loading?: boolean
   clearing?: boolean
+  sending?: boolean
   draftMessage?: string
   activityLines?: string[]
   inputPlaceholder?: string
   sessionStatusLabel?: string
+  inputDisabled?: boolean
+  inputDisabledReason?: string | null
+  forbidden?: boolean
+  forbiddenReason?: string | null
 }>(), {
   loading: false,
   clearing: false,
+  sending: false,
   draftMessage: '',
   activityLines: () => [],
   inputPlaceholder: 'Describe what you want to do in this graph management session…',
   sessionStatusLabel: 'No active session',
+  inputDisabled: false,
+  inputDisabledReason: null,
+  forbidden: false,
+  forbiddenReason: null,
 })
 
 const emit = defineEmits<{
   refresh: []
   clearChat: []
+  sendMessage: [message: string]
   'update:draftMessage': [value: string]
 }>()
 
@@ -60,6 +72,18 @@ const combinedTimelineLength = computed(
   () => messageHistory.value.length + activityTimeline.value.length,
 )
 
+const chatInputDisabled = computed(
+  () => props.loading || props.clearing || props.sending || props.inputDisabled || props.forbidden,
+)
+
+const chatInputHelp = computed(() => {
+  if (props.forbidden) {
+    return props.forbiddenReason ?? 'Chat is unavailable because you lack permission for this action.'
+  }
+  if (props.inputDisabledReason) return props.inputDisabledReason
+  return 'Press Enter to send. Shift+Enter adds a new line.'
+})
+
 watch(combinedTimelineLength, async () => {
   await nextTick()
   if (timelineRef.value) {
@@ -70,6 +94,17 @@ watch(combinedTimelineLength, async () => {
 function confirmClearChat() {
   clearConfirmOpen.value = false
   emit('clearChat')
+}
+
+function sendDraftMessage() {
+  const trimmed = props.draftMessage.trim()
+  if (!trimmed || chatInputDisabled.value) return
+  emit('sendMessage', trimmed)
+  emit('update:draftMessage', '')
+}
+
+function onChatInputKeydown(event: KeyboardEvent) {
+  handleChatInputKeydown(event, sendDraftMessage)
 }
 </script>
 
@@ -89,6 +124,14 @@ function confirmClearChat() {
       </div>
     </CardHeader>
     <CardContent class="space-y-3">
+      <div
+        v-if="forbidden"
+        class="rounded border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive"
+        role="alert"
+      >
+        {{ forbiddenReason ?? 'You do not have permission to use graph management chat for this knowledge graph.' }}
+      </div>
+
       <div class="flex items-center justify-between">
         <p class="text-xs text-muted-foreground">No local cache: conversation state is server-side only.</p>
         <Button size="sm" variant="ghost" class="h-7 px-2 text-[11px]" :disabled="loading" @click="emit('refresh')">
@@ -128,21 +171,39 @@ function confirmClearChat() {
           v-if="messageHistory.length === 0 && activityTimeline.length === 0"
           class="text-xs text-muted-foreground"
         >
-          No messages yet. Use validate/transition actions to drive session activity.
+          No messages yet. Send a prompt or use validate/transition actions to drive session activity.
         </p>
       </div>
 
-      <div class="flex items-center gap-2">
-        <Input
-          :model-value="draftMessage"
-          disabled
-          :placeholder="inputPlaceholder"
-          @update:model-value="(value) => emit('update:draftMessage', value)"
-        />
-        <Button variant="outline" :disabled="clearing || loading" @click="clearConfirmOpen = true">
-          <Loader2 v-if="clearing" class="mr-1.5 size-3.5 animate-spin" />
-          Clear chat
-        </Button>
+      <div class="space-y-2">
+        <div class="flex items-start gap-2">
+          <Textarea
+            :model-value="draftMessage"
+            :disabled="chatInputDisabled"
+            :placeholder="inputPlaceholder"
+            class="min-h-20"
+            aria-label="Graph management chat input"
+            @update:model-value="(value) => emit('update:draftMessage', value)"
+            @keydown="onChatInputKeydown"
+          />
+          <Button
+            variant="default"
+            class="shrink-0"
+            :disabled="chatInputDisabled || !draftMessage.trim()"
+            :title="chatInputHelp"
+            @click="sendDraftMessage"
+          >
+            <Loader2 v-if="sending" class="size-3.5 animate-spin" />
+            <SendHorizontal v-else class="size-3.5" />
+          </Button>
+        </div>
+        <div class="flex flex-wrap items-center justify-between gap-2">
+          <p class="text-[11px] text-muted-foreground">{{ chatInputHelp }}</p>
+          <Button variant="outline" :disabled="clearing || loading || forbidden" @click="clearConfirmOpen = true">
+            <Loader2 v-if="clearing" class="mr-1.5 size-3.5 animate-spin" />
+            Clear chat
+          </Button>
+        </div>
       </div>
     </CardContent>
   </Card>

--- a/src/dev-ui/app/components/extraction/SharedConversationPanel.vue
+++ b/src/dev-ui/app/components/extraction/SharedConversationPanel.vue
@@ -33,11 +33,15 @@ const props = withDefaults(defineProps<{
   clearing?: boolean
   draftMessage?: string
   activityLines?: string[]
+  inputPlaceholder?: string
+  sessionStatusLabel?: string
 }>(), {
   loading: false,
   clearing: false,
   draftMessage: '',
   activityLines: () => [],
+  inputPlaceholder: 'Describe what you want to do in this graph management session…',
+  sessionStatusLabel: 'No active session',
 })
 
 const emit = defineEmits<{
@@ -72,10 +76,17 @@ function confirmClearChat() {
 <template>
   <Card>
     <CardHeader>
-      <CardTitle class="text-base">Conversation</CardTitle>
-      <CardDescription>
-        Shared conversation feed for {{ modeLabel }} with server-side session resume.
-      </CardDescription>
+      <div class="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <CardTitle class="text-base">Conversation</CardTitle>
+          <CardDescription>
+            Shared conversation feed for {{ modeLabel }} with server-side session resume.
+          </CardDescription>
+        </div>
+        <p class="text-xs text-muted-foreground">
+          Session: <span class="font-medium text-foreground">{{ sessionStatusLabel }}</span>
+        </p>
+      </div>
     </CardHeader>
     <CardContent class="space-y-3">
       <div class="flex items-center justify-between">
@@ -125,7 +136,7 @@ function confirmClearChat() {
         <Input
           :model-value="draftMessage"
           disabled
-          placeholder="NDJSON streaming send/receive wiring will attach here."
+          :placeholder="inputPlaceholder"
           @update:model-value="(value) => emit('update:draftMessage', value)"
         />
         <Button variant="outline" :disabled="clearing || loading" @click="clearConfirmOpen = true">
@@ -141,7 +152,7 @@ function confirmClearChat() {
       <AlertDialogHeader>
         <AlertDialogTitle>Clear conversation?</AlertDialogTitle>
         <AlertDialogDescription>
-          This starts a fresh server-side session timeline for the current mode.
+          This starts a fresh server-side session timeline while keeping the selected graph management mode.
         </AlertDialogDescription>
       </AlertDialogHeader>
       <AlertDialogFooter>

--- a/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
+++ b/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
@@ -32,6 +32,15 @@ import {
   stepStatusTintClass,
   type WorkspaceStepId,
 } from '@/utils/kgManageWorkspace'
+import {
+  appendLocalChatMessage,
+  buildTransitionRestrictionReason,
+  handleActivatableKeydown,
+  isForbiddenHttpError,
+  resolveForbiddenReason,
+  resolveSectionState,
+  shouldApplyMutationResult,
+} from '@/utils/kgManageState'
 
 interface WorkspaceReadinessStatus {
   has_minimum_entity_types: boolean
@@ -121,16 +130,24 @@ const kgIdentity = ref<KnowledgeGraphIdentity | null>(null)
 const dataSourceCount = ref(0)
 const maintenanceReadyCount = ref(0)
 const loading = ref(false)
+const workspaceLoadError = ref<string | null>(null)
+const workspaceForbidden = ref(false)
+const workspaceForbiddenReason = ref<string | null>(null)
 const validating = ref(false)
 const transitioning = ref(false)
 const sessionLoading = ref(false)
 const sessionHistoryLoading = ref(false)
+const sessionLoadError = ref<string | null>(null)
+const sessionForbidden = ref(false)
+const sessionForbiddenReason = ref<string | null>(null)
 const clearingChat = ref(false)
+const sendingChat = ref(false)
 const extractionSession = ref<ExtractionSessionResponse | null>(null)
 const sessionHistory = ref<ExtractionSessionHistoryItem[]>([])
 const draftMessage = ref('')
 const statusProjection = ref<WorkspaceStatusResponse | null>(null)
 const mutationLogLoading = ref(false)
+const mutationLogLoadError = ref<string | null>(null)
 const mutationLogRuns = ref<MutationLogRunView[]>([])
 const selectedMutationLogRunId = ref<string | null>(null)
 const graphManagementMode = ref<GraphManagementMode>('initial-schema-design')
@@ -213,6 +230,47 @@ const selectedRailItem = computed(() =>
 const canTransition = computed(() =>
   statusProjection.value?.workspace_mode === 'schema_bootstrap'
   && statusProjection.value?.transition_eligible === true,
+)
+
+const transitionRestrictionReason = computed(() =>
+  buildTransitionRestrictionReason(
+    canTransition.value,
+    statusProjection.value?.readiness.blocking_reasons ?? [],
+  ),
+)
+
+const workspaceOverviewState = computed(() =>
+  resolveSectionState({
+    section: 'workspace-overview',
+    loading: loading.value,
+    error: workspaceLoadError.value,
+    forbidden: workspaceForbidden.value,
+    forbiddenReason: workspaceForbiddenReason.value,
+  }),
+)
+
+const mutationLogsSectionState = computed(() =>
+  resolveSectionState({
+    section: 'mutation-logs',
+    loading: mutationLogLoading.value,
+    error: mutationLogLoadError.value,
+    forbidden: workspaceForbidden.value,
+    forbiddenReason: workspaceForbiddenReason.value,
+    empty: !mutationLogLoading.value
+      && !mutationLogLoadError.value
+      && mutationLogRuns.value.length === 0,
+    emptyActionLabel: 'Refresh runs',
+  }),
+)
+
+const graphManagementSectionState = computed(() =>
+  resolveSectionState({
+    section: 'graph-management',
+    loading: sessionLoading.value,
+    error: sessionLoadError.value,
+    forbidden: sessionForbidden.value,
+    forbiddenReason: sessionForbiddenReason.value,
+  }),
 )
 
 const selectedMutationLogRun = computed(() =>
@@ -314,15 +372,30 @@ function returnToWorkspaceOverview() {
 async function loadWorkspaceStatus() {
   if (!hasTenant.value || !kgId.value) return
   loading.value = true
+  workspaceLoadError.value = null
   try {
     statusProjection.value = await apiFetch<WorkspaceStatusResponse>(
       `/management/knowledge-graphs/${kgId.value}/workspace-status`,
     )
+    workspaceForbidden.value = false
+    workspaceForbiddenReason.value = null
   } catch (err) {
-    statusProjection.value = null
-    toast.error('Failed to load knowledge graph workspace', {
-      description: extractErrorMessage(err),
-    })
+    if (isForbiddenHttpError(err)) {
+      workspaceForbidden.value = true
+      workspaceForbiddenReason.value = resolveForbiddenReason(
+        err,
+        'You do not have permission to view this knowledge graph workspace.',
+      )
+      statusProjection.value = null
+    } else {
+      workspaceForbidden.value = false
+      workspaceForbiddenReason.value = null
+      statusProjection.value = null
+      workspaceLoadError.value = extractErrorMessage(err)
+      toast.error('Failed to load knowledge graph workspace', {
+        description: workspaceLoadError.value,
+      })
+    }
   } finally {
     loading.value = false
   }
@@ -331,6 +404,7 @@ async function loadWorkspaceStatus() {
 async function loadMutationLogRuns() {
   if (!hasTenant.value || !kgId.value) return
   mutationLogLoading.value = true
+  mutationLogLoadError.value = null
   try {
     const dataSources = await apiFetch<DataSourceRef[]>(
       `/management/knowledge-graphs/${kgId.value}/data-sources`,
@@ -365,11 +439,19 @@ async function loadMutationLogRuns() {
       selectedMutationLogRunId.value = collected[0]?.id ?? null
     }
   } catch (err) {
+    if (isForbiddenHttpError(err)) {
+      mutationLogLoadError.value = resolveForbiddenReason(
+        err,
+        'You do not have permission to view mutation logs for this graph.',
+      )
+    } else {
+      mutationLogLoadError.value = extractErrorMessage(err)
+      toast.error('Failed to load mutation log runs', {
+        description: mutationLogLoadError.value,
+      })
+    }
     mutationLogRuns.value = []
     selectedMutationLogRunId.value = null
-    toast.error('Failed to load mutation log runs', {
-      description: extractErrorMessage(err),
-    })
   } finally {
     mutationLogLoading.value = false
   }
@@ -378,15 +460,29 @@ async function loadMutationLogRuns() {
 async function loadExtractionSession() {
   if (!kgId.value || activeStep.value !== 'graph-management') return
   sessionLoading.value = true
+  sessionLoadError.value = null
   try {
     extractionSession.value = await apiFetch<ExtractionSessionResponse>(
       `/extraction/knowledge-graphs/${kgId.value}/sessions/${sharedSessionMode.value}/active`,
     )
+    sessionForbidden.value = false
+    sessionForbiddenReason.value = null
   } catch (err) {
     extractionSession.value = null
-    toast.error('Failed to load extraction conversation', {
-      description: extractErrorMessage(err),
-    })
+    if (isForbiddenHttpError(err)) {
+      sessionForbidden.value = true
+      sessionForbiddenReason.value = resolveForbiddenReason(
+        err,
+        'You do not have permission to manage this knowledge graph.',
+      )
+    } else {
+      sessionForbidden.value = false
+      sessionForbiddenReason.value = null
+      sessionLoadError.value = extractErrorMessage(err)
+      toast.error('Failed to load extraction conversation', {
+        description: sessionLoadError.value,
+      })
+    }
   } finally {
     sessionLoading.value = false
   }
@@ -439,14 +535,54 @@ function selectRailItem(itemId: GraphManagementRailItemId) {
 }
 
 function onRailKeydown(event: KeyboardEvent, itemId: GraphManagementRailItemId) {
-  if (event.key === 'Enter' || event.key === ' ') {
-    event.preventDefault()
-    selectRailItem(itemId)
+  handleActivatableKeydown(event, () => selectRailItem(itemId))
+}
+
+function onStepActionKeydown(event: KeyboardEvent, stepId: WorkspaceStepId) {
+  handleActivatableKeydown(event, () => openWorkspaceStep(stepId))
+}
+
+function onModeSwitchKeydown(event: KeyboardEvent, mode: GraphManagementMode) {
+  handleActivatableKeydown(event, () => setGraphManagementMode(mode))
+}
+
+function selectMutationLogRun(runId: string) {
+  selectedMutationLogRunId.value = runId
+}
+
+function onMutationRunKeydown(event: KeyboardEvent, runId: string) {
+  handleActivatableKeydown(event, () => selectMutationLogRun(runId))
+}
+
+function sendChatMessage(message: string) {
+  if (sessionForbidden.value || !shouldApplyMutationResult(sessionForbidden.value)) {
+    toast.error('Chat unavailable', {
+      description: sessionForbiddenReason.value
+        ?? 'You do not have permission to send messages for this knowledge graph.',
+    })
+    return
+  }
+
+  sendingChat.value = true
+  try {
+    const nextHistory = appendLocalChatMessage(extractionSession.value, message)
+    extractionSession.value = {
+      ...(extractionSession.value ?? {
+        id: 'local-session',
+        runtime_context: {},
+        updated_at: new Date().toISOString(),
+      }),
+      message_history: nextHistory,
+      updated_at: new Date().toISOString(),
+    }
+    draftMessage.value = ''
+  } finally {
+    sendingChat.value = false
   }
 }
 
 async function validateWorkspace() {
-  if (!kgId.value) return
+  if (!kgId.value || workspaceForbidden.value) return
   validating.value = true
   try {
     statusProjection.value = await apiFetch<WorkspaceStatusResponse>(
@@ -455,17 +591,26 @@ async function validateWorkspace() {
     )
     toast.success('Workspace validation complete')
   } catch (err) {
-    toast.error('Validation failed', {
-      description: extractErrorMessage(err),
-    })
+    if (isForbiddenHttpError(err)) {
+      workspaceForbidden.value = true
+      workspaceForbiddenReason.value = resolveForbiddenReason(
+        err,
+        'You do not have permission to validate this workspace.',
+      )
+    } else {
+      toast.error('Validation failed', {
+        description: extractErrorMessage(err),
+      })
+    }
   } finally {
     validating.value = false
   }
 }
 
 async function transitionToExtraction() {
-  if (!kgId.value || !canTransition.value) return
+  if (!kgId.value || !canTransition.value || workspaceForbidden.value) return
   transitioning.value = true
+  const previousStatus = statusProjection.value
   try {
     statusProjection.value = await apiFetch<WorkspaceStatusResponse>(
       `/management/knowledge-graphs/${kgId.value}/workspace/transition-to-extraction`,
@@ -474,9 +619,18 @@ async function transitionToExtraction() {
     toast.success('Workspace transitioned to extraction operations')
     await loadExtractionSession()
   } catch (err) {
-    toast.error('Transition failed', {
-      description: extractErrorMessage(err),
-    })
+    statusProjection.value = previousStatus
+    if (isForbiddenHttpError(err)) {
+      workspaceForbidden.value = true
+      workspaceForbiddenReason.value = resolveForbiddenReason(
+        err,
+        'You do not have permission to transition this workspace.',
+      )
+    } else {
+      toast.error('Transition failed', {
+        description: extractErrorMessage(err),
+      })
+    }
   } finally {
     transitioning.value = false
   }
@@ -484,7 +638,7 @@ async function transitionToExtraction() {
 
 async function clearChat() {
   // Clear chat resets the active extraction session for this knowledge graph.
-  if (!kgId.value) return
+  if (!kgId.value || sessionForbidden.value) return
   clearingChat.value = true
   try {
     extractionSession.value = await apiFetch<ExtractionSessionResponse>(
@@ -515,6 +669,13 @@ watch(tenantVersion, () => {
   extractionSession.value = null
   dataSourceCount.value = 0
   maintenanceReadyCount.value = 0
+  workspaceLoadError.value = null
+  workspaceForbidden.value = false
+  workspaceForbiddenReason.value = null
+  mutationLogLoadError.value = null
+  sessionLoadError.value = null
+  sessionForbidden.value = false
+  sessionForbiddenReason.value = null
   loadKgIdentity()
   loadWorkspaceStatus()
   loadOverviewMetrics()
@@ -579,9 +740,34 @@ watch(
       Select a tenant to manage this workspace.
     </div>
 
-    <div v-else-if="loading" class="flex items-center gap-2 text-sm text-muted-foreground">
+    <div
+      v-else-if="workspaceOverviewState.phase === 'loading'"
+      class="flex items-center gap-2 text-sm text-muted-foreground"
+      role="status"
+    >
       <Loader2 class="size-4 animate-spin" />
-      Loading workspace status...
+      {{ workspaceOverviewState.message }}
+    </div>
+
+    <div
+      v-else-if="workspaceOverviewState.phase === 'forbidden'"
+      class="rounded-lg border border-destructive/40 bg-destructive/5 p-6 text-sm"
+      role="alert"
+    >
+      <p class="font-medium text-destructive">{{ workspaceOverviewState.title }}</p>
+      <p class="mt-1 text-muted-foreground">{{ workspaceOverviewState.message }}</p>
+    </div>
+
+    <div
+      v-else-if="workspaceOverviewState.phase === 'error'"
+      class="rounded-lg border border-dashed p-6 text-sm"
+      role="alert"
+    >
+      <p class="font-medium">{{ workspaceOverviewState.title }}</p>
+      <p class="mt-1 text-muted-foreground">{{ workspaceOverviewState.message }}</p>
+      <Button class="mt-3" size="sm" variant="outline" @click="loadWorkspaceStatus">
+        Retry workspace load
+      </Button>
     </div>
 
     <template v-else-if="statusProjection">
@@ -624,7 +810,9 @@ watch(
               <Button
                 class="w-full"
                 variant="outline"
+                tabindex="0"
                 @click="openWorkspaceStep(card.id)"
+                @keydown="onStepActionKeydown($event, card.id)"
               >
                 {{ card.actionLabel }}
               </Button>
@@ -634,7 +822,26 @@ watch(
       </section>
 
       <section v-else-if="activeStep === 'mutation-logs'" class="space-y-4">
-        <Card>
+        <div
+          v-if="mutationLogsSectionState.phase === 'forbidden'"
+          class="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm"
+          role="alert"
+        >
+          <p class="font-medium text-destructive">{{ mutationLogsSectionState.title }}</p>
+          <p class="mt-1 text-muted-foreground">{{ mutationLogsSectionState.message }}</p>
+        </div>
+        <div
+          v-else-if="mutationLogsSectionState.phase === 'error'"
+          class="rounded-lg border border-dashed p-4 text-sm"
+          role="alert"
+        >
+          <p class="font-medium">{{ mutationLogsSectionState.title }}</p>
+          <p class="mt-1 text-muted-foreground">{{ mutationLogsSectionState.message }}</p>
+          <Button class="mt-3" size="sm" variant="outline" @click="loadMutationLogRuns">
+            Retry mutation log load
+          </Button>
+        </div>
+        <Card v-else>
           <CardHeader>
             <CardTitle class="text-base">MutationLogs</CardTitle>
             <CardDescription>
@@ -649,20 +856,29 @@ watch(
                   Refresh
                 </Button>
               </div>
-              <div v-if="mutationLogLoading" class="flex items-center gap-2 px-3 py-4 text-xs text-muted-foreground">
+              <div v-if="mutationLogLoading" class="flex items-center gap-2 px-3 py-4 text-xs text-muted-foreground" role="status">
                 <Loader2 class="size-3.5 animate-spin" />
-                Loading mutation runs...
+                {{ mutationLogsSectionState.message }}
               </div>
-              <div v-else-if="mutationLogRuns.length === 0" class="px-3 py-4 text-xs text-muted-foreground">
-                No mutation log runs found for this knowledge graph yet.
+              <div
+                v-else-if="mutationLogRuns.length === 0"
+                class="space-y-2 px-3 py-4 text-xs text-muted-foreground"
+              >
+                <p>{{ mutationLogsSectionState.message }}</p>
+                <Button size="sm" variant="outline" @click="loadMutationLogRuns">
+                  {{ mutationLogsSectionState.actionLabel ?? 'Refresh runs' }}
+                </Button>
               </div>
               <div v-else class="max-h-64 overflow-auto p-2 space-y-1.5">
                 <button
                   v-for="run in mutationLogRuns"
                   :key="run.id"
-                  class="w-full rounded border px-2 py-1.5 text-left text-xs transition-colors"
+                  type="button"
+                  tabindex="0"
+                  class="w-full rounded border px-2 py-1.5 text-left text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   :class="selectedMutationLogRunId === run.id ? 'border-primary bg-primary/5' : 'hover:bg-muted/40'"
-                  @click="selectedMutationLogRunId = run.id"
+                  @click="selectMutationLogRun(run.id)"
+                  @keydown="onMutationRunKeydown($event, run.id)"
                 >
                   <p class="font-medium truncate">{{ run.data_source_name }}</p>
                   <p class="text-muted-foreground truncate">{{ new Date(run.started_at).toLocaleString() }}</p>
@@ -743,6 +959,18 @@ watch(
       </section>
 
       <section v-else-if="activeStep === 'graph-management'" class="space-y-4">
+        <div
+          v-if="graphManagementSectionState.phase === 'error'"
+          class="rounded-lg border border-dashed p-4 text-sm"
+          role="alert"
+        >
+          <p class="font-medium">{{ graphManagementSectionState.title }}</p>
+          <p class="mt-1 text-muted-foreground">{{ graphManagementSectionState.message }}</p>
+          <Button class="mt-3" size="sm" variant="outline" @click="loadExtractionSession">
+            Retry session load
+          </Button>
+        </div>
+
         <Card class="graph-management-controls">
           <CardHeader class="pb-3">
             <CardTitle class="text-base">Graph Management</CardTitle>
@@ -751,13 +979,21 @@ watch(
             </CardDescription>
           </CardHeader>
           <CardContent class="space-y-3">
-            <div class="flex flex-wrap gap-2">
+            <div
+              class="flex flex-wrap gap-2"
+              role="tablist"
+              aria-label="Graph management modes"
+            >
               <Button
                 v-for="mode in GRAPH_MANAGEMENT_MODE_ORDER"
                 :key="mode"
                 size="sm"
+                role="tab"
+                :aria-selected="graphManagementMode === mode"
+                tabindex="0"
                 :variant="graphManagementMode === mode ? 'default' : 'outline'"
                 @click="setGraphManagementMode(mode)"
+                @keydown="onModeSwitchKeydown($event, mode)"
               >
                 {{ GRAPH_MANAGEMENT_MODE_LABELS[mode] }}
               </Button>
@@ -767,7 +1003,8 @@ watch(
               <Button
                 variant="outline"
                 size="sm"
-                :disabled="validating || transitioning"
+                :disabled="validating || transitioning || workspaceForbidden"
+                :title="workspaceForbiddenReason ?? undefined"
                 @click="validateWorkspace"
               >
                 <Loader2 v-if="validating" class="mr-1.5 size-3.5 animate-spin" />
@@ -789,9 +1026,15 @@ watch(
           :session="extractionSession"
           :loading="sessionLoading"
           :clearing="clearingChat"
+          :sending="sendingChat"
           :activity-lines="sessionActivityLines"
+          :forbidden="sessionForbidden"
+          :forbidden-reason="sessionForbiddenReason"
+          :input-disabled="workspaceForbidden"
+          :input-disabled-reason="workspaceForbiddenReason"
           @refresh="loadExtractionSession"
           @clear-chat="clearChat"
+          @send-message="sendChatMessage"
         />
 
         <div class="grid gap-4 xl:grid-cols-[280px_1fr]">
@@ -864,13 +1107,14 @@ watch(
                   </div>
                 </div>
                 <div class="flex flex-wrap gap-2">
-                  <Button variant="outline" :disabled="validating || transitioning" @click="validateWorkspace">
+                  <Button variant="outline" :disabled="validating || transitioning || workspaceForbidden" @click="validateWorkspace">
                     <Loader2 v-if="validating" class="mr-1.5 size-3.5 animate-spin" />
                     <CheckCircle2 v-else class="mr-1.5 size-3.5" />
                     Validate
                   </Button>
                   <Button
-                    :disabled="!canTransition || transitioning || validating"
+                    :disabled="!canTransition || transitioning || validating || workspaceForbidden"
+                    :title="transitionRestrictionReason ?? undefined"
                     @click="transitionToExtraction"
                   >
                     <Loader2 v-if="transitioning" class="mr-1.5 size-3.5 animate-spin" />

--- a/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
+++ b/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
@@ -6,8 +6,21 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import SharedConversationPanel from '@/components/extraction/SharedConversationPanel.vue'
+import {
+  GRAPH_MANAGEMENT_INPUT_PLACEHOLDERS,
+  GRAPH_MANAGEMENT_MODE_LABELS,
+  GRAPH_MANAGEMENT_MODE_ORDER,
+  buildGraphManagementRailItems,
+  buildGraphManagementStepUrl,
+  filterRailItemsForMode,
+  parseGraphManagementModeQuery,
+  resolveDefaultGraphManagementMode,
+  resolveRailSelectionForMode,
+  resolveSharedSessionMode,
+  type GraphManagementMode,
+  type GraphManagementRailItemId,
+} from '@/utils/kgGraphManagement'
 import {
   buildDataSourcesStepUrl,
   buildMaintainStepUrl,
@@ -115,12 +128,13 @@ const sessionHistoryLoading = ref(false)
 const clearingChat = ref(false)
 const extractionSession = ref<ExtractionSessionResponse | null>(null)
 const sessionHistory = ref<ExtractionSessionHistoryItem[]>([])
-const extractionTab = ref('extraction-jobs')
 const draftMessage = ref('')
 const statusProjection = ref<WorkspaceStatusResponse | null>(null)
 const mutationLogLoading = ref(false)
 const mutationLogRuns = ref<MutationLogRunView[]>([])
 const selectedMutationLogRunId = ref<string | null>(null)
+const graphManagementMode = ref<GraphManagementMode>('initial-schema-design')
+const selectedRailItemId = ref<GraphManagementRailItemId | null>(null)
 
 const activeStep = computed(() => parseManageStepQuery(route.query.step))
 const showOverview = computed(() => activeStep.value === null)
@@ -146,10 +160,54 @@ const modeLabel = computed(() =>
     : 'Schema Bootstrap',
 )
 
-const sessionMode = computed<'schema_bootstrap' | 'extraction_operations'>(() =>
-  statusProjection.value?.workspace_mode === 'extraction_operations'
-    ? 'extraction_operations'
-    : 'schema_bootstrap',
+const stepBadgeLabel = computed(() => {
+  if (activeStep.value === 'graph-management') {
+    return graphManagementModeLabel.value
+  }
+  return modeLabel.value
+})
+
+const sharedSessionMode = computed<'schema_bootstrap' | 'extraction_operations'>(() =>
+  resolveSharedSessionMode(
+    statusProjection.value?.workspace_mode ?? 'schema_bootstrap',
+  ),
+)
+
+const graphManagementModeLabel = computed(
+  () => GRAPH_MANAGEMENT_MODE_LABELS[graphManagementMode.value],
+)
+
+const graphManagementInputPlaceholder = computed(
+  () => GRAPH_MANAGEMENT_INPUT_PLACEHOLDERS[graphManagementMode.value],
+)
+
+const sessionStatusLabel = computed(() => {
+  if (sessionLoading.value) return 'Loading session'
+  if (clearingChat.value) return 'Resetting chat'
+  if (extractionSession.value?.id) {
+    return `Active · ${extractionSession.value.id.slice(0, 8)}`
+  }
+  return 'No active session'
+})
+
+const graphManagementRailItems = computed(() => {
+  if (!statusProjection.value) return []
+  return buildGraphManagementRailItems({
+    workspaceMode: statusProjection.value.workspace_mode,
+    transitionEligible: statusProjection.value.transition_eligible,
+    blockingReasonCount: statusProjection.value.readiness.blocking_reasons.length,
+    prepopulatedGapCount: statusProjection.value.readiness.prepopulated_types_without_instances.length,
+    sessionUpdatedAt: extractionSession.value?.updated_at ?? null,
+    hasActiveSession: Boolean(extractionSession.value?.id),
+  })
+})
+
+const visibleRailItems = computed(() =>
+  filterRailItemsForMode(graphManagementRailItems.value, graphManagementMode.value),
+)
+
+const selectedRailItem = computed(() =>
+  visibleRailItems.value.find((item) => item.id === selectedRailItemId.value) ?? null,
 )
 
 const canTransition = computed(() =>
@@ -318,11 +376,11 @@ async function loadMutationLogRuns() {
 }
 
 async function loadExtractionSession() {
-  if (!kgId.value) return
+  if (!kgId.value || activeStep.value !== 'graph-management') return
   sessionLoading.value = true
   try {
     extractionSession.value = await apiFetch<ExtractionSessionResponse>(
-      `/extraction/knowledge-graphs/${kgId.value}/sessions/${sessionMode.value}/active`,
+      `/extraction/knowledge-graphs/${kgId.value}/sessions/${sharedSessionMode.value}/active`,
     )
   } catch (err) {
     extractionSession.value = null
@@ -339,7 +397,7 @@ async function loadSessionHistory() {
   sessionHistoryLoading.value = true
   try {
     const response = await apiFetch<{ sessions: ExtractionSessionHistoryItem[] }>(
-      `/extraction/knowledge-graphs/${kgId.value}/sessions/${sessionMode.value}/history`,
+      `/extraction/knowledge-graphs/${kgId.value}/sessions/${sharedSessionMode.value}/history`,
     )
     sessionHistory.value = response.sessions
   } catch (err) {
@@ -349,6 +407,41 @@ async function loadSessionHistory() {
     })
   } finally {
     sessionHistoryLoading.value = false
+  }
+}
+
+function syncGraphManagementState() {
+  if (activeStep.value !== 'graph-management') return
+  const fromQuery = parseGraphManagementModeQuery(route.query.gm_mode)
+  graphManagementMode.value = fromQuery
+    ?? resolveDefaultGraphManagementMode(
+      statusProjection.value?.workspace_mode ?? 'schema_bootstrap',
+    )
+  selectedRailItemId.value = resolveRailSelectionForMode(
+    selectedRailItemId.value,
+    graphManagementMode.value,
+    graphManagementRailItems.value,
+  )
+}
+
+function setGraphManagementMode(mode: GraphManagementMode) {
+  graphManagementMode.value = mode
+  selectedRailItemId.value = resolveRailSelectionForMode(
+    selectedRailItemId.value,
+    mode,
+    graphManagementRailItems.value,
+  )
+  navigateTo(buildGraphManagementStepUrl(kgId.value, mode), { replace: true })
+}
+
+function selectRailItem(itemId: GraphManagementRailItemId) {
+  selectedRailItemId.value = itemId
+}
+
+function onRailKeydown(event: KeyboardEvent, itemId: GraphManagementRailItemId) {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    selectRailItem(itemId)
   }
 }
 
@@ -395,7 +488,7 @@ async function clearChat() {
   clearingChat.value = true
   try {
     extractionSession.value = await apiFetch<ExtractionSessionResponse>(
-      `/extraction/knowledge-graphs/${kgId.value}/sessions/${sessionMode.value}/clear-chat`,
+      `/extraction/knowledge-graphs/${kgId.value}/sessions/${sharedSessionMode.value}/clear-chat`,
       { method: 'POST' },
     )
     toast.success('Extraction chat cleared')
@@ -430,8 +523,19 @@ watch(tenantVersion, () => {
 
 watch(
   () => statusProjection.value?.workspace_mode,
-  (mode) => {
-    if (mode) {
+  () => {
+    if (activeStep.value === 'graph-management') {
+      syncGraphManagementState()
+      loadExtractionSession()
+    }
+  },
+)
+
+watch(
+  () => [activeStep.value, route.query.gm_mode] as const,
+  () => {
+    if (activeStep.value === 'graph-management') {
+      syncGraphManagementState()
       loadExtractionSession()
       loadSessionHistory()
     }
@@ -445,14 +549,17 @@ watch(
       <div class="space-y-1">
         <div class="flex items-center gap-2">
           <h1 class="text-2xl font-semibold tracking-tight">{{ graphHeaderTitle }}</h1>
-          <Badge v-if="!showOverview" variant="secondary">{{ modeLabel }}</Badge>
+          <Badge v-if="!showOverview" variant="secondary">{{ stepBadgeLabel }}</Badge>
         </div>
         <p class="text-sm text-muted-foreground">
           <template v-if="showOverview">
             Project workspace for knowledge graph {{ kgId }}.
           </template>
+          <template v-else-if="activeStep === 'graph-management'">
+            Conversation-first graph management with shared session and mode-specific workspace panels.
+          </template>
           <template v-else>
-            Validate readiness and move from schema bootstrap to extraction operations.
+            Knowledge-graph scoped mutation run visibility and run metrics.
           </template>
         </p>
       </div>
@@ -635,238 +742,50 @@ watch(
         </Card>
       </section>
 
-      <section v-else class="space-y-6">
-      <Card>
-        <CardHeader>
-          <CardTitle class="text-base">Mode & Transition Controls</CardTitle>
-          <CardDescription>
-            Validate current readiness and transition when eligible.
-          </CardDescription>
-        </CardHeader>
-        <CardContent class="flex flex-wrap gap-2">
-          <Button variant="outline" :disabled="validating || transitioning" @click="validateWorkspace">
-            <Loader2 v-if="validating" class="mr-1.5 size-3.5 animate-spin" />
-            <CheckCircle2 v-else class="mr-1.5 size-3.5" />
-            Validate
-          </Button>
-          <Button
-            :disabled="!canTransition || transitioning || validating"
-            @click="transitionToExtraction"
-          >
-            <Loader2 v-if="transitioning" class="mr-1.5 size-3.5 animate-spin" />
-            <PlayCircle v-else class="mr-1.5 size-3.5" />
-            Go to Extraction/Mutations
-          </Button>
-          <Badge :variant="canTransition ? 'default' : 'secondary'">
-            {{ canTransition ? 'Transition eligible' : 'Transition blocked' }}
-          </Badge>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle class="text-base">Readiness Results</CardTitle>
-          <CardDescription>
-            Bootstrap readiness requirements from workspace validation.
-          </CardDescription>
-        </CardHeader>
-        <CardContent class="space-y-4 text-sm">
-          <div class="rounded border p-3">
-            <p class="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Bootstrap Progress Checklist
-            </p>
-            <div class="space-y-2">
-              <div
-                v-for="item in progressChecklist"
-                :key="item.id"
-                class="rounded border px-3 py-2"
+      <section v-else-if="activeStep === 'graph-management'" class="space-y-4">
+        <Card class="graph-management-controls">
+          <CardHeader class="pb-3">
+            <CardTitle class="text-base">Graph Management</CardTitle>
+            <CardDescription>
+              Shared chat session with mode-specific assistant framing and workspace panels.
+            </CardDescription>
+          </CardHeader>
+          <CardContent class="space-y-3">
+            <div class="flex flex-wrap gap-2">
+              <Button
+                v-for="mode in GRAPH_MANAGEMENT_MODE_ORDER"
+                :key="mode"
+                size="sm"
+                :variant="graphManagementMode === mode ? 'default' : 'outline'"
+                @click="setGraphManagementMode(mode)"
               >
-                <div class="flex items-center justify-between">
-                  <p class="font-medium">{{ item.label }}</p>
-                  <Badge :variant="item.passed ? 'default' : 'destructive'">
-                    {{ item.passed ? 'Pass' : 'Fail' }}
-                  </Badge>
-                </div>
-                <p class="mt-1 text-xs text-muted-foreground">
-                  {{ item.passed ? item.passDetail : item.failDetail }}
-                </p>
-              </div>
+                {{ GRAPH_MANAGEMENT_MODE_LABELS[mode] }}
+              </Button>
             </div>
-          </div>
-
-          <div class="flex items-center justify-between rounded border px-3 py-2">
-            <span>Has minimum entity types</span>
-            <Badge :variant="statusProjection.readiness.has_minimum_entity_types ? 'default' : 'destructive'">
-              {{ statusProjection.readiness.has_minimum_entity_types ? 'Yes' : 'No' }}
-            </Badge>
-          </div>
-          <div class="flex items-center justify-between rounded border px-3 py-2">
-            <span>Has minimum relationship types</span>
-            <Badge :variant="statusProjection.readiness.has_minimum_relationship_types ? 'default' : 'destructive'">
-              {{ statusProjection.readiness.has_minimum_relationship_types ? 'Yes' : 'No' }}
-            </Badge>
-          </div>
-          <div class="flex items-center justify-between rounded border px-3 py-2">
-            <span>Prepopulated types ready</span>
-            <Badge :variant="statusProjection.readiness.prepopulated_types_ready ? 'default' : 'destructive'">
-              {{ statusProjection.readiness.prepopulated_types_ready ? 'Yes' : 'No' }}
-            </Badge>
-          </div>
-
-          <div class="rounded border p-3">
-            <p class="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Validation Diagnostics
-            </p>
-            <div
-              v-if="statusProjection.readiness.prepopulated_types_without_instances.length > 0"
-              class="rounded border border-amber-400/60 bg-amber-50/60 p-2 text-xs dark:border-amber-800 dark:bg-amber-950/20"
-            >
-              <p class="font-medium text-amber-800 dark:text-amber-300">
-                Prepopulated types missing instances
-              </p>
-              <ul class="mt-1 list-disc space-y-1 pl-4 text-muted-foreground">
-                <li
-                  v-for="typeLabel in statusProjection.readiness.prepopulated_types_without_instances"
-                  :key="typeLabel"
-                >
-                  {{ typeLabel }}
-                </li>
-              </ul>
-            </div>
-
-            <div v-if="statusProjection.readiness.blocking_reasons.length > 0" class="mt-2 rounded border border-destructive/50 p-3">
-              <p class="mb-1 text-xs font-medium text-destructive flex items-center gap-1.5">
-                <ShieldAlert class="size-3.5" />
-                Blocking reasons
-              </p>
-              <ul class="list-disc pl-4 text-xs text-muted-foreground space-y-1">
-                <li v-for="reason in statusProjection.readiness.blocking_reasons" :key="reason">
-                  {{ reason }}
-                </li>
-              </ul>
-            </div>
-            <p
-              v-else-if="statusProjection.readiness.prepopulated_types_without_instances.length === 0"
-              class="text-xs text-muted-foreground"
-            >
-              No validation diagnostics are currently blocking transition.
-            </p>
-          </div>
-
-          <div class="rounded border p-3">
-            <p class="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Next Steps
-            </p>
-            <ul class="list-disc pl-4 text-xs text-muted-foreground space-y-1">
-              <li v-for="step in nextSteps" :key="step">{{ step }}</li>
-            </ul>
-          </div>
-
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle class="text-base">Session Pointers</CardTitle>
-          <CardDescription>
-            Active and recent extraction session references for this knowledge graph.
-          </CardDescription>
-        </CardHeader>
-        <CardContent class="grid gap-2 md:grid-cols-3 text-xs">
-          <div class="rounded border px-3 py-2">
-            <p class="text-muted-foreground">Active schema bootstrap session</p>
-            <p class="font-mono break-all mt-1">
-              {{ statusProjection.session_pointers.active_schema_bootstrap_session_id ?? 'None' }}
-            </p>
-          </div>
-          <div class="rounded border px-3 py-2">
-            <p class="text-muted-foreground">Active extraction operations session</p>
-            <p class="font-mono break-all mt-1">
-              {{ statusProjection.session_pointers.active_extraction_operations_session_id ?? 'None' }}
-            </p>
-          </div>
-          <div class="rounded border px-3 py-2">
-            <p class="text-muted-foreground">Most recent completed session</p>
-            <p class="font-mono break-all mt-1">
-              {{ statusProjection.session_pointers.most_recent_completed_session_id ?? 'None' }}
-            </p>
-          </div>
-        </CardContent>
-        <CardContent class="space-y-3 border-t pt-4">
-          <div class="flex items-center justify-between">
-            <p class="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Session History
-            </p>
-            <Button
-              size="sm"
-              variant="ghost"
-              class="h-6 px-2 text-[10px]"
-              :disabled="sessionHistoryLoading"
-              @click="loadSessionHistory"
-            >
-              Refresh
-            </Button>
-          </div>
-          <div
-            v-if="sessionHistoryLoading"
-            class="flex items-center gap-2 text-xs text-muted-foreground"
-          >
-            <Loader2 class="size-3.5 animate-spin" />
-            Loading session history...
-          </div>
-          <div
-            v-else-if="sessionHistory.length === 0"
-            class="rounded border border-dashed px-3 py-4 text-xs text-muted-foreground"
-          >
-            No archived or active sessions found for this scope yet.
-          </div>
-          <div v-else class="space-y-2">
-            <div
-              v-for="entry in sessionHistory"
-              :key="entry.id"
-              class="rounded border px-3 py-2 text-xs"
-            >
-              <div class="flex flex-wrap items-center justify-between gap-2">
-                <p class="font-mono break-all">{{ entry.id }}</p>
-                <Badge :variant="entry.is_active ? 'default' : 'secondary'">
-                  {{ entry.is_active ? 'Active' : 'Archived' }}
-                </Badge>
-              </div>
-              <p class="mt-1 text-muted-foreground">
-                Updated {{ new Date(entry.updated_at).toLocaleString() }}
-                <span v-if="entry.archived_at">
-                  · Archived {{ new Date(entry.archived_at).toLocaleString() }}
-                </span>
-              </p>
-              <p class="mt-1 text-muted-foreground">
-                {{ entry.message_count }} message(s)
-                · {{ entry.run_metrics.length }} linked run(s)
-              </p>
-              <div
-                v-if="entry.run_metrics.length > 0"
-                class="mt-2 space-y-1.5 rounded border bg-muted/20 p-2"
+            <div class="flex flex-wrap items-center gap-2">
+              <Badge variant="outline">{{ sessionStatusLabel }}</Badge>
+              <Button
+                variant="outline"
+                size="sm"
+                :disabled="validating || transitioning"
+                @click="validateWorkspace"
               >
-                <div
-                  v-for="metric in entry.run_metrics"
-                  :key="metric.sync_run_id"
-                  class="flex flex-wrap items-center justify-between gap-2"
-                >
-                  <span class="font-mono">{{ metric.mutation_log_id ?? metric.sync_run_id }}</span>
-                  <span class="text-muted-foreground">
-                    {{ metric.token_usage_total ?? 0 }} tokens ·
-                    ${{ (metric.cost_total_usd ?? 0).toFixed(2) }}
-                  </span>
-                </div>
-              </div>
+                <Loader2 v-if="validating" class="mr-1.5 size-3.5 animate-spin" />
+                <CheckCircle2 v-else class="mr-1.5 size-3.5" />
+                Validate
+              </Button>
+              <Badge :variant="canTransition ? 'default' : 'secondary'">
+                {{ canTransition ? 'Transition eligible' : 'Transition blocked' }}
+              </Badge>
             </div>
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
 
-      <div class="space-y-4">
         <SharedConversationPanel
           v-model:draft-message="draftMessage"
-          :mode-label="modeLabel"
+          :mode-label="graphManagementModeLabel"
+          :input-placeholder="graphManagementInputPlaceholder"
+          :session-status-label="sessionStatusLabel"
           :session="extractionSession"
           :loading="sessionLoading"
           :clearing="clearingChat"
@@ -875,154 +794,275 @@ watch(
           @clear-chat="clearChat"
         />
 
-        <Card v-if="statusProjection.workspace_mode === 'extraction_operations'">
-          <CardHeader>
-            <CardTitle class="text-base">Operations Workspace</CardTitle>
-            <CardDescription>
-              Tabbed controls for extraction jobs, manual mutations, and run/log visibility.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Tabs v-model="extractionTab" class="w-full">
-              <TabsList class="grid w-full grid-cols-3">
-                <TabsTrigger value="extraction-jobs">Extraction Jobs</TabsTrigger>
-                <TabsTrigger value="manual-mutations">Manual Mutations</TabsTrigger>
-                <TabsTrigger value="run-logs">Run/Logs</TabsTrigger>
-              </TabsList>
-              <TabsContent value="extraction-jobs" class="mt-3 space-y-2 text-sm">
+        <div class="grid gap-4 xl:grid-cols-[280px_1fr]">
+          <div
+            class="graph-management-rail rounded border"
+            role="listbox"
+            aria-label="Graph management status and artifacts"
+          >
+            <div class="border-b px-3 py-2">
+              <p class="text-xs font-medium text-muted-foreground">Status &amp; artifacts</p>
+            </div>
+            <div class="space-y-1.5 p-2">
+              <button
+                v-for="item in visibleRailItems"
+                :key="item.id"
+                type="button"
+                role="option"
+                :aria-selected="selectedRailItemId === item.id"
+                tabindex="0"
+                class="w-full rounded border px-2 py-2 text-left text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                :class="[
+                  stepStatusTintClass(item.status),
+                  selectedRailItemId === item.id ? 'border-primary ring-1 ring-primary/30' : 'hover:bg-muted/40',
+                ]"
+                @click="selectRailItem(item.id)"
+                @keydown="onRailKeydown($event, item.id)"
+              >
+                <div class="flex items-center justify-between gap-2">
+                  <p class="font-medium">{{ item.label }}</p>
+                  <Badge variant="outline" class="text-[10px]">{{ item.status }}</Badge>
+                </div>
+                <p class="mt-1 text-muted-foreground">{{ item.detailHint }}</p>
+                <p class="mt-1 text-[10px] text-muted-foreground">Updated {{ item.lastUpdated }}</p>
+              </button>
+            </div>
+          </div>
+
+          <Card class="graph-management-detail">
+            <CardHeader class="pb-3">
+              <CardTitle class="text-base">
+                {{ selectedRailItem?.label ?? 'Workspace detail' }}
+              </CardTitle>
+              <CardDescription>
+                Mode:
+                <span class="font-medium text-foreground">{{ graphManagementModeLabel }}</span>
+              </CardDescription>
+            </CardHeader>
+            <CardContent class="space-y-4 text-sm">
+              <template v-if="selectedRailItemId === 'schema-readiness'">
+                <div class="rounded border p-3">
+                  <p class="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Bootstrap Progress Checklist
+                  </p>
+                  <div class="space-y-2">
+                    <div
+                      v-for="item in progressChecklist"
+                      :key="item.id"
+                      class="rounded border px-3 py-2"
+                    >
+                      <div class="flex items-center justify-between">
+                        <p class="font-medium">{{ item.label }}</p>
+                        <Badge :variant="item.passed ? 'default' : 'destructive'">
+                          {{ item.passed ? 'Pass' : 'Fail' }}
+                        </Badge>
+                      </div>
+                      <p class="mt-1 text-xs text-muted-foreground">
+                        {{ item.passed ? item.passDetail : item.failDetail }}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div class="flex flex-wrap gap-2">
+                  <Button variant="outline" :disabled="validating || transitioning" @click="validateWorkspace">
+                    <Loader2 v-if="validating" class="mr-1.5 size-3.5 animate-spin" />
+                    <CheckCircle2 v-else class="mr-1.5 size-3.5" />
+                    Validate
+                  </Button>
+                  <Button
+                    :disabled="!canTransition || transitioning || validating"
+                    @click="transitionToExtraction"
+                  >
+                    <Loader2 v-if="transitioning" class="mr-1.5 size-3.5 animate-spin" />
+                    <PlayCircle v-else class="mr-1.5 size-3.5" />
+                    Go to Extraction/Mutations
+                  </Button>
+                </div>
+              </template>
+
+              <template v-else-if="selectedRailItemId === 'validation-diagnostics'">
+                <div class="rounded border p-3">
+                  <p class="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Validation Diagnostics
+                  </p>
+                  <div
+                    v-if="statusProjection.readiness.prepopulated_types_without_instances.length > 0"
+                    class="rounded border border-amber-400/60 bg-amber-50/60 p-2 text-xs dark:border-amber-800 dark:bg-amber-950/20"
+                  >
+                    <p class="font-medium text-amber-800 dark:text-amber-300">
+                      Prepopulated types missing instances
+                    </p>
+                    <ul class="mt-1 list-disc space-y-1 pl-4 text-muted-foreground">
+                      <li
+                        v-for="typeLabel in statusProjection.readiness.prepopulated_types_without_instances"
+                        :key="typeLabel"
+                      >
+                        {{ typeLabel }}
+                      </li>
+                    </ul>
+                  </div>
+                  <div
+                    v-if="statusProjection.readiness.blocking_reasons.length > 0"
+                    class="mt-2 rounded border border-destructive/50 p-3"
+                  >
+                    <p class="mb-1 flex items-center gap-1.5 text-xs font-medium text-destructive">
+                      <ShieldAlert class="size-3.5" />
+                      Blocking reasons
+                    </p>
+                    <ul class="list-disc space-y-1 pl-4 text-xs text-muted-foreground">
+                      <li v-for="reason in statusProjection.readiness.blocking_reasons" :key="reason">
+                        {{ reason }}
+                      </li>
+                    </ul>
+                  </div>
+                  <p
+                    v-else-if="statusProjection.readiness.prepopulated_types_without_instances.length === 0"
+                    class="text-xs text-muted-foreground"
+                  >
+                    No validation diagnostics are currently blocking transition.
+                  </p>
+                </div>
+                <div class="rounded border p-3">
+                  <p class="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Next Steps
+                  </p>
+                  <ul class="list-disc space-y-1 pl-4 text-xs text-muted-foreground">
+                    <li v-for="step in nextSteps" :key="step">{{ step }}</li>
+                  </ul>
+                </div>
+              </template>
+
+              <template v-else-if="selectedRailItemId === 'session-pointers'">
+                <div class="grid gap-2 md:grid-cols-3 text-xs">
+                  <div class="rounded border px-3 py-2">
+                    <p class="text-muted-foreground">Active schema bootstrap session</p>
+                    <p class="mt-1 break-all font-mono">
+                      {{ statusProjection.session_pointers.active_schema_bootstrap_session_id ?? 'None' }}
+                    </p>
+                  </div>
+                  <div class="rounded border px-3 py-2">
+                    <p class="text-muted-foreground">Active extraction operations session</p>
+                    <p class="mt-1 break-all font-mono">
+                      {{ statusProjection.session_pointers.active_extraction_operations_session_id ?? 'None' }}
+                    </p>
+                  </div>
+                  <div class="rounded border px-3 py-2">
+                    <p class="text-muted-foreground">Most recent completed session</p>
+                    <p class="mt-1 break-all font-mono">
+                      {{ statusProjection.session_pointers.most_recent_completed_session_id ?? 'None' }}
+                    </p>
+                  </div>
+                </div>
+                <div class="space-y-3 border-t pt-3">
+                  <div class="flex items-center justify-between">
+                    <p class="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                      Session History
+                    </p>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      class="h-6 px-2 text-[10px]"
+                      :disabled="sessionHistoryLoading"
+                      @click="loadSessionHistory"
+                    >
+                      Refresh
+                    </Button>
+                  </div>
+                  <div
+                    v-if="sessionHistoryLoading"
+                    class="flex items-center gap-2 text-xs text-muted-foreground"
+                  >
+                    <Loader2 class="size-3.5 animate-spin" />
+                    Loading session history...
+                  </div>
+                  <div
+                    v-else-if="sessionHistory.length === 0"
+                    class="rounded border border-dashed px-3 py-4 text-xs text-muted-foreground"
+                  >
+                    No archived or active sessions found for this scope yet.
+                  </div>
+                  <div v-else class="space-y-2">
+                    <div
+                      v-for="entry in sessionHistory"
+                      :key="entry.id"
+                      class="rounded border px-3 py-2 text-xs"
+                    >
+                      <div class="flex flex-wrap items-center justify-between gap-2">
+                        <p class="font-mono break-all">{{ entry.id }}</p>
+                        <Badge :variant="entry.is_active ? 'default' : 'secondary'">
+                          {{ entry.is_active ? 'Active' : 'Archived' }}
+                        </Badge>
+                      </div>
+                      <p class="mt-1 text-muted-foreground">
+                        Updated {{ new Date(entry.updated_at).toLocaleString() }}
+                        <span v-if="entry.archived_at">
+                          · Archived {{ new Date(entry.archived_at).toLocaleString() }}
+                        </span>
+                      </p>
+                      <p class="mt-1 text-muted-foreground">
+                        {{ entry.message_count }} message(s)
+                        · {{ entry.run_metrics.length }} linked run(s)
+                      </p>
+                      <div
+                        v-if="entry.run_metrics.length > 0"
+                        class="mt-2 space-y-1.5 rounded border bg-muted/20 p-2"
+                      >
+                        <div
+                          v-for="metric in entry.run_metrics"
+                          :key="metric.sync_run_id"
+                          class="flex flex-wrap items-center justify-between gap-2"
+                        >
+                          <span class="font-mono">{{ metric.mutation_log_id ?? metric.sync_run_id }}</span>
+                          <span class="text-muted-foreground">
+                            {{ metric.token_usage_total ?? 0 }} tokens ·
+                            ${{ (metric.cost_total_usd ?? 0).toFixed(2) }}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </template>
+
+              <template v-else-if="graphManagementMode === 'extraction-jobs'">
                 <p class="text-muted-foreground">
                   Trigger extraction and maintenance controls from the data sources operations panel.
                 </p>
-                <Button size="sm" variant="outline" @click="navigateTo('/data-sources')">
-                  Open Data Source Operations
-                </Button>
-              </TabsContent>
-              <TabsContent value="manual-mutations" class="mt-3 space-y-2 text-sm">
+                <div class="flex flex-wrap gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    @click="navigateTo(buildDataSourcesStepUrl(kgId))"
+                  >
+                    Open Data Source Operations
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    @click="navigateTo(buildMaintainStepUrl(kgId))"
+                  >
+                    Open Maintain Step
+                  </Button>
+                </div>
+              </template>
+
+              <template v-else-if="graphManagementMode === 'one-off-mutations'">
                 <p class="text-muted-foreground">
                   Open the mutation editor scoped to this knowledge graph for minor direct edits.
                 </p>
                 <Button size="sm" @click="navigateTo(`/graph/mutations?kg_id=${kgId}&view=editor`)">
                   Open Manual Mutations
                 </Button>
-              </TabsContent>
-              <TabsContent value="run-logs" class="mt-3 space-y-2 text-sm">
-                <p class="text-muted-foreground">
-                  Review sync run history, maintenance outcomes, and operational logs.
-                </p>
-                <Button size="sm" variant="outline" @click="navigateTo('/data-sources')">
-                  Open Run and Log Views
-                </Button>
-                <Card class="mt-2">
-                  <CardHeader>
-                    <CardTitle class="text-sm">MutationLog Browser</CardTitle>
-                    <CardDescription>
-                      Knowledge-graph scoped mutation runs with per-entry operation previews and run metrics.
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent class="grid gap-3 xl:grid-cols-[280px_1fr]">
-                    <div class="rounded border">
-                      <div class="flex items-center justify-between border-b px-3 py-2">
-                        <p class="text-xs font-medium text-muted-foreground">Runs</p>
-                        <Button size="sm" variant="ghost" class="h-6 px-2 text-[10px]" @click="loadMutationLogRuns">
-                          Refresh
-                        </Button>
-                      </div>
-                      <div v-if="mutationLogLoading" class="flex items-center gap-2 px-3 py-4 text-xs text-muted-foreground">
-                        <Loader2 class="size-3.5 animate-spin" />
-                        Loading mutation runs...
-                      </div>
-                      <div v-else-if="mutationLogRuns.length === 0" class="px-3 py-4 text-xs text-muted-foreground">
-                        No mutation log runs found for this knowledge graph yet.
-                      </div>
-                      <div v-else class="max-h-64 overflow-auto p-2 space-y-1.5">
-                        <button
-                          v-for="run in mutationLogRuns"
-                          :key="run.id"
-                          class="w-full rounded border px-2 py-1.5 text-left text-xs transition-colors"
-                          :class="selectedMutationLogRunId === run.id ? 'border-primary bg-primary/5' : 'hover:bg-muted/40'"
-                          @click="selectedMutationLogRunId = run.id"
-                        >
-                          <p class="font-medium truncate">{{ run.data_source_name }}</p>
-                          <p class="text-muted-foreground truncate">{{ new Date(run.started_at).toLocaleString() }}</p>
-                          <div class="mt-1 flex items-center justify-between">
-                            <Badge variant="outline" class="text-[10px]">{{ run.status }}</Badge>
-                            <span class="font-mono text-[10px] text-muted-foreground">{{ run.mutation_log_id }}</span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
+              </template>
 
-                    <div v-if="selectedMutationLogRun" class="space-y-3 rounded border p-3">
-                      <div class="flex flex-wrap items-center gap-2">
-                        <Badge>{{ selectedMutationLogRun.status }}</Badge>
-                        <p class="text-xs text-muted-foreground">
-                          Data source:
-                          <span class="font-medium text-foreground">{{ selectedMutationLogRun.data_source_name }}</span>
-                        </p>
-                      </div>
-                      <div class="grid gap-2 sm:grid-cols-2">
-                        <div class="rounded border px-3 py-2 text-xs">
-                          <p class="text-muted-foreground">MutationLog</p>
-                          <p class="mt-1 font-mono break-all">{{ selectedMutationLogRun.mutation_log_id }}</p>
-                        </div>
-                        <div class="rounded border px-3 py-2 text-xs">
-                          <p class="text-muted-foreground">Session</p>
-                          <p class="mt-1 font-mono break-all">{{ selectedMutationLogRun.session_id ?? 'None' }}</p>
-                        </div>
-                        <div class="rounded border px-3 py-2 text-xs">
-                          <p class="text-muted-foreground">Started</p>
-                          <p class="mt-1">{{ new Date(selectedMutationLogRun.started_at).toLocaleString() }}</p>
-                        </div>
-                        <div class="rounded border px-3 py-2 text-xs">
-                          <p class="text-muted-foreground">Completed</p>
-                          <p class="mt-1">
-                            {{ selectedMutationLogRun.completed_at ? new Date(selectedMutationLogRun.completed_at).toLocaleString() : 'In progress' }}
-                          </p>
-                        </div>
-                      </div>
-                      <div class="grid gap-2 sm:grid-cols-2">
-                        <div class="rounded border px-3 py-2 text-xs">
-                          <p class="text-muted-foreground flex items-center gap-1.5">
-                            <Coins class="size-3.5" />
-                            Token usage
-                          </p>
-                          <p class="mt-1 font-medium">{{ (selectedMutationLogRun.token_usage_total ?? 0).toLocaleString() }}</p>
-                        </div>
-                        <div class="rounded border px-3 py-2 text-xs">
-                          <p class="text-muted-foreground flex items-center gap-1.5">
-                            <DollarSign class="size-3.5" />
-                            Cost (USD)
-                          </p>
-                          <p class="mt-1 font-medium">${{ (selectedMutationLogRun.cost_total_usd ?? 0).toFixed(2) }}</p>
-                        </div>
-                      </div>
-                      <div class="rounded border p-3">
-                        <p class="mb-2 text-xs font-medium text-muted-foreground">Per-entry operation previews</p>
-                        <div v-if="Object.keys(selectedMutationLogRun.operation_counts).length === 0" class="text-xs text-muted-foreground">
-                          No operation class counts recorded for this run.
-                        </div>
-                        <div v-else class="space-y-1.5">
-                          <div
-                            v-for="([opClass, count]) in Object.entries(selectedMutationLogRun.operation_counts)"
-                            :key="opClass"
-                            class="flex items-center justify-between rounded border px-2 py-1.5 text-xs"
-                          >
-                            <span class="font-mono">{{ opClass }}</span>
-                            <Badge variant="secondary">{{ count }}</Badge>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <div v-else class="rounded border border-dashed p-6 text-sm text-muted-foreground">
-                      Select a mutation run to view summary and per-entry previews.
-                    </div>
-                  </CardContent>
-                </Card>
-              </TabsContent>
-            </Tabs>
-          </CardContent>
-        </Card>
-      </div>
+              <template v-else>
+                <p class="text-xs text-muted-foreground">
+                  Select a status or artifact item to inspect mode-specific workspace content.
+                </p>
+              </template>
+            </CardContent>
+          </Card>
+        </div>
       </section>
     </template>
   </div>

--- a/src/dev-ui/app/tests/kgManageState.test.ts
+++ b/src/dev-ui/app/tests/kgManageState.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  SECTION_STATE_MESSAGES,
+  appendLocalChatMessage,
+  buildTransitionRestrictionReason,
+  handleActivatableKeydown,
+  handleChatInputKeydown,
+  isForbiddenHttpError,
+  resolveForbiddenReason,
+  resolveSectionState,
+  shouldApplyMutationResult,
+} from '../utils/kgManageState'
+
+describe('KG-MANAGE-017 - chat input keyboard contract', () => {
+  it('sends on Enter without Shift', () => {
+    const onSend = vi.fn()
+    const preventDefault = vi.fn()
+    const result = handleChatInputKeydown(
+      { key: 'Enter', shiftKey: false, preventDefault },
+      onSend,
+    )
+
+    expect(result).toBe('send')
+    expect(preventDefault).toHaveBeenCalledOnce()
+    expect(onSend).toHaveBeenCalledOnce()
+  })
+
+  it('inserts newline on Shift+Enter without sending', () => {
+    const onSend = vi.fn()
+    const preventDefault = vi.fn()
+    const result = handleChatInputKeydown(
+      { key: 'Enter', shiftKey: true, preventDefault },
+      onSend,
+    )
+
+    expect(result).toBe('newline')
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(onSend).not.toHaveBeenCalled()
+  })
+
+  it('ignores non-Enter keys', () => {
+    const onSend = vi.fn()
+    const preventDefault = vi.fn()
+    const result = handleChatInputKeydown(
+      { key: 'a', shiftKey: false, preventDefault },
+      onSend,
+    )
+
+    expect(result).toBe('ignored')
+    expect(onSend).not.toHaveBeenCalled()
+  })
+})
+
+describe('KG-MANAGE-018 - keyboard operable step and rail actions', () => {
+  it('activates step actions on Enter', () => {
+    const onActivate = vi.fn()
+    const preventDefault = vi.fn()
+    const handled = handleActivatableKeydown(
+      { key: 'Enter', preventDefault },
+      onActivate,
+    )
+
+    expect(handled).toBe(true)
+    expect(preventDefault).toHaveBeenCalledOnce()
+    expect(onActivate).toHaveBeenCalledOnce()
+  })
+
+  it('activates step actions on Space', () => {
+    const onActivate = vi.fn()
+    const preventDefault = vi.fn()
+    const handled = handleActivatableKeydown(
+      { key: ' ', preventDefault },
+      onActivate,
+    )
+
+    expect(handled).toBe(true)
+    expect(onActivate).toHaveBeenCalledOnce()
+  })
+
+  it('ignores unrelated keys for activatable controls', () => {
+    const onActivate = vi.fn()
+    const handled = handleActivatableKeydown(
+      { key: 'Tab', preventDefault: vi.fn() },
+      onActivate,
+    )
+
+    expect(handled).toBe(false)
+    expect(onActivate).not.toHaveBeenCalled()
+  })
+})
+
+describe('KG-MANAGE-019 - section-specific loading, empty, and error states', () => {
+  it('uses step-specific loading messages', () => {
+    const overview = resolveSectionState({
+      section: 'workspace-overview',
+      loading: true,
+    })
+    const mutationLogs = resolveSectionState({
+      section: 'mutation-logs',
+      loading: true,
+    })
+
+    expect(overview.message).toBe(SECTION_STATE_MESSAGES['workspace-overview'].loading)
+    expect(mutationLogs.message).toBe(SECTION_STATE_MESSAGES['mutation-logs'].loading)
+    expect(overview.message).not.toBe(mutationLogs.message)
+  })
+
+  it('returns actionable empty states with optional next-step labels', () => {
+    const state = resolveSectionState({
+      section: 'mutation-logs',
+      empty: true,
+      emptyActionLabel: 'Refresh runs',
+    })
+
+    expect(state.phase).toBe('empty')
+    expect(state.message).toBe(SECTION_STATE_MESSAGES['mutation-logs'].empty)
+    expect(state.actionLabel).toBe('Refresh runs')
+  })
+
+  it('surfaces section-specific error messaging', () => {
+    const state = resolveSectionState({
+      section: 'graph-management',
+      error: 'Session service unavailable',
+    })
+
+    expect(state.phase).toBe('error')
+    expect(state.message).toBe('Session service unavailable')
+  })
+})
+
+describe('KG-MANAGE-020 - forbidden and disabled action restrictions', () => {
+  it('detects forbidden HTTP errors', () => {
+    expect(isForbiddenHttpError({ statusCode: 403 })).toBe(true)
+    expect(isForbiddenHttpError(new Error('Forbidden'))).toBe(true)
+    expect(isForbiddenHttpError({ statusCode: 404 })).toBe(false)
+  })
+
+  it('builds explicit forbidden section messaging', () => {
+    const state = resolveSectionState({
+      section: 'graph-management',
+      forbidden: true,
+      forbiddenReason: 'You do not have permission to perform this action',
+    })
+
+    expect(state.phase).toBe('forbidden')
+    expect(state.message).toBe('You do not have permission to perform this action')
+  })
+
+  it('explains why transition is disabled', () => {
+    expect(
+      buildTransitionRestrictionReason(false, ['Missing entity types']),
+    ).toBe('Transition blocked: Missing entity types')
+    expect(buildTransitionRestrictionReason(true, [])).toBeNull()
+  })
+
+  it('blocks mutation result application when forbidden', () => {
+    expect(shouldApplyMutationResult(true)).toBe(false)
+    expect(shouldApplyMutationResult(false)).toBe(true)
+  })
+
+  it('extracts forbidden reasons from API errors', () => {
+    expect(
+      resolveForbiddenReason(
+        { data: { detail: 'You do not have permission to perform this action' } },
+        'Access restricted',
+      ),
+    ).toBe('You do not have permission to perform this action')
+  })
+})
+
+describe('KG-MANAGE-017 - local chat send helper', () => {
+  it('appends trimmed user messages to session history', () => {
+    const history = appendLocalChatMessage(
+      { message_history: [{ role: 'assistant', content: 'Hello' }] },
+      '  Define schema  ',
+    )
+
+    expect(history).toHaveLength(2)
+    expect(history[1]).toEqual({ role: 'user', content: 'Define schema' })
+  })
+
+  it('ignores blank chat submissions', () => {
+    const history = appendLocalChatMessage(
+      { message_history: [{ role: 'assistant', content: 'Hello' }] },
+      '   ',
+    )
+
+    expect(history).toHaveLength(1)
+  })
+})

--- a/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
+++ b/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
@@ -475,3 +475,70 @@ describe('KG-MANAGE-016 - graph management top controls', () => {
     expect(parseGraphManagementModeQuery('initial-schema-design')).toBe('initial-schema-design')
   })
 })
+
+describe('KG-MANAGE-017 - chat input keyboard contract', () => {
+  it('wires Enter-to-send and Shift+Enter newline handling in shared conversation panel', () => {
+    expect(sharedConversationPanelVue).toContain('handleChatInputKeydown')
+    expect(sharedConversationPanelVue).toContain('@keydown="onChatInputKeydown"')
+    expect(sharedConversationPanelVue).toContain('Shift+Enter adds a new line')
+    expect(sharedConversationPanelVue).toContain("emit('sendMessage'")
+    expect(manageWorkspaceVue).toContain('@send-message="sendChatMessage"')
+  })
+})
+
+describe('KG-MANAGE-018 - keyboard operable step and rail actions', () => {
+  it('supports keyboard activation for step card primary actions', () => {
+    expect(manageWorkspaceVue).toContain('onStepActionKeydown')
+    expect(manageWorkspaceVue).toContain('handleActivatableKeydown')
+    expect(manageWorkspaceVue).toContain('@keydown="onStepActionKeydown($event, card.id)"')
+  })
+
+  it('supports keyboard activation for graph management rail selection', () => {
+    expect(manageWorkspaceVue).toContain('onRailKeydown')
+    expect(manageWorkspaceVue).toContain('role="listbox"')
+    expect(manageWorkspaceVue).toContain('tabindex="0"')
+    expect(manageWorkspaceVue).toContain('@keydown="onRailKeydown($event, item.id)"')
+  })
+
+  it('exposes keyboard-reachable graph management mode switch tabs', () => {
+    expect(manageWorkspaceVue).toContain('role="tablist"')
+    expect(manageWorkspaceVue).toContain('onModeSwitchKeydown')
+    expect(manageWorkspaceVue).toContain('@keydown="onModeSwitchKeydown($event, mode)"')
+  })
+})
+
+describe('KG-MANAGE-019 - section-specific loading, empty, and error states', () => {
+  it('uses section state contracts for workspace, graph management, and mutation logs', () => {
+    expect(manageWorkspaceVue).toContain('resolveSectionState')
+    expect(manageWorkspaceVue).toContain('workspaceOverviewState')
+    expect(manageWorkspaceVue).toContain('graphManagementSectionState')
+    expect(manageWorkspaceVue).toContain('mutationLogsSectionState')
+    expect(manageWorkspaceVue).toContain('Retry workspace load')
+    expect(manageWorkspaceVue).toContain('Retry mutation log load')
+    expect(manageWorkspaceVue).toContain('Retry session load')
+  })
+
+  it('renders actionable empty states for mutation log runs', () => {
+    expect(manageWorkspaceVue).toContain('mutationLogsSectionState.actionLabel')
+    expect(manageWorkspaceVue).toContain('Refresh runs')
+  })
+})
+
+describe('KG-MANAGE-020 - forbidden and disabled action restrictions', () => {
+  it('detects forbidden responses and surfaces explicit restriction messaging', () => {
+    expect(manageWorkspaceVue).toContain('isForbiddenHttpError')
+    expect(manageWorkspaceVue).toContain('workspaceForbiddenReason')
+    expect(manageWorkspaceVue).toContain('sessionForbiddenReason')
+    expect(manageWorkspaceVue).toContain('role="alert"')
+    expect(manageWorkspaceVue).toContain(':forbidden="sessionForbidden"')
+    expect(sharedConversationPanelVue).toContain('forbidden?: boolean')
+    expect(sharedConversationPanelVue).toContain('v-if="forbidden"')
+  })
+
+  it('explains disabled transition actions and avoids partial updates on forbidden', () => {
+    expect(manageWorkspaceVue).toContain('transitionRestrictionReason')
+    expect(manageWorkspaceVue).toContain('buildTransitionRestrictionReason')
+    expect(manageWorkspaceVue).toContain('shouldApplyMutationResult')
+    expect(manageWorkspaceVue).toContain('statusProjection.value = previousStatus')
+  })
+})

--- a/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
+++ b/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
@@ -13,6 +13,18 @@ import {
   resolveStepDestination,
   stepStatusTintClass,
 } from '../utils/kgManageWorkspace'
+import {
+  GRAPH_MANAGEMENT_MODE_LABELS,
+  GRAPH_MANAGEMENT_MODE_ORDER,
+  buildGraphManagementRailItems,
+  buildGraphManagementStepUrl,
+  filterRailItemsForMode,
+  isRailItemValidInMode,
+  parseGraphManagementModeQuery,
+  resolveDefaultGraphManagementMode,
+  resolveRailSelectionForMode,
+  resolveSharedSessionMode,
+} from '../utils/kgGraphManagement'
 
 const manageWorkspaceVue = readFileSync(
   resolve(__dirname, '../pages/knowledge-graphs/[kgId]/manage.vue'),
@@ -42,7 +54,7 @@ const baseWorkspaceStatus = {
   },
 }
 
-describe('Knowledge Graph Manage Workspace - mode-aware controls', () => {
+describe('Knowledge Graph Manage Workspace - graph management controls', () => {
   it('loads workspace status projection from management API', () => {
     expect(manageWorkspaceVue).toContain('/workspace-status')
     expect(manageWorkspaceVue).toContain('loadWorkspaceStatus')
@@ -60,50 +72,18 @@ describe('Knowledge Graph Manage Workspace - mode-aware controls', () => {
     expect(manageWorkspaceVue).toContain('Go to Extraction/Mutations')
   })
 
-  it('renders readiness result blocks and blocking reasons list', () => {
-    expect(manageWorkspaceVue).toContain('Readiness Results')
-    expect(manageWorkspaceVue).toContain('blocking_reasons')
-    expect(manageWorkspaceVue).toContain('prepopulated_types_ready')
-  })
-
-  it('renders session pointer references for bootstrap and extraction modes', () => {
-    expect(manageWorkspaceVue).toContain('Session Pointers')
-    expect(manageWorkspaceVue).toContain('active_schema_bootstrap_session_id')
-    expect(manageWorkspaceVue).toContain('active_extraction_operations_session_id')
-  })
-
   it('loads scoped session history with run metrics after clear chat', () => {
     expect(manageWorkspaceVue).toContain('loadSessionHistory')
-    expect(manageWorkspaceVue).toContain('/sessions/${sessionMode.value}/history')
+    expect(manageWorkspaceVue).toContain('/sessions/${sharedSessionMode.value}/history')
     expect(manageWorkspaceVue).toContain('sessionHistory')
     expect(manageWorkspaceVue).toContain('run_metrics')
     expect(manageWorkspaceVue).toContain('Session History')
   })
-
-
-  it('uses shared conversation panel for bootstrap and extraction sessions', () => {
-    expect(manageWorkspaceVue).toContain('SharedConversationPanel')
-    expect(manageWorkspaceVue).toContain('sessionMode')
-    expect(manageWorkspaceVue).toContain('/sessions/${sessionMode.value}/active')
-  })
-
-  it('supports explicit Clear chat reset for extraction session', () => {
-    expect(manageWorkspaceVue).toContain('clearChat')
-    expect(manageWorkspaceVue).toContain('/sessions/${sessionMode.value}/clear-chat')
-    expect(sharedConversationPanelVue).toContain('Clear chat')
-  })
-
-  it('provides tabbed lower operations area for extraction workflows', () => {
-    expect(manageWorkspaceVue).toContain('Operations Workspace')
-    expect(manageWorkspaceVue).toContain('TabsTrigger value="extraction-jobs"')
-    expect(manageWorkspaceVue).toContain('TabsTrigger value="manual-mutations"')
-    expect(manageWorkspaceVue).toContain('TabsTrigger value="run-logs"')
-  })
 })
 
 describe('Knowledge Graph Manage Workspace - mutation log browser', () => {
-  it('renders mutation log browser card and scoped run listing', () => {
-    expect(manageWorkspaceVue).toContain('MutationLog Browser')
+  it('renders mutation log step with scoped run listing', () => {
+    expect(manageWorkspaceVue).toContain('MutationLogs')
     expect(manageWorkspaceVue).toContain('loadMutationLogRuns')
     expect(manageWorkspaceVue).toContain('/management/knowledge-graphs/${kgId.value}/data-sources')
   })
@@ -326,5 +306,172 @@ describe('Shared conversation panel - extraction UX contract', () => {
     expect(sharedConversationPanelVue).toContain('activityTimeline')
     expect(sharedConversationPanelVue).toContain('timelineRef')
     expect(sharedConversationPanelVue).toContain('scrollTop = timelineRef.value.scrollHeight')
+  })
+
+  it('accepts mode-aware input placeholder and session status props', () => {
+    expect(sharedConversationPanelVue).toContain('inputPlaceholder')
+    expect(sharedConversationPanelVue).toContain('sessionStatusLabel')
+  })
+})
+
+describe('KG-MANAGE-006 - graph management conversation-first layout', () => {
+  it('renders graph management step with shared conversation panel', () => {
+    expect(manageWorkspaceVue).toContain("activeStep === 'graph-management'")
+    expect(manageWorkspaceVue).toContain('SharedConversationPanel')
+    expect(manageWorkspaceVue).toContain('graph-management-controls')
+  })
+
+  it('uses one shared session endpoint across UI mode changes', () => {
+    expect(manageWorkspaceVue).toContain('sharedSessionMode')
+    expect(manageWorkspaceVue).toContain('/sessions/${sharedSessionMode.value}/active')
+    expect(manageWorkspaceVue).not.toContain('watch(graphManagementMode')
+  })
+})
+
+describe('KG-MANAGE-007 - graph management modes', () => {
+  it('supports the three canonical graph management modes', () => {
+    for (const mode of GRAPH_MANAGEMENT_MODE_ORDER) {
+      expect(GRAPH_MANAGEMENT_MODE_LABELS[mode]).toBeTruthy()
+      expect(manageWorkspaceVue).toContain(mode)
+    }
+    expect(manageWorkspaceVue).toContain('graphManagementMode')
+    expect(manageWorkspaceVue).toContain('parseGraphManagementModeQuery')
+  })
+
+  it('defaults mode from workspace lifecycle state', () => {
+    expect(resolveDefaultGraphManagementMode('schema_bootstrap')).toBe('initial-schema-design')
+    expect(resolveDefaultGraphManagementMode('extraction_operations')).toBe('extraction-jobs')
+  })
+
+  it('updates chat placeholder by mode without changing session scope', () => {
+    expect(manageWorkspaceVue).toContain('graphManagementInputPlaceholder')
+    expect(manageWorkspaceVue).toContain('GRAPH_MANAGEMENT_INPUT_PLACEHOLDERS')
+  })
+})
+
+describe('KG-MANAGE-008 - hybrid lower panel shared rail', () => {
+  it('renders persistent status and artifact rail with keyboard selection', () => {
+    expect(manageWorkspaceVue).toContain('graph-management-rail')
+    expect(manageWorkspaceVue).toContain('buildGraphManagementRailItems')
+    expect(manageWorkspaceVue).toContain('role="listbox"')
+    expect(manageWorkspaceVue).toContain('@keydown')
+  })
+
+  it('builds rail items with status and last-updated metadata', () => {
+    const items = buildGraphManagementRailItems({
+      workspaceMode: 'schema_bootstrap',
+      transitionEligible: false,
+      blockingReasonCount: 1,
+      prepopulatedGapCount: 0,
+      sessionUpdatedAt: '2026-05-22T12:00:00Z',
+      hasActiveSession: true,
+    })
+
+    expect(items.every((item) => item.status && item.lastUpdated && item.label)).toBe(true)
+    expect(items.find((item) => item.id === 'session-pointers')?.modes).toEqual(
+      GRAPH_MANAGEMENT_MODE_ORDER,
+    )
+  })
+})
+
+describe('KG-MANAGE-009 - hybrid lower panel mode-specific detail', () => {
+  it('renders mode-specific detail panel content regions', () => {
+    expect(manageWorkspaceVue).toContain('graph-management-detail')
+    expect(manageWorkspaceVue).toContain('selectedRailItemId')
+    expect(manageWorkspaceVue).toContain("selectedRailItemId === 'schema-readiness'")
+    expect(manageWorkspaceVue).toContain("graphManagementMode === 'extraction-jobs'")
+    expect(manageWorkspaceVue).toContain("graphManagementMode === 'one-off-mutations'")
+  })
+
+  it('filters rail items to the active mode', () => {
+    const items = buildGraphManagementRailItems({
+      workspaceMode: 'extraction_operations',
+      transitionEligible: true,
+      blockingReasonCount: 0,
+      prepopulatedGapCount: 0,
+      sessionUpdatedAt: null,
+      hasActiveSession: true,
+    })
+
+    expect(filterRailItemsForMode(items, 'extraction-jobs').map((item) => item.id)).toContain(
+      'extraction-jobs-setup',
+    )
+    expect(filterRailItemsForMode(items, 'one-off-mutations').map((item) => item.id)).toContain(
+      'mutation-authoring',
+    )
+  })
+})
+
+describe('KG-MANAGE-010 - schema design parity behavior', () => {
+  it('exposes schema readiness and validation detail in initial schema design mode', () => {
+    expect(manageWorkspaceVue).toContain('progressChecklist')
+    expect(manageWorkspaceVue).toContain('Bootstrap Progress Checklist')
+    expect(manageWorkspaceVue).toContain('blocking_reasons')
+    expect(manageWorkspaceVue).toContain('prepopulated_types_without_instances')
+  })
+
+  it('keeps validate and transition controls available for schema design work', () => {
+    expect(manageWorkspaceVue).toContain('validateWorkspace')
+    expect(manageWorkspaceVue).toContain('transitionToExtraction')
+    expect(manageWorkspaceVue).toContain('canTransition')
+  })
+})
+
+describe('KG-MANAGE-011 - session reset behavior', () => {
+  it('supports explicit clear chat reset on the shared session', () => {
+    expect(manageWorkspaceVue).toContain('clearChat')
+    expect(manageWorkspaceVue).toContain('/sessions/${sharedSessionMode.value}/clear-chat')
+    expect(sharedConversationPanelVue).toContain('Clear chat')
+  })
+
+  it('keeps graph management mode unchanged after clear chat', () => {
+    const clearChatBlock = manageWorkspaceVue.match(
+      /async function clearChat\(\) \{[\s\S]*?\n\}/,
+    )?.[0] ?? ''
+    expect(clearChatBlock).toContain('clearChat')
+    expect(clearChatBlock).not.toContain('graphManagementMode')
+  })
+})
+
+describe('KG-MANAGE-016 - graph management top controls', () => {
+  it('renders mode switcher, session status, and validation affordance without scrolling', () => {
+    expect(manageWorkspaceVue).toContain('graph-management-controls')
+    expect(manageWorkspaceVue).toContain('graphManagementModeLabel')
+    expect(manageWorkspaceVue).toContain('sessionStatusLabel')
+    expect(manageWorkspaceVue).toContain('validateWorkspace')
+    expect(manageWorkspaceVue).toContain('Clear chat')
+  })
+
+  it('maps shared session mode from workspace lifecycle without UI mode coupling', () => {
+    expect(resolveSharedSessionMode('schema_bootstrap')).toBe('schema_bootstrap')
+    expect(resolveSharedSessionMode('extraction_operations')).toBe('extraction_operations')
+  })
+
+  it('preserves rail selection across mode changes when still valid', () => {
+    const items = buildGraphManagementRailItems({
+      workspaceMode: 'extraction_operations',
+      transitionEligible: true,
+      blockingReasonCount: 0,
+      prepopulatedGapCount: 0,
+      sessionUpdatedAt: '2026-05-22T12:00:00Z',
+      hasActiveSession: true,
+    })
+
+    expect(
+      resolveRailSelectionForMode('session-pointers', 'extraction-jobs', items),
+    ).toBe('session-pointers')
+    expect(
+      isRailItemValidInMode('schema-readiness', 'extraction-jobs', items),
+    ).toBe(false)
+    expect(
+      resolveRailSelectionForMode('schema-readiness', 'extraction-jobs', items),
+    ).toBe('session-pointers')
+  })
+
+  it('builds graph management URLs with mode query for keyboard navigation', () => {
+    expect(buildGraphManagementStepUrl('kg-abc', 'one-off-mutations')).toBe(
+      '/knowledge-graphs/kg-abc/manage?step=graph-management&gm_mode=one-off-mutations',
+    )
+    expect(parseGraphManagementModeQuery('initial-schema-design')).toBe('initial-schema-design')
   })
 })

--- a/src/dev-ui/app/utils/kgGraphManagement.ts
+++ b/src/dev-ui/app/utils/kgGraphManagement.ts
@@ -1,0 +1,167 @@
+import type { StepStatusLabel } from './kgManageWorkspace'
+
+export type GraphManagementMode =
+  | 'initial-schema-design'
+  | 'extraction-jobs'
+  | 'one-off-mutations'
+
+export type GraphManagementRailItemId =
+  | 'schema-readiness'
+  | 'validation-diagnostics'
+  | 'session-pointers'
+  | 'extraction-jobs-setup'
+  | 'mutation-authoring'
+
+export const GRAPH_MANAGEMENT_MODE_ORDER: GraphManagementMode[] = [
+  'initial-schema-design',
+  'extraction-jobs',
+  'one-off-mutations',
+]
+
+export const GRAPH_MANAGEMENT_MODE_LABELS: Record<GraphManagementMode, string> = {
+  'initial-schema-design': 'Initial Schema Design',
+  'extraction-jobs': 'Extraction Jobs',
+  'one-off-mutations': 'One-off Mutations',
+}
+
+export const GRAPH_MANAGEMENT_INPUT_PLACEHOLDERS: Record<GraphManagementMode, string> = {
+  'initial-schema-design':
+    'Describe schema goals, entity types, or relationship constraints for this knowledge graph…',
+  'extraction-jobs':
+    'Ask about extraction job setup, sync runs, or maintenance execution for this graph…',
+  'one-off-mutations':
+    'Author or preview one-off graph mutations scoped to this knowledge graph…',
+}
+
+export interface GraphManagementRailItem {
+  id: GraphManagementRailItemId
+  label: string
+  status: StepStatusLabel
+  lastUpdated: string
+  detailHint: string
+  modes: GraphManagementMode[]
+}
+
+export interface GraphManagementRailInputs {
+  workspaceMode: 'schema_bootstrap' | 'extraction_operations'
+  transitionEligible: boolean
+  blockingReasonCount: number
+  prepopulatedGapCount: number
+  sessionUpdatedAt: string | null
+  hasActiveSession: boolean
+}
+
+export function parseGraphManagementModeQuery(mode: unknown): GraphManagementMode | null {
+  if (
+    mode === 'initial-schema-design'
+    || mode === 'extraction-jobs'
+    || mode === 'one-off-mutations'
+  ) {
+    return mode
+  }
+  return null
+}
+
+export function resolveDefaultGraphManagementMode(
+  workspaceMode: 'schema_bootstrap' | 'extraction_operations',
+): GraphManagementMode {
+  return workspaceMode === 'extraction_operations' ? 'extraction-jobs' : 'initial-schema-design'
+}
+
+export function resolveSharedSessionMode(
+  workspaceMode: 'schema_bootstrap' | 'extraction_operations',
+): 'schema_bootstrap' | 'extraction_operations' {
+  return workspaceMode === 'extraction_operations' ? 'extraction_operations' : 'schema_bootstrap'
+}
+
+export function buildGraphManagementRailItems(
+  input: GraphManagementRailInputs,
+): GraphManagementRailItem[] {
+  const sessionStamp = input.sessionUpdatedAt ?? 'Not loaded'
+  const readinessStatus: StepStatusLabel = input.blockingReasonCount > 0
+    ? 'needs_attention'
+    : input.transitionEligible
+      ? 'ready'
+      : 'in_progress'
+
+  return [
+    {
+      id: 'schema-readiness',
+      label: 'Schema readiness',
+      status: readinessStatus,
+      lastUpdated: sessionStamp,
+      detailHint: 'Bootstrap checklist, validate, and transition controls.',
+      modes: ['initial-schema-design'],
+    },
+    {
+      id: 'validation-diagnostics',
+      label: 'Validation diagnostics',
+      status: input.prepopulatedGapCount > 0 || input.blockingReasonCount > 0
+        ? 'needs_attention'
+        : 'ready',
+      lastUpdated: sessionStamp,
+      detailHint: 'Blocking reasons and prepopulated type gaps.',
+      modes: ['initial-schema-design'],
+    },
+    {
+      id: 'session-pointers',
+      label: 'Session pointers',
+      status: input.hasActiveSession ? 'ready' : 'in_progress',
+      lastUpdated: sessionStamp,
+      detailHint: 'Active bootstrap, extraction, and completed session references.',
+      modes: GRAPH_MANAGEMENT_MODE_ORDER,
+    },
+    {
+      id: 'extraction-jobs-setup',
+      label: 'Extraction jobs setup',
+      status: input.workspaceMode === 'extraction_operations' ? 'ready' : 'blocked',
+      lastUpdated: sessionStamp,
+      detailHint: 'Job setup, execution controls, and run context.',
+      modes: ['extraction-jobs'],
+    },
+    {
+      id: 'mutation-authoring',
+      label: 'Mutation authoring',
+      status: input.workspaceMode === 'extraction_operations' ? 'ready' : 'blocked',
+      lastUpdated: sessionStamp,
+      detailHint: 'One-off mutation preview and submit context.',
+      modes: ['one-off-mutations'],
+    },
+  ]
+}
+
+export function filterRailItemsForMode(
+  items: GraphManagementRailItem[],
+  mode: GraphManagementMode,
+): GraphManagementRailItem[] {
+  return items.filter((item) => item.modes.includes(mode))
+}
+
+export function isRailItemValidInMode(
+  itemId: GraphManagementRailItemId,
+  mode: GraphManagementMode,
+  items: GraphManagementRailItem[],
+): boolean {
+  const item = items.find((candidate) => candidate.id === itemId)
+  return item?.modes.includes(mode) ?? false
+}
+
+export function resolveRailSelectionForMode(
+  selectedId: GraphManagementRailItemId | null,
+  mode: GraphManagementMode,
+  items: GraphManagementRailItem[],
+): GraphManagementRailItemId | null {
+  const modeItems = filterRailItemsForMode(items, mode)
+  if (modeItems.length === 0) return null
+  if (selectedId && isRailItemValidInMode(selectedId, mode, items)) {
+    return selectedId
+  }
+  return modeItems[0]?.id ?? null
+}
+
+export function buildGraphManagementStepUrl(
+  kgId: string,
+  mode: GraphManagementMode,
+): string {
+  return `/knowledge-graphs/${encodeURIComponent(kgId)}/manage?step=graph-management&gm_mode=${mode}`
+}

--- a/src/dev-ui/app/utils/kgManageState.ts
+++ b/src/dev-ui/app/utils/kgManageState.ts
@@ -1,0 +1,180 @@
+export type ManageSectionId =
+  | 'workspace-overview'
+  | 'graph-management'
+  | 'mutation-logs'
+  | 'data-sources'
+  | 'maintain'
+
+export type SectionPhase = 'loading' | 'empty' | 'error' | 'ready' | 'forbidden'
+
+export interface SectionStateContract {
+  phase: SectionPhase
+  title: string
+  message: string
+  actionLabel?: string
+}
+
+export const SECTION_STATE_MESSAGES: Record<
+  ManageSectionId,
+  { loading: string; empty: string; error: string; forbidden: string }
+> = {
+  'workspace-overview': {
+    loading: 'Loading workspace overview and step readiness…',
+    empty: 'Workspace overview is unavailable until status loads.',
+    error: 'Could not load workspace overview for this knowledge graph.',
+    forbidden: 'You do not have permission to view this workspace overview.',
+  },
+  'graph-management': {
+    loading: 'Loading graph management session and workspace panels…',
+    empty: 'Graph management is ready, but no session activity is loaded yet.',
+    error: 'Could not load graph management session data.',
+    forbidden: 'You do not have permission to manage this knowledge graph.',
+  },
+  'mutation-logs': {
+    loading: 'Loading mutation log runs for this knowledge graph…',
+    empty: 'No mutation log runs recorded for this knowledge graph yet.',
+    error: 'Could not load mutation log runs for this knowledge graph.',
+    forbidden: 'You do not have permission to view mutation logs for this graph.',
+  },
+  'data-sources': {
+    loading: 'Loading data source readiness for this knowledge graph…',
+    empty: 'Connect a data source to continue workspace setup.',
+    error: 'Could not load data sources for this knowledge graph.',
+    forbidden: 'You do not have permission to view data sources for this graph.',
+  },
+  maintain: {
+    loading: 'Loading maintenance readiness for tracked sources…',
+    empty: 'No tracked source changes are ready for maintenance.',
+    error: 'Could not load maintenance readiness for this knowledge graph.',
+    forbidden: 'You do not have permission to run maintenance for this graph.',
+  },
+}
+
+export function isForbiddenHttpError(err: unknown): boolean {
+  if (err && typeof err === 'object') {
+    const fetchErr = err as { statusCode?: number; status?: number }
+    const status = fetchErr.statusCode ?? fetchErr.status
+    if (status === 403) return true
+  }
+  if (err instanceof Error) {
+    const message = err.message.toLowerCase()
+    return message.includes('forbidden') || message.includes('403')
+  }
+  return false
+}
+
+export function resolveForbiddenReason(
+  err: unknown,
+  fallback: string,
+): string {
+  if (err instanceof Error && err.message.trim()) {
+    return err.message
+  }
+  if (err && typeof err === 'object') {
+    const fetchErr = err as { data?: { detail?: unknown } }
+    if (typeof fetchErr.data?.detail === 'string' && fetchErr.data.detail.trim()) {
+      return fetchErr.data.detail
+    }
+  }
+  return fallback
+}
+
+export function resolveSectionState(input: {
+  section: ManageSectionId
+  loading?: boolean
+  error?: string | null
+  forbidden?: boolean
+  forbiddenReason?: string | null
+  empty?: boolean
+  emptyActionLabel?: string
+}): SectionStateContract {
+  const defaults = SECTION_STATE_MESSAGES[input.section]
+
+  if (input.forbidden) {
+    return {
+      phase: 'forbidden',
+      title: 'Access restricted',
+      message: input.forbiddenReason?.trim() || defaults.forbidden,
+    }
+  }
+
+  if (input.loading) {
+    return {
+      phase: 'loading',
+      title: 'Loading',
+      message: defaults.loading,
+    }
+  }
+
+  if (input.error) {
+    return {
+      phase: 'error',
+      title: 'Unable to load section',
+      message: input.error,
+    }
+  }
+
+  if (input.empty) {
+    return {
+      phase: 'empty',
+      title: 'Nothing to show yet',
+      message: defaults.empty,
+      actionLabel: input.emptyActionLabel,
+    }
+  }
+
+  return {
+    phase: 'ready',
+    title: 'Ready',
+    message: '',
+  }
+}
+
+export function handleChatInputKeydown(
+  event: Pick<KeyboardEvent, 'key' | 'shiftKey' | 'preventDefault'>,
+  onSend: () => void,
+): 'send' | 'newline' | 'ignored' {
+  if (event.key !== 'Enter') return 'ignored'
+  if (event.shiftKey) return 'newline'
+  event.preventDefault()
+  onSend()
+  return 'send'
+}
+
+export function handleActivatableKeydown(
+  event: Pick<KeyboardEvent, 'key' | 'preventDefault'>,
+  onActivate: () => void,
+): boolean {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    onActivate()
+    return true
+  }
+  return false
+}
+
+export function buildTransitionRestrictionReason(
+  canTransition: boolean,
+  blockingReasons: string[],
+): string | null {
+  if (canTransition) return null
+  if (blockingReasons.length > 0) {
+    return `Transition blocked: ${blockingReasons.join('; ')}`
+  }
+  return 'Transition blocked until schema bootstrap readiness requirements are met.'
+}
+
+export function shouldApplyMutationResult(forbidden: boolean): boolean {
+  return !forbidden
+}
+
+export function appendLocalChatMessage(
+  session: { message_history: Array<{ role?: string; content?: string; message?: string }> } | null,
+  content: string,
+): Array<{ role?: string; content?: string; message?: string }> {
+  const trimmed = content.trim()
+  if (!trimmed) return session?.message_history ?? []
+  const history = [...(session?.message_history ?? [])]
+  history.push({ role: 'user', content: trimmed })
+  return history
+}

--- a/src/dev-ui/vitest.config.ts
+++ b/src/dev-ui/vitest.config.ts
@@ -7,6 +7,11 @@ export default defineConfig({
   test: {
     environment: 'happy-dom',
     globals: true,
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/local_modules/**',
+    ],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Adds `kgManageState` helpers and UI wiring for KG-MANAGE-017/018/019/020: chat Enter/Shift+Enter keyboard contract, keyboard-operable step/rail/mode actions, section-specific loading/empty/error states, and forbidden/disabled restriction messaging without partial updates.
- Updates `SharedConversationPanel` with an enabled textarea, send action, and explicit forbidden/permission UX.
- Extends manage workspace tests for the new matrix IDs and state-contract source assertions.

Closes #725

## Test plan
- [x] `cd src/dev-ui && ./node_modules/.bin/vitest run app/tests/kgManageState.test.ts app/tests/knowledge-graph-manage-workspace.test.ts`
  - Result: **70 passed** (16 unit + 54 source/contract tests)

Made with [Cursor](https://cursor.com)