### PR TITLE
feat(extraction): secure runtime credential injection for extraction containers

### DIFF
--- a/src/api/extraction/infrastructure/event_handler.py
+++ b/src/api/extraction/infrastructure/event_handler.py
@@ -10,9 +10,16 @@ from the raw data packaged by the Ingestion context.
 
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from extraction.ports.runtime import (
+    EphemeralWorkerLaunchRequest,
+    IEphemeralExtractionWorkerLauncher,
+    IWorkloadCredentialIssuer,
+    ScopedWorkloadCredentials,
+)
 from extraction.ports.services import IExtractionService
 
 if TYPE_CHECKING:
@@ -23,9 +30,10 @@ class ExtractionEventHandler:
     """Handles JobPackageProduced events by running the extraction pipeline.
 
     When a JobPackageProduced event is processed from the outbox, this handler:
-    1. Delegates to IExtractionService.run() to extract entities and relationships
-    2. On success: appends MutationLogProduced to the outbox
-    3. On failure: appends ExtractionFailed to the outbox
+    1. Issues short-lived scoped credentials and launches an ephemeral worker
+    2. Delegates to IExtractionService.run() to extract entities and relationships
+    3. On success: appends MutationLogProduced to the outbox
+    4. On failure: appends ExtractionFailed to the outbox
 
     This handler is the entry point for the Extraction bounded context in the
     sync lifecycle. It creates the linkage between the Ingestion context
@@ -41,6 +49,9 @@ class ExtractionEventHandler:
         extraction_service: IExtractionService,
         outbox: "IOutboxRepository",
         runtime_context_builder: Any,
+        *,
+        credential_issuer: IWorkloadCredentialIssuer | None = None,
+        worker_launcher: IEphemeralExtractionWorkerLauncher | None = None,
     ) -> None:
         """Initialize the extraction event handler.
 
@@ -48,19 +59,58 @@ class ExtractionEventHandler:
             extraction_service: Service that runs the AI extraction pipeline
             outbox: Repository for writing output events (MutationLogProduced /
                 ExtractionFailed)
+            runtime_context_builder: Resolves runtime paths for the workload
+            credential_issuer: Optional issuer for runtime-only workload credentials
+            worker_launcher: Optional launcher that enforces credential scope
         """
+        if (credential_issuer is None) ^ (worker_launcher is None):
+            raise ValueError(
+                "credential_issuer and worker_launcher must be configured together"
+            )
+
         self._extraction_service = extraction_service
         self._outbox = outbox
         self._runtime_context_builder = runtime_context_builder
+        self._credential_issuer = credential_issuer
+        self._worker_launcher = worker_launcher
 
     def supported_event_types(self) -> frozenset[str]:
         """Return event types handled by this handler."""
         return frozenset({"JobPackageProduced"})
 
+    @staticmethod
+    def _redact_sensitive_error(message: str) -> str:
+        """Redact token-like secrets from error strings before persistence."""
+        patterns = (
+            re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
+            re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._\-+/=]{16,}\b"),
+            re.compile(
+                r"(?i)\b(token|access_token|password|api[_-]?key)\b\s*[:=]\s*['\"]?[^\s,'\"]+"
+            ),
+        )
+        redacted = message
+        for pattern in patterns:
+            redacted = pattern.sub("***REDACTED***", redacted)
+        return redacted
+
+    @classmethod
+    def _sanitize_failure_error(
+        cls,
+        exc: Exception,
+        *,
+        workload_credentials: ScopedWorkloadCredentials | None,
+    ) -> str:
+        message = str(exc)
+        if workload_credentials is not None and workload_credentials.token:
+            message = message.replace(workload_credentials.token, "***REDACTED***")
+        return cls._redact_sensitive_error(message)
+
     async def handle(
         self,
         event_type: str,
         payload: dict[str, Any],
+        *,
+        tenant_id: str | None = None,
     ) -> None:
         """Process a JobPackageProduced event by running the extraction pipeline.
 
@@ -71,6 +121,7 @@ class ExtractionEventHandler:
                 - data_source_id: The data source being extracted
                 - knowledge_graph_id: The target knowledge graph
                 - job_package_id: The JobPackage to process
+            tenant_id: Tenant scope used for runtime credential issuance
         """
         if event_type != "JobPackageProduced":
             return
@@ -81,7 +132,32 @@ class ExtractionEventHandler:
         job_package_id = payload["job_package_id"]
         now = datetime.now(UTC)
 
+        workload_credentials: ScopedWorkloadCredentials | None = None
+        worker_id: str | None = None
+
         try:
+            if self._credential_issuer is not None and self._worker_launcher is not None:
+                if not tenant_id:
+                    raise ValueError(
+                        "tenant_id is required for scoped workload credential injection"
+                    )
+
+                workload_credentials = self._credential_issuer.issue(
+                    tenant_id=tenant_id,
+                    knowledge_graph_id=knowledge_graph_id,
+                )
+                launch_result = self._worker_launcher.launch(
+                    request=EphemeralWorkerLaunchRequest(
+                        tenant_id=tenant_id,
+                        knowledge_graph_id=knowledge_graph_id,
+                        session_id=f"sync:{sync_run_id}",
+                        sync_run_id=sync_run_id,
+                        job_package_id=job_package_id,
+                    ),
+                    credentials=workload_credentials,
+                )
+                worker_id = launch_result.worker_id
+
             runtime_context = self._runtime_context_builder.build(
                 sync_run_id=sync_run_id,
                 job_package_id=job_package_id,
@@ -92,6 +168,7 @@ class ExtractionEventHandler:
                 knowledge_graph_id=knowledge_graph_id,
                 job_package_id=job_package_id,
                 runtime_context=runtime_context,
+                workload_credentials=workload_credentials,
             )
         except Exception as exc:
             await self._outbox.append(
@@ -99,7 +176,10 @@ class ExtractionEventHandler:
                 payload={
                     "sync_run_id": sync_run_id,
                     "data_source_id": data_source_id,
-                    "error": str(exc),
+                    "error": self._sanitize_failure_error(
+                        exc,
+                        workload_credentials=workload_credentials,
+                    ),
                     "occurred_at": now.isoformat(),
                 },
                 occurred_at=now,
@@ -107,6 +187,9 @@ class ExtractionEventHandler:
                 aggregate_id=sync_run_id,
             )
             return
+        finally:
+            if worker_id is not None and self._worker_launcher is not None:
+                self._worker_launcher.complete_worker(worker_id)
 
         # Extraction succeeded — append success event outside the try block so
         # that an outbox write failure here is not mistaken for an extraction

--- a/src/api/extraction/ports/__init__.py
+++ b/src/api/extraction/ports/__init__.py
@@ -9,6 +9,7 @@ from extraction.ports.runtime import (
     EphemeralWorkerLaunchResult,
     IEphemeralExtractionWorkerLauncher,
     IStickySessionRuntimeManager,
+    IWorkloadCredentialIssuer,
     ScopedWorkloadCredentials,
     StickySessionRuntimeLease,
 )
@@ -20,6 +21,7 @@ __all__ = [
     "IExtractionSkillOverrideRepository",
     "IStickySessionRuntimeManager",
     "IEphemeralExtractionWorkerLauncher",
+    "IWorkloadCredentialIssuer",
     "StickySessionRuntimeLease",
     "ScopedWorkloadCredentials",
     "EphemeralWorkerLaunchRequest",

--- a/src/api/extraction/ports/runtime.py
+++ b/src/api/extraction/ports/runtime.py
@@ -50,6 +50,16 @@ class EphemeralWorkerLaunchResult:
     credentials_expires_at: datetime
 
 
+class IWorkloadCredentialIssuer(Protocol):
+    """Issues short-lived credentials scoped to tenant and knowledge graph."""
+
+    def issue(
+        self, *, tenant_id: str, knowledge_graph_id: str
+    ) -> ScopedWorkloadCredentials:
+        """Return runtime-only credentials for one extraction workload."""
+        ...
+
+
 class IStickySessionRuntimeManager(Protocol):
     """Manages sticky chat runtime containers for active sessions."""
 

--- a/src/api/extraction/ports/services.py
+++ b/src/api/extraction/ports/services.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from extraction.ports.runtime import ScopedWorkloadCredentials
 
 
 @dataclass(frozen=True)
@@ -34,6 +37,7 @@ class IExtractionService(Protocol):
         knowledge_graph_id: str,
         job_package_id: str,
         runtime_context: ExtractionRuntimeContext,
+        workload_credentials: ScopedWorkloadCredentials | None = None,
     ) -> str:
         """Run the AI extraction pipeline for a JobPackage.
 
@@ -44,6 +48,7 @@ class IExtractionService(Protocol):
             job_package_id: Identifier for the JobPackage to process
             runtime_context: Resolved runtime context paths for ingestion resources,
                 reconstructed repository files, and skills availability.
+            workload_credentials: Short-lived runtime credentials injected into the worker
 
         Returns:
             mutation_log_id: Identifier for the produced MutationLog (JSONL)

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -287,6 +287,7 @@ class _StubExtractionService:
         knowledge_graph_id: str,
         job_package_id: str,
         runtime_context: Any,
+        workload_credentials: Any = None,
     ) -> str:
         raise NotImplementedError(
             "AI extraction pipeline is not yet implemented. "
@@ -312,14 +313,25 @@ class _SessionedExtractionEventHandler:
         return self._SUPPORTED
 
     async def handle(self, event_type: str, payload: dict[str, Any]) -> None:
+        from datetime import timedelta
+
         from infrastructure.outbox.repository import OutboxRepository
         from extraction.infrastructure.event_handler import ExtractionEventHandler
         from extraction.infrastructure.runtime_context_builder import (
             FilesystemExtractionRuntimeContextBuilder,
         )
+        from extraction.infrastructure.workload_runtime import (
+            InMemoryEphemeralExtractionWorkerLauncher,
+            ScopedWorkloadCredentialIssuer,
+        )
+        from management.domain.value_objects import KnowledgeGraphId
+        from management.infrastructure.repositories.knowledge_graph_repository import (
+            KnowledgeGraphRepository,
+        )
 
         async with self._session_factory() as session:
             outbox = OutboxRepository(session=session)
+            kg_repo = KnowledgeGraphRepository(session=session, outbox=outbox)
             runtime_context_builder = FilesystemExtractionRuntimeContextBuilder(
                 work_dir=_JOB_PACKAGE_WORK_DIR,
                 skills_dir=_EXTRACTION_SKILLS_DIR,
@@ -328,8 +340,24 @@ class _SessionedExtractionEventHandler:
                 extraction_service=self._extraction_service,
                 outbox=outbox,
                 runtime_context_builder=runtime_context_builder,
+                credential_issuer=ScopedWorkloadCredentialIssuer(
+                    default_ttl=timedelta(minutes=15)
+                ),
+                worker_launcher=InMemoryEphemeralExtractionWorkerLauncher(),
             )
-            await extraction_handler.handle(event_type, payload)
+
+            tenant_id = str(payload.get("tenant_id", "")) if payload.get("tenant_id") else ""
+            knowledge_graph_id = str(payload.get("knowledge_graph_id", ""))
+            if not tenant_id and knowledge_graph_id:
+                kg = await kg_repo.get_by_id(KnowledgeGraphId(value=knowledge_graph_id))
+                if kg is not None:
+                    tenant_id = kg.tenant_id
+
+            await extraction_handler.handle(
+                event_type,
+                payload,
+                tenant_id=tenant_id or None,
+            )
             await session.commit()
 
 

--- a/src/api/tests/integration/extraction/test_workload_credential_injection.py
+++ b/src/api/tests/integration/extraction/test_workload_credential_injection.py
@@ -1,0 +1,215 @@
+"""Integration tests for extraction workload credential injection."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from extraction.infrastructure.event_handler import ExtractionEventHandler
+from extraction.infrastructure.workload_runtime import (
+    InMemoryEphemeralExtractionWorkerLauncher,
+    ScopedWorkloadCredentialIssuer,
+)
+from extraction.ports.runtime import ScopedWorkloadCredentials
+from extraction.ports.services import ExtractionRuntimeContext
+
+pytestmark = pytest.mark.integration
+
+
+class _RecordingOutbox:
+    def __init__(self) -> None:
+        self.appended: list[dict[str, Any]] = []
+
+    async def append(
+        self,
+        event_type: str,
+        payload: dict[str, Any],
+        occurred_at: datetime,
+        aggregate_type: str,
+        aggregate_id: str,
+    ) -> None:
+        self.appended.append(
+            {
+                "event_type": event_type,
+                "payload": payload,
+                "occurred_at": occurred_at,
+                "aggregate_type": aggregate_type,
+                "aggregate_id": aggregate_id,
+            }
+        )
+
+    async def fetch_unprocessed(self, limit: int = 100) -> list[Any]:
+        return []
+
+    async def mark_processed(self, entry_id: UUID) -> None:
+        pass
+
+
+class _RecordingExtractionService:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def run(
+        self,
+        sync_run_id: str,
+        data_source_id: str,
+        knowledge_graph_id: str,
+        job_package_id: str,
+        runtime_context: ExtractionRuntimeContext,
+        workload_credentials: ScopedWorkloadCredentials | None = None,
+    ) -> str:
+        self.calls.append(
+            {
+                "sync_run_id": sync_run_id,
+                "workload_credentials": workload_credentials,
+            }
+        )
+        return "mutation-log-integration"
+
+
+class _StaticRuntimeContextBuilder:
+    def build(self, *, sync_run_id: str, job_package_id: str) -> ExtractionRuntimeContext:
+        return ExtractionRuntimeContext(
+            ingestion_context_dir="/tmp/ingestion-context",
+            repository_files_dir="/tmp/repository-files",
+            skills_dir="/app/skills",
+            job_package_archive="/tmp/job-package.zip",
+        )
+
+
+def _payload(*, tenant_id: str = "tenant-integration") -> dict[str, Any]:
+    return {
+        "sync_run_id": "sync-integration-1",
+        "data_source_id": "ds-integration-1",
+        "knowledge_graph_id": "kg-integration-1",
+        "job_package_id": "pkg-integration-1",
+        "tenant_id": tenant_id,
+        "occurred_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def _handler(
+    *,
+    service: _RecordingExtractionService | None = None,
+    launcher: InMemoryEphemeralExtractionWorkerLauncher | None = None,
+) -> tuple[ExtractionEventHandler, _RecordingOutbox, _RecordingExtractionService, InMemoryEphemeralExtractionWorkerLauncher]:
+    outbox = _RecordingOutbox()
+    extraction_service = service or _RecordingExtractionService()
+    worker_launcher = launcher or InMemoryEphemeralExtractionWorkerLauncher()
+    handler = ExtractionEventHandler(
+        extraction_service=extraction_service,
+        outbox=outbox,
+        runtime_context_builder=_StaticRuntimeContextBuilder(),
+        credential_issuer=ScopedWorkloadCredentialIssuer(default_ttl=timedelta(minutes=10)),
+        worker_launcher=worker_launcher,
+    )
+    return handler, outbox, extraction_service, worker_launcher
+
+
+@pytest.mark.asyncio
+async def test_scoped_credentials_are_injected_at_runtime_only() -> None:
+    handler, outbox, service, launcher = _handler()
+
+    await handler.handle("JobPackageProduced", _payload(), tenant_id="tenant-integration")
+
+    assert len(service.calls) == 1
+    credentials = service.calls[0]["workload_credentials"]
+    assert credentials is not None
+    assert credentials.scopes == (
+        "tenant:tenant-integration",
+        "knowledge_graph:kg-integration-1",
+        "workload:extraction",
+    )
+    assert launcher.active_worker_count == 0
+    assert len(outbox.appended) == 1
+    success = outbox.appended[0]
+    assert success["event_type"] == "MutationLogProduced"
+    assert "token" not in success["payload"]
+    assert credentials.token not in str(success["payload"])
+
+
+@pytest.mark.asyncio
+async def test_rejects_credentials_with_insufficient_scope() -> None:
+    outbox = _RecordingOutbox()
+    service = _RecordingExtractionService()
+    launcher = InMemoryEphemeralExtractionWorkerLauncher()
+
+    class _WrongScopeIssuer:
+        def issue(
+            self, *, tenant_id: str, knowledge_graph_id: str
+        ) -> ScopedWorkloadCredentials:
+            return ScopedWorkloadCredentials(
+                token="wrong-scope-token",
+                expires_at=datetime.now(UTC) + timedelta(minutes=5),
+                scopes=(
+                    "tenant:tenant-other",
+                    f"knowledge_graph:{knowledge_graph_id}",
+                    "workload:extraction",
+                ),
+            )
+
+    handler = ExtractionEventHandler(
+        extraction_service=service,
+        outbox=outbox,
+        runtime_context_builder=_StaticRuntimeContextBuilder(),
+        credential_issuer=_WrongScopeIssuer(),
+        worker_launcher=launcher,
+    )
+
+    await handler.handle(
+        "JobPackageProduced",
+        _payload(),
+        tenant_id="tenant-integration",
+    )
+
+    assert service.calls == []
+    assert len(outbox.appended) == 1
+    failure = outbox.appended[0]
+    assert failure["event_type"] == "ExtractionFailed"
+    assert "scope" in failure["payload"]["error"].lower()
+    assert "wrong-scope-token" not in failure["payload"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_rejects_expired_credentials() -> None:
+    outbox = _RecordingOutbox()
+    service = _RecordingExtractionService()
+    launcher = InMemoryEphemeralExtractionWorkerLauncher()
+
+    class _ExpiredIssuer:
+        def issue(
+            self, *, tenant_id: str, knowledge_graph_id: str
+        ) -> ScopedWorkloadCredentials:
+            return ScopedWorkloadCredentials(
+                token="expired-token-value",
+                expires_at=datetime.now(UTC) - timedelta(seconds=1),
+                scopes=(
+                    f"tenant:{tenant_id}",
+                    f"knowledge_graph:{knowledge_graph_id}",
+                    "workload:extraction",
+                ),
+            )
+
+    handler = ExtractionEventHandler(
+        extraction_service=service,
+        outbox=outbox,
+        runtime_context_builder=_StaticRuntimeContextBuilder(),
+        credential_issuer=_ExpiredIssuer(),
+        worker_launcher=launcher,
+    )
+
+    await handler.handle(
+        "JobPackageProduced",
+        _payload(),
+        tenant_id="tenant-integration",
+    )
+
+    assert service.calls == []
+    assert len(outbox.appended) == 1
+    failure = outbox.appended[0]
+    assert failure["event_type"] == "ExtractionFailed"
+    assert "expired" in failure["payload"]["error"].lower()
+    assert "expired-token-value" not in failure["payload"]["error"]

--- a/src/api/tests/unit/extraction/infrastructure/test_extraction_event_handler.py
+++ b/src/api/tests/unit/extraction/infrastructure/test_extraction_event_handler.py
@@ -11,13 +11,18 @@ Spec coverage:
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import UUID
 
 import pytest
 
 from extraction.infrastructure.event_handler import ExtractionEventHandler
+from extraction.infrastructure.workload_runtime import (
+    InMemoryEphemeralExtractionWorkerLauncher,
+    ScopedWorkloadCredentialIssuer,
+)
+from extraction.ports.runtime import ScopedWorkloadCredentials
 from extraction.ports.services import ExtractionRuntimeContext
 
 
@@ -67,6 +72,7 @@ class _FakeExtractionService:
         knowledge_graph_id: str,
         job_package_id: str,
         runtime_context: ExtractionRuntimeContext,
+        workload_credentials: ScopedWorkloadCredentials | None = None,
     ) -> str:
         self.calls.append(
             {
@@ -75,6 +81,7 @@ class _FakeExtractionService:
                 "knowledge_graph_id": knowledge_graph_id,
                 "job_package_id": job_package_id,
                 "runtime_context": runtime_context,
+                "workload_credentials": workload_credentials,
             }
         )
         if self._fail:
@@ -261,6 +268,115 @@ class TestExtractionEventHandlerFailure:
         event = outbox.appended[0]
         assert event["aggregate_type"] == "sync_run"
         assert event["aggregate_id"] == "run-003"
+
+
+@pytest.mark.asyncio
+class TestExtractionEventHandlerCredentialInjection:
+    """Tests for runtime credential issuance and worker launch enforcement."""
+
+    async def test_injects_scoped_credentials_before_extraction(
+        self,
+        extraction_service: _FakeExtractionService,
+        outbox: _FakeOutboxRepository,
+    ) -> None:
+        handler = ExtractionEventHandler(
+            extraction_service=extraction_service,
+            outbox=outbox,
+            runtime_context_builder=_FakeRuntimeContextBuilder(),
+            credential_issuer=ScopedWorkloadCredentialIssuer(
+                default_ttl=timedelta(minutes=10)
+            ),
+            worker_launcher=InMemoryEphemeralExtractionWorkerLauncher(),
+        )
+        payload = _job_package_produced_payload(sync_run_id="run-cred")
+
+        await handler.handle("JobPackageProduced", payload, tenant_id="tenant-1")
+
+        assert len(extraction_service.calls) == 1
+        credentials = extraction_service.calls[0]["workload_credentials"]
+        assert credentials is not None
+        assert credentials.scopes == (
+            "tenant:tenant-1",
+            "knowledge_graph:kg-001",
+            "workload:extraction",
+        )
+
+    async def test_emits_extraction_failed_when_scope_is_invalid(
+        self,
+        outbox: _FakeOutboxRepository,
+    ) -> None:
+        class _WrongScopeIssuer:
+            def issue(
+                self, *, tenant_id: str, knowledge_graph_id: str
+            ) -> ScopedWorkloadCredentials:
+                return ScopedWorkloadCredentials(
+                    token="wrong-scope-token",
+                    expires_at=datetime.now(UTC) + timedelta(minutes=5),
+                    scopes=(
+                        "tenant:tenant-other",
+                        f"knowledge_graph:{knowledge_graph_id}",
+                        "workload:extraction",
+                    ),
+                )
+
+        handler = ExtractionEventHandler(
+            extraction_service=_FakeExtractionService(),
+            outbox=outbox,
+            runtime_context_builder=_FakeRuntimeContextBuilder(),
+            credential_issuer=_WrongScopeIssuer(),
+            worker_launcher=InMemoryEphemeralExtractionWorkerLauncher(),
+        )
+        payload = _job_package_produced_payload(sync_run_id="run-scope-fail")
+
+        await handler.handle(
+            "JobPackageProduced",
+            payload,
+            tenant_id="tenant-1",
+        )
+
+        assert len(outbox.appended) == 1
+        event = outbox.appended[0]
+        assert event["event_type"] == "ExtractionFailed"
+        assert "scope" in event["payload"]["error"].lower()
+        assert "wrong-scope-token" not in event["payload"]["error"]
+
+    async def test_redacts_secret_material_from_failure_payload(
+        self,
+        outbox: _FakeOutboxRepository,
+    ) -> None:
+        class _LeakyService(_FakeExtractionService):
+            async def run(  # type: ignore[override]
+                self,
+                sync_run_id: str,
+                data_source_id: str,
+                knowledge_graph_id: str,
+                job_package_id: str,
+                runtime_context: ExtractionRuntimeContext,
+                workload_credentials: ScopedWorkloadCredentials | None = None,
+            ) -> str:
+                raise RuntimeError(
+                    "workload auth failed for token ghp_1234567890abcdef1234567890abcdef1234"
+                )
+
+        handler = ExtractionEventHandler(
+            extraction_service=_LeakyService(),
+            outbox=outbox,
+            runtime_context_builder=_FakeRuntimeContextBuilder(),
+            credential_issuer=ScopedWorkloadCredentialIssuer(
+                default_ttl=timedelta(minutes=10)
+            ),
+            worker_launcher=InMemoryEphemeralExtractionWorkerLauncher(),
+        )
+        payload = _job_package_produced_payload(sync_run_id="run-redact")
+
+        await handler.handle("JobPackageProduced", payload, tenant_id="tenant-1")
+
+        event = outbox.appended[0]
+        assert event["event_type"] == "ExtractionFailed"
+        assert "ghp_1234567890abcdef1234567890abcdef1234" not in event["payload"][
+            "error"
+        ]
+        assert "***REDACTED***" in event["payload"]["error"]
 
 
 class _FailingOutboxRepository(_FakeOutboxRepository):

--- a/src/api/tests/unit/extraction/infrastructure/test_workload_runtime.py
+++ b/src/api/tests/unit/extraction/infrastructure/test_workload_runtime.py
@@ -13,6 +13,7 @@ from extraction.infrastructure.workload_runtime import (
 )
 from extraction.ports.runtime import (
     EphemeralWorkerLaunchRequest,
+    ScopedWorkloadCredentials,
 )
 
 
@@ -79,6 +80,26 @@ class TestInMemoryStickySessionRuntimeManager:
 
 
 class TestEphemeralWorkerLauncher:
+    def test_launch_rejects_expired_credentials(self) -> None:
+        issuer = ScopedWorkloadCredentialIssuer(default_ttl=timedelta(minutes=10))
+        launcher = InMemoryEphemeralExtractionWorkerLauncher()
+        scoped_credentials = issuer.issue(tenant_id="tenant-1", knowledge_graph_id="kg-1")
+        expired_credentials = ScopedWorkloadCredentials(
+            token=scoped_credentials.token,
+            expires_at=datetime.now(UTC) - timedelta(seconds=1),
+            scopes=scoped_credentials.scopes,
+        )
+        request = EphemeralWorkerLaunchRequest(
+            tenant_id="tenant-1",
+            knowledge_graph_id="kg-1",
+            session_id="session-1",
+            sync_run_id="sync-1",
+            job_package_id="pkg-1",
+        )
+
+        with pytest.raises(ValueError, match="expired"):
+            launcher.launch(request=request, credentials=expired_credentials)
+
     def test_launch_requires_credentials_scoped_to_request(self) -> None:
         issuer = ScopedWorkloadCredentialIssuer(default_ttl=timedelta(minutes=10))
         launcher = InMemoryEphemeralExtractionWorkerLauncher()


### PR DESCRIPTION
## Summary
- Wire `ScopedWorkloadCredentialIssuer` and `InMemoryEphemeralExtractionWorkerLauncher` into the `JobPackageProduced` extraction path so workers receive short-lived tenant/KG scoped credentials at runtime only.
- Enforce least-privilege scope and expiration before extraction starts; sanitize failure telemetry so credential material is redacted from outbox `ExtractionFailed` payloads.
- Resolve tenant scope in the sessioned outbox handler via knowledge graph lookup when not present on the event payload.

Closes #717

## Test plan
- [x] Unit: scope enforcement, expiration rejection, credential redaction, and runtime-only injection
  ```bash
  cd src/api && uv run pytest tests/unit/extraction/infrastructure/test_workload_runtime.py tests/unit/extraction/infrastructure/test_extraction_event_handler.py -v
  ```
  Result: **23 passed**
- [x] Integration: end-to-end handler flow for scoped injection, insufficient scope, and expired credentials
  ```bash
  cd src/api && uv run pytest tests/integration/extraction/test_workload_credential_injection.py -v
  ```
  Result: **3 passed**

## Risks
- Production container launchers are still in-memory adapters; this PR completes the credential contract and outbox wiring so a real launcher can be swapped in without changing handler semantics.


Made with [Cursor](https://cursor.com)