### PR TITLE
feat(extraction): session history views with run-level metrics retention (#719)

### DIFF
--- a/src/api/extraction/application/agent_session_service.py
+++ b/src/api/extraction/application/agent_session_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from ulid import ULID
@@ -11,7 +12,19 @@ from extraction.application.skill_resolution_service import (
 )
 from extraction.domain.entities.agent_session import ExtractionAgentSession
 from extraction.domain.value_objects import BootstrapIntakePath, ExtractionSessionMode
-from extraction.ports.repositories import IExtractionAgentSessionRepository
+from extraction.domain.value_objects import ExtractionSessionRunMetric
+from extraction.ports.repositories import (
+    IExtractionAgentSessionRepository,
+    IExtractionSessionRunMetricsReader,
+)
+
+
+@dataclass(frozen=True)
+class ExtractionSessionHistoryRecord:
+    """Session history entry with linked run-level metrics."""
+
+    session: ExtractionAgentSession
+    run_metrics: list[ExtractionSessionRunMetric]
 
 
 class ExtractionAgentSessionService:
@@ -21,9 +34,11 @@ class ExtractionAgentSessionService:
         self,
         repository: IExtractionAgentSessionRepository,
         skill_resolution_service: ExtractionSkillResolutionService | None = None,
+        run_metrics_reader: IExtractionSessionRunMetricsReader | None = None,
     ) -> None:
         self._repository = repository
         self._skill_resolution_service = skill_resolution_service
+        self._run_metrics_reader = run_metrics_reader
 
     @staticmethod
     def _build_bootstrap_intake_prompt() -> str:
@@ -113,6 +128,35 @@ class ExtractionAgentSessionService:
             knowledge_graph_id=knowledge_graph_id,
             mode=mode,
         )
+
+    async def list_session_history(
+        self,
+        user_id: str,
+        knowledge_graph_id: str,
+        mode: ExtractionSessionMode,
+    ) -> list[ExtractionSessionHistoryRecord]:
+        sessions = await self._repository.list_by_scope(
+            user_id=user_id,
+            knowledge_graph_id=knowledge_graph_id,
+            mode=mode,
+        )
+        if not sessions:
+            return []
+
+        metrics_by_session: dict[str, list[ExtractionSessionRunMetric]] = {}
+        if self._run_metrics_reader is not None:
+            metrics_by_session = await self._run_metrics_reader.find_metrics_by_session_ids(
+                knowledge_graph_id=knowledge_graph_id,
+                session_ids=[session.id for session in sessions],
+            )
+
+        return [
+            ExtractionSessionHistoryRecord(
+                session=session,
+                run_metrics=metrics_by_session.get(session.id, []),
+            )
+            for session in sessions
+        ]
 
     async def archive_session(self, session_id: str) -> ExtractionAgentSession | None:
         session = await self._repository.get_by_id(session_id)

--- a/src/api/extraction/dependencies.py
+++ b/src/api/extraction/dependencies.py
@@ -11,6 +11,7 @@ from extraction.application import (
 )
 from extraction.infrastructure.repositories import (
     ExtractionAgentSessionRepository,
+    ExtractionSessionRunMetricsReader,
     ExtractionSkillOverrideRepository,
 )
 from infrastructure.database.dependencies import get_write_session
@@ -26,5 +27,5 @@ def get_extraction_agent_session_service(
     return ExtractionAgentSessionService(
         repository=ExtractionAgentSessionRepository(session=session),
         skill_resolution_service=skill_resolution_service,
+        run_metrics_reader=ExtractionSessionRunMetricsReader(session=session),
     )
-

--- a/src/api/extraction/domain/value_objects.py
+++ b/src/api/extraction/domain/value_objects.py
@@ -1,5 +1,9 @@
 """Value objects for Extraction session lifecycle."""
 
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
 from enum import StrEnum
 
 
@@ -16,3 +20,16 @@ class BootstrapIntakePath(StrEnum):
     FIRST_PASS_SCHEMA_ATTEMPT = "first_pass_schema_attempt"
     GUIDED_CO_DESIGN = "guided_co_design"
 
+
+@dataclass(frozen=True)
+class ExtractionSessionRunMetric:
+    """Run-level metrics linked to an extraction session."""
+
+    sync_run_id: str
+    mutation_log_id: str | None
+    status: str
+    started_at: datetime
+    completed_at: datetime | None = None
+    token_usage_total: int | None = None
+    cost_total_usd: float | None = None
+    operation_counts: dict[str, int] = field(default_factory=dict)

--- a/src/api/extraction/infrastructure/repositories/__init__.py
+++ b/src/api/extraction/infrastructure/repositories/__init__.py
@@ -3,9 +3,15 @@
 from extraction.infrastructure.repositories.agent_session_repository import (
     ExtractionAgentSessionRepository,
 )
+from extraction.infrastructure.repositories.session_run_metrics_reader import (
+    ExtractionSessionRunMetricsReader,
+)
 from extraction.infrastructure.repositories.skill_override_repository import (
     ExtractionSkillOverrideRepository,
 )
 
-__all__ = ["ExtractionAgentSessionRepository", "ExtractionSkillOverrideRepository"]
-
+__all__ = [
+    "ExtractionAgentSessionRepository",
+    "ExtractionSessionRunMetricsReader",
+    "ExtractionSkillOverrideRepository",
+]

--- a/src/api/extraction/infrastructure/repositories/session_run_metrics_reader.py
+++ b/src/api/extraction/infrastructure/repositories/session_run_metrics_reader.py
@@ -1,0 +1,82 @@
+"""PostgreSQL reader for extraction session run metrics."""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from extraction.domain.value_objects import ExtractionSessionRunMetric
+from extraction.ports.repositories import IExtractionSessionRunMetricsReader
+
+
+class ExtractionSessionRunMetricsReader(IExtractionSessionRunMetricsReader):
+    """Resolve sync-run metrics for extraction sessions without Management imports."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def find_metrics_by_session_ids(
+        self,
+        *,
+        knowledge_graph_id: str,
+        session_ids: list[str],
+    ) -> dict[str, list[ExtractionSessionRunMetric]]:
+        if not session_ids:
+            return {}
+
+        stmt = text(
+            """
+            SELECT
+                sr.id AS sync_run_id,
+                sr.status,
+                sr.started_at,
+                sr.completed_at,
+                sr.mutation_log_run
+            FROM data_source_sync_runs sr
+            JOIN data_sources ds ON ds.id = sr.data_source_id
+            WHERE ds.knowledge_graph_id = :knowledge_graph_id
+              AND sr.mutation_log_run IS NOT NULL
+              AND sr.mutation_log_run->>'session_id' = ANY(:session_ids)
+            ORDER BY sr.started_at DESC
+            """
+        )
+        result = await self._session.execute(
+            stmt,
+            {
+                "knowledge_graph_id": knowledge_graph_id,
+                "session_ids": session_ids,
+            },
+        )
+
+        metrics_by_session: dict[str, list[ExtractionSessionRunMetric]] = {
+            session_id: [] for session_id in session_ids
+        }
+        for row in result.mappings().all():
+            payload = row["mutation_log_run"] or {}
+            session_id = payload.get("session_id")
+            if session_id not in metrics_by_session:
+                continue
+            metrics_by_session[session_id].append(
+                ExtractionSessionRunMetric(
+                    sync_run_id=row["sync_run_id"],
+                    mutation_log_id=payload.get("mutation_log_id"),
+                    status=row["status"],
+                    started_at=row["started_at"],
+                    completed_at=row["completed_at"],
+                    token_usage_total=(
+                        int(payload["token_usage_total"])
+                        if payload.get("token_usage_total") is not None
+                        else None
+                    ),
+                    cost_total_usd=(
+                        float(payload["cost_total_usd"])
+                        if payload.get("cost_total_usd") is not None
+                        else None
+                    ),
+                    operation_counts={
+                        str(key): int(value)
+                        for key, value in (payload.get("operation_counts") or {}).items()
+                    },
+                )
+            )
+        return metrics_by_session

--- a/src/api/extraction/ports/repositories.py
+++ b/src/api/extraction/ports/repositories.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Protocol
 
 from extraction.domain.entities.agent_session import ExtractionAgentSession
-from extraction.domain.value_objects import ExtractionSessionMode
+from extraction.domain.value_objects import ExtractionSessionMode, ExtractionSessionRunMetric
 
 
 class IExtractionAgentSessionRepository(Protocol):
@@ -28,6 +28,17 @@ class IExtractionAgentSessionRepository(Protocol):
         knowledge_graph_id: str,
         mode: ExtractionSessionMode | None = None,
     ) -> list[ExtractionAgentSession]: ...
+
+
+class IExtractionSessionRunMetricsReader(Protocol):
+    """Read-only access to run-level metrics linked to extraction sessions."""
+
+    async def find_metrics_by_session_ids(
+        self,
+        *,
+        knowledge_graph_id: str,
+        session_ids: list[str],
+    ) -> dict[str, list[ExtractionSessionRunMetric]]: ...
 
 
 class IExtractionSkillOverrideRepository(Protocol):

--- a/src/api/extraction/presentation/models.py
+++ b/src/api/extraction/presentation/models.py
@@ -7,8 +7,39 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from extraction.application.agent_session_service import ExtractionSessionHistoryRecord
 from extraction.domain.entities.agent_session import ExtractionAgentSession
-from extraction.domain.value_objects import BootstrapIntakePath, ExtractionSessionMode
+from extraction.domain.value_objects import (
+    BootstrapIntakePath,
+    ExtractionSessionMode,
+    ExtractionSessionRunMetric,
+)
+
+
+class SessionRunMetricResponse(BaseModel):
+    """Run-level metrics linked to an extraction session."""
+
+    sync_run_id: str
+    mutation_log_id: str | None = None
+    status: str
+    started_at: datetime
+    completed_at: datetime | None = None
+    token_usage_total: int | None = None
+    cost_total_usd: float | None = None
+    operation_counts: dict[str, int] = Field(default_factory=dict)
+
+    @classmethod
+    def from_domain(cls, metric: ExtractionSessionRunMetric) -> "SessionRunMetricResponse":
+        return cls(
+            sync_run_id=metric.sync_run_id,
+            mutation_log_id=metric.mutation_log_id,
+            status=metric.status,
+            started_at=metric.started_at,
+            completed_at=metric.completed_at,
+            token_usage_total=metric.token_usage_total,
+            cost_total_usd=metric.cost_total_usd,
+            operation_counts=dict(metric.operation_counts),
+        )
 
 
 class ExtractionSessionResponse(BaseModel):
@@ -46,6 +77,50 @@ class ExtractionSessionListResponse(BaseModel):
     count: int
 
 
+class ExtractionSessionHistoryItemResponse(BaseModel):
+    """Historical session summary with linked run metrics."""
+
+    id: str
+    user_id: str
+    knowledge_graph_id: str
+    mode: ExtractionSessionMode
+    created_at: datetime
+    updated_at: datetime
+    archived_at: datetime | None = None
+    is_active: bool
+    message_count: int
+    run_metrics: list[SessionRunMetricResponse] = Field(default_factory=list)
+
+    @classmethod
+    def from_history_record(
+        cls,
+        record: ExtractionSessionHistoryRecord,
+    ) -> "ExtractionSessionHistoryItemResponse":
+        session = record.session
+        return cls(
+            id=session.id,
+            user_id=session.user_id,
+            knowledge_graph_id=session.knowledge_graph_id,
+            mode=session.mode,
+            created_at=session.created_at,
+            updated_at=session.updated_at,
+            archived_at=session.archived_at,
+            is_active=session.is_active,
+            message_count=len(session.message_history),
+            run_metrics=[
+                SessionRunMetricResponse.from_domain(metric)
+                for metric in record.run_metrics
+            ],
+        )
+
+
+class ExtractionSessionHistoryResponse(BaseModel):
+    """History response for scoped extraction sessions."""
+
+    sessions: list[ExtractionSessionHistoryItemResponse]
+    count: int
+
+
 class BootstrapIntakePathSelectionRequest(BaseModel):
     """Request model for bootstrap intake path selection."""
 
@@ -54,4 +129,3 @@ class BootstrapIntakePathSelectionRequest(BaseModel):
         default=None,
         description="Optional user summary of capabilities and schema goals",
     )
-

--- a/src/api/extraction/presentation/routes.py
+++ b/src/api/extraction/presentation/routes.py
@@ -11,6 +11,8 @@ from extraction.dependencies import get_extraction_agent_session_service
 from extraction.domain.value_objects import ExtractionSessionMode
 from extraction.presentation.models import (
     BootstrapIntakePathSelectionRequest,
+    ExtractionSessionHistoryItemResponse,
+    ExtractionSessionHistoryResponse,
     ExtractionSessionListResponse,
     ExtractionSessionResponse,
 )
@@ -95,6 +97,36 @@ async def list_sessions(
     )
     payload = [ExtractionSessionResponse.from_domain(session) for session in sessions]
     return ExtractionSessionListResponse(sessions=payload, count=len(payload))
+
+
+@router.get(
+    "/knowledge-graphs/{knowledge_graph_id}/sessions/{mode}/history",
+    response_model=ExtractionSessionHistoryResponse,
+)
+async def list_session_history(
+    knowledge_graph_id: str,
+    mode: ExtractionSessionMode,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    service: Annotated[
+        ExtractionAgentSessionService, Depends(get_extraction_agent_session_service)
+    ],
+    authz: Annotated[AuthorizationProvider, Depends(get_spicedb_client)],
+) -> ExtractionSessionHistoryResponse:
+    await _assert_kg_edit_permission(
+        authz=authz,
+        current_user=current_user,
+        knowledge_graph_id=knowledge_graph_id,
+    )
+    history = await service.list_session_history(
+        user_id=current_user.user_id.value,
+        knowledge_graph_id=knowledge_graph_id,
+        mode=mode,
+    )
+    payload = [
+        ExtractionSessionHistoryItemResponse.from_history_record(record)
+        for record in history
+    ]
+    return ExtractionSessionHistoryResponse(sessions=payload, count=len(payload))
 
 
 @router.post(

--- a/src/api/tests/integration/extraction/__init__.py
+++ b/src/api/tests/integration/extraction/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for Extraction bounded context."""

--- a/src/api/tests/integration/extraction/conftest.py
+++ b/src/api/tests/integration/extraction/conftest.py
@@ -1,0 +1,3 @@
+"""Integration test fixtures for Extraction bounded context."""
+
+pytest_plugins = ["tests.integration.management.conftest"]

--- a/src/api/tests/integration/extraction/test_session_history_retention.py
+++ b/src/api/tests/integration/extraction/test_session_history_retention.py
@@ -1,0 +1,192 @@
+"""Integration tests for archived extraction session history and run metadata."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import text
+
+from extraction.application.agent_session_service import ExtractionAgentSessionService
+from extraction.domain.value_objects import ExtractionSessionMode
+from extraction.infrastructure.repositories import (
+    ExtractionAgentSessionRepository,
+    ExtractionSessionRunMetricsReader,
+)
+from management.application.services.data_source_service import DataSourceService
+from management.application.services.knowledge_graph_service import KnowledgeGraphService
+from management.domain.aggregates import KnowledgeGraph
+from management.domain.entities.data_source_sync_run import MutationLogRunMetadata
+from management.domain.value_objects import EdgeTypeDefinition, NodeTypeDefinition, OntologyConfig
+from shared_kernel.datasource_types import DataSourceAdapterType
+from tests.fakes.authorization import InMemoryAuthorizationProvider
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_archived_session_history_retains_linked_run_metadata(
+    async_session,
+    clean_management_data: None,
+    knowledge_graph_repository,
+    data_source_repository,
+    data_source_sync_run_repository,
+    test_tenant: str,
+    test_workspace: str,
+) -> None:
+    """Clear chat archives sessions while history retrieval keeps run metrics."""
+    table_check = await async_session.execute(
+        text(
+            """
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_name = 'extraction_agent_sessions'
+            """
+        )
+    )
+    if table_check.scalar_one_or_none() is None:
+        pytest.skip("extraction_agent_sessions table is missing in local integration database")
+    await async_session.rollback()
+
+    user_id = "user-integration-session-history"
+    authz = InMemoryAuthorizationProvider()
+
+    kg_service = KnowledgeGraphService(
+        session=async_session,
+        knowledge_graph_repository=knowledge_graph_repository,
+        data_source_repository=data_source_repository,
+        sync_run_repository=data_source_sync_run_repository,
+        secret_store=None,
+        authz=authz,
+        scope_to_tenant=test_tenant,
+    )
+    ds_service = DataSourceService(
+        session=async_session,
+        data_source_repository=data_source_repository,
+        knowledge_graph_repository=knowledge_graph_repository,
+        sync_run_repository=data_source_sync_run_repository,
+        secret_store=None,
+        authz=authz,
+        scope_to_tenant=test_tenant,
+    )
+
+    knowledge_graph = KnowledgeGraph.create(
+        tenant_id=test_tenant,
+        workspace_id=test_workspace,
+        name="Session History KG",
+        description="Archived session history retention",
+        created_by=user_id,
+    )
+    ontology_config = OntologyConfig(
+        node_types=(
+            NodeTypeDefinition(label="Repository"),
+            NodeTypeDefinition(
+                label="SeedNode",
+                prepopulated=True,
+                prepopulated_instance_count=1,
+            ),
+        ),
+        edge_types=(
+            EdgeTypeDefinition(
+                label="CONTAINS",
+                source_labels=("Repository",),
+                target_labels=("SeedNode",),
+            ),
+        ),
+    )
+    knowledge_graph.set_ontology(ontology_config)
+    async with async_session.begin():
+        await knowledge_graph_repository.save(knowledge_graph)
+
+    await authz.write_relationship(
+        f"knowledge_graph:{knowledge_graph.id.value}",
+        "admin",
+        f"user:{user_id}",
+    )
+    await kg_service.save_ontology(
+        user_id=user_id,
+        kg_id=knowledge_graph.id.value,
+        config=ontology_config,
+    )
+    transitioned = await kg_service.transition_workspace_to_extraction(
+        user_id=user_id,
+        kg_id=knowledge_graph.id.value,
+    )
+    assert transitioned.session_pointers.active_extraction_operations_session_id is not None
+
+    session_repo = ExtractionAgentSessionRepository(session=async_session)
+    metrics_reader = ExtractionSessionRunMetricsReader(session=async_session)
+    session_service = ExtractionAgentSessionService(
+        repository=session_repo,
+        run_metrics_reader=metrics_reader,
+    )
+
+    active = await session_service.get_or_create_active_session(
+        user_id=user_id,
+        knowledge_graph_id=knowledge_graph.id.value,
+        mode=ExtractionSessionMode.EXTRACTION_OPERATIONS,
+    )
+    session_id = active.id
+
+    data_source = await ds_service.create(
+        user_id=user_id,
+        kg_id=knowledge_graph.id.value,
+        name="History Source",
+        adapter_type=DataSourceAdapterType.GITHUB,
+        connection_config={"repo_url": "https://github.com/example/repo"},
+    )
+    await authz.write_relationship(
+        f"data_source:{data_source.id.value}",
+        "manage",
+        f"user:{user_id}",
+    )
+    sync_run = await ds_service.trigger_sync(
+        user_id=user_id,
+        ds_id=data_source.id.value,
+    )
+    sync_run.status = "completed"
+    sync_run.completed_at = datetime.now(UTC)
+    sync_run.mutation_log_run = MutationLogRunMetadata(
+        mutation_log_id="mlog-history-001",
+        knowledge_graph_id=knowledge_graph.id.value,
+        session_id=session_id,
+        actor_id=user_id,
+        started_at=sync_run.started_at,
+        completed_at=sync_run.completed_at,
+        token_usage_total=1024,
+        cost_total_usd=0.88,
+        operation_counts={"create_node": 4},
+    )
+    async with async_session.begin():
+        await data_source_sync_run_repository.save(sync_run)
+
+    archived_session = await session_service.clear_chat(
+        user_id=user_id,
+        knowledge_graph_id=knowledge_graph.id.value,
+        mode=ExtractionSessionMode.EXTRACTION_OPERATIONS,
+    )
+    assert archived_session.id != session_id
+
+    history = await session_service.list_session_history(
+        user_id=user_id,
+        knowledge_graph_id=knowledge_graph.id.value,
+        mode=ExtractionSessionMode.EXTRACTION_OPERATIONS,
+    )
+
+    assert len(history) == 2
+    archived_record = next(item for item in history if item.session.id == session_id)
+    assert archived_record.session.archived_at is not None
+    assert archived_record.session.updated_at is not None
+    assert len(archived_record.run_metrics) == 1
+    assert archived_record.run_metrics[0].mutation_log_id == "mlog-history-001"
+    assert archived_record.run_metrics[0].token_usage_total == 1024
+    assert archived_record.run_metrics[0].operation_counts == {"create_node": 4}
+
+    still_archived = await session_repo.get_by_id(session_id)
+    assert still_archived is not None
+    assert still_archived.archived_at is not None
+
+    runs = await data_source_sync_run_repository.find_by_data_source(data_source.id.value)
+    assert len(runs) == 1
+    assert runs[0].mutation_log_run is not None
+    assert runs[0].mutation_log_run.session_id == session_id

--- a/src/api/tests/integration/management/conftest.py
+++ b/src/api/tests/integration/management/conftest.py
@@ -105,6 +105,7 @@ async def clean_management_data(
                 )
             )
             await async_session.execute(text("DELETE FROM data_source_sync_runs"))
+            await async_session.execute(text("DELETE FROM extraction_agent_sessions"))
             await async_session.execute(text("DELETE FROM data_sources"))
             await async_session.execute(text("DELETE FROM knowledge_graphs"))
             await async_session.commit()

--- a/src/api/tests/unit/extraction/application/test_session_history_service.py
+++ b/src/api/tests/unit/extraction/application/test_session_history_service.py
@@ -1,0 +1,164 @@
+"""Unit tests for extraction session history with run-level metrics."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+
+import pytest
+
+from extraction.application.agent_session_service import ExtractionAgentSessionService
+from extraction.domain.entities.agent_session import ExtractionAgentSession
+from extraction.domain.value_objects import ExtractionSessionMode, ExtractionSessionRunMetric
+from extraction.domain.value_objects import ExtractionSessionMode as Mode
+
+
+class _InMemoryAgentSessionRepository:
+    def __init__(self) -> None:
+        self._by_id: dict[str, ExtractionAgentSession] = {}
+
+    async def save(self, session: ExtractionAgentSession) -> None:
+        self._by_id[session.id] = replace(session)
+
+    async def get_by_id(self, session_id: str) -> ExtractionAgentSession | None:
+        session = self._by_id.get(session_id)
+        return replace(session) if session else None
+
+    async def find_active_by_scope(
+        self,
+        user_id: str,
+        knowledge_graph_id: str,
+        mode: ExtractionSessionMode,
+    ) -> ExtractionAgentSession | None:
+        for session in self._by_id.values():
+            if (
+                session.user_id == user_id
+                and session.knowledge_graph_id == knowledge_graph_id
+                and session.mode == mode
+                and session.archived_at is None
+            ):
+                return replace(session)
+        return None
+
+    async def list_by_scope(
+        self,
+        user_id: str,
+        knowledge_graph_id: str,
+        mode: ExtractionSessionMode | None = None,
+    ) -> list[ExtractionAgentSession]:
+        sessions = [
+            replace(session)
+            for session in self._by_id.values()
+            if session.user_id == user_id
+            and session.knowledge_graph_id == knowledge_graph_id
+            and (mode is None or session.mode == mode)
+        ]
+        return sorted(sessions, key=lambda s: s.updated_at, reverse=True)
+
+
+class _InMemoryRunMetricsReader:
+    def __init__(self) -> None:
+        self._metrics: dict[str, list[ExtractionSessionRunMetric]] = {}
+
+    def seed(self, session_id: str, metric: ExtractionSessionRunMetric) -> None:
+        self._metrics.setdefault(session_id, []).append(metric)
+
+    async def find_metrics_by_session_ids(
+        self,
+        *,
+        knowledge_graph_id: str,
+        session_ids: list[str],
+    ) -> dict[str, list[ExtractionSessionRunMetric]]:
+        del knowledge_graph_id
+        return {
+            session_id: list(self._metrics.get(session_id, []))
+            for session_id in session_ids
+        }
+
+
+@pytest.mark.asyncio
+class TestExtractionSessionHistoryService:
+    async def test_list_session_history_includes_archived_sessions_with_metrics(self):
+        repo = _InMemoryAgentSessionRepository()
+        metrics_reader = _InMemoryRunMetricsReader()
+        service = ExtractionAgentSessionService(
+            repository=repo,
+            run_metrics_reader=metrics_reader,
+        )
+
+        archived = await service.get_or_create_active_session(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode=Mode.EXTRACTION_OPERATIONS,
+        )
+        archived.message_history = [{"role": "user", "content": "hello"}]
+        archived.updated_at = datetime(2026, 5, 20, 12, 0, tzinfo=UTC)
+        await repo.save(archived)
+        metrics_reader.seed(
+            archived.id,
+            ExtractionSessionRunMetric(
+                sync_run_id="run-1",
+                mutation_log_id="mlog-1",
+                status="completed",
+                started_at=datetime(2026, 5, 20, 11, 0, tzinfo=UTC),
+                completed_at=datetime(2026, 5, 20, 11, 30, tzinfo=UTC),
+                token_usage_total=512,
+                cost_total_usd=0.42,
+                operation_counts={"create_node": 3},
+            ),
+        )
+
+        await service.clear_chat(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode=Mode.EXTRACTION_OPERATIONS,
+        )
+
+        history = await service.list_session_history(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode=Mode.EXTRACTION_OPERATIONS,
+        )
+
+        assert len(history) == 2
+        archived_record = next(item for item in history if item.session.archived_at is not None)
+        assert archived_record.session.id == archived.id
+        assert archived_record.session.updated_at is not None
+        assert archived_record.session.archived_at is not None
+        assert len(archived_record.run_metrics) == 1
+        assert archived_record.run_metrics[0].mutation_log_id == "mlog-1"
+        assert archived_record.run_metrics[0].token_usage_total == 512
+
+    async def test_clear_chat_retains_archived_sessions_for_history(self):
+        repo = _InMemoryAgentSessionRepository()
+        metrics_reader = _InMemoryRunMetricsReader()
+        service = ExtractionAgentSessionService(
+            repository=repo,
+            run_metrics_reader=metrics_reader,
+        )
+
+        first = await service.get_or_create_active_session(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode=Mode.EXTRACTION_OPERATIONS,
+        )
+        await service.clear_chat(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode=Mode.EXTRACTION_OPERATIONS,
+        )
+        await service.clear_chat(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode=Mode.EXTRACTION_OPERATIONS,
+        )
+
+        history = await service.list_session_history(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode=Mode.EXTRACTION_OPERATIONS,
+        )
+
+        assert len(history) == 3
+        assert any(item.session.id == first.id and item.session.archived_at is not None for item in history)
+        assert sum(1 for item in history if item.session.archived_at is None) == 1

--- a/src/api/tests/unit/extraction/presentation/test_routes.py
+++ b/src/api/tests/unit/extraction/presentation/test_routes.py
@@ -197,3 +197,30 @@ class TestExtractionSessionRoutes:
         assert intake["selected_path"] == BootstrapIntakePath.GUIDED_CO_DESIGN.value
         assert intake["status"] == "path_selected"
 
+    def test_session_history_endpoint_returns_archived_sessions_with_run_metrics(
+        self, extraction_client
+    ):
+        client, _ = extraction_client
+        active = client.get(
+            "/extraction/knowledge-graphs/kg-123/sessions/extraction_operations/active"
+        )
+        assert active.status_code == status.HTTP_200_OK
+        archived_id = active.json()["id"]
+
+        client.post(
+            "/extraction/knowledge-graphs/kg-123/sessions/extraction_operations/clear-chat"
+        )
+
+        response = client.get(
+            "/extraction/knowledge-graphs/kg-123/sessions/extraction_operations/history"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        payload = response.json()
+        assert payload["count"] == 2
+        archived = next(
+            row for row in payload["sessions"] if row["id"] == archived_id
+        )
+        assert archived["archived_at"] is not None
+        assert archived["updated_at"] is not None
+        assert archived["run_metrics"] == []
+

--- a/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
+++ b/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
@@ -59,6 +59,27 @@ interface ExtractionSessionResponse {
   updated_at: string
 }
 
+interface SessionRunMetricView {
+  sync_run_id: string
+  mutation_log_id: string | null
+  status: string
+  started_at: string
+  completed_at: string | null
+  token_usage_total: number | null
+  cost_total_usd: number | null
+  operation_counts: Record<string, number>
+}
+
+interface ExtractionSessionHistoryItem {
+  id: string
+  created_at: string
+  updated_at: string
+  archived_at: string | null
+  is_active: boolean
+  message_count: number
+  run_metrics: SessionRunMetricView[]
+}
+
 const route = useRoute()
 const { hasTenant, tenantVersion } = useTenant()
 const { extractErrorMessage } = useErrorHandler()
@@ -68,8 +89,10 @@ const loading = ref(false)
 const validating = ref(false)
 const transitioning = ref(false)
 const sessionLoading = ref(false)
+const sessionHistoryLoading = ref(false)
 const clearingChat = ref(false)
 const extractionSession = ref<ExtractionSessionResponse | null>(null)
+const sessionHistory = ref<ExtractionSessionHistoryItem[]>([])
 const extractionTab = ref('extraction-jobs')
 const draftMessage = ref('')
 const statusProjection = ref<WorkspaceStatusResponse | null>(null)
@@ -232,6 +255,24 @@ async function loadExtractionSession() {
   }
 }
 
+async function loadSessionHistory() {
+  if (!kgId.value) return
+  sessionHistoryLoading.value = true
+  try {
+    const response = await apiFetch<{ sessions: ExtractionSessionHistoryItem[] }>(
+      `/extraction/knowledge-graphs/${kgId.value}/sessions/${sessionMode.value}/history`,
+    )
+    sessionHistory.value = response.sessions
+  } catch (err) {
+    sessionHistory.value = []
+    toast.error('Failed to load session history', {
+      description: extractErrorMessage(err),
+    })
+  } finally {
+    sessionHistoryLoading.value = false
+  }
+}
+
 async function validateWorkspace() {
   if (!kgId.value) return
   validating.value = true
@@ -278,6 +319,7 @@ async function clearChat() {
       { method: 'POST' },
     )
     toast.success('Extraction chat cleared')
+    await loadSessionHistory()
   } catch (err) {
     toast.error('Failed to clear chat', {
       description: extractErrorMessage(err),
@@ -304,6 +346,7 @@ watch(
   (mode) => {
     if (mode) {
       loadExtractionSession()
+      loadSessionHistory()
     }
   },
 )
@@ -493,6 +536,75 @@ watch(
             <p class="font-mono break-all mt-1">
               {{ statusProjection.session_pointers.most_recent_completed_session_id ?? 'None' }}
             </p>
+          </div>
+        </CardContent>
+        <CardContent class="space-y-3 border-t pt-4">
+          <div class="flex items-center justify-between">
+            <p class="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Session History
+            </p>
+            <Button
+              size="sm"
+              variant="ghost"
+              class="h-6 px-2 text-[10px]"
+              :disabled="sessionHistoryLoading"
+              @click="loadSessionHistory"
+            >
+              Refresh
+            </Button>
+          </div>
+          <div
+            v-if="sessionHistoryLoading"
+            class="flex items-center gap-2 text-xs text-muted-foreground"
+          >
+            <Loader2 class="size-3.5 animate-spin" />
+            Loading session history...
+          </div>
+          <div
+            v-else-if="sessionHistory.length === 0"
+            class="rounded border border-dashed px-3 py-4 text-xs text-muted-foreground"
+          >
+            No archived or active sessions found for this scope yet.
+          </div>
+          <div v-else class="space-y-2">
+            <div
+              v-for="entry in sessionHistory"
+              :key="entry.id"
+              class="rounded border px-3 py-2 text-xs"
+            >
+              <div class="flex flex-wrap items-center justify-between gap-2">
+                <p class="font-mono break-all">{{ entry.id }}</p>
+                <Badge :variant="entry.is_active ? 'default' : 'secondary'">
+                  {{ entry.is_active ? 'Active' : 'Archived' }}
+                </Badge>
+              </div>
+              <p class="mt-1 text-muted-foreground">
+                Updated {{ new Date(entry.updated_at).toLocaleString() }}
+                <span v-if="entry.archived_at">
+                  · Archived {{ new Date(entry.archived_at).toLocaleString() }}
+                </span>
+              </p>
+              <p class="mt-1 text-muted-foreground">
+                {{ entry.message_count }} message(s)
+                · {{ entry.run_metrics.length }} linked run(s)
+              </p>
+              <div
+                v-if="entry.run_metrics.length > 0"
+                class="mt-2 space-y-1.5 rounded border bg-muted/20 p-2"
+              >
+                <div
+                  v-for="metric in entry.run_metrics"
+                  :key="metric.sync_run_id"
+                  class="flex flex-wrap items-center justify-between gap-2"
+                >
+                  <span class="font-mono">{{ metric.mutation_log_id ?? metric.sync_run_id }}</span>
+                  <span class="text-muted-foreground">
+                    {{ metric.token_usage_total ?? 0 }} tokens ·
+                    ${{ (metric.cost_total_usd ?? 0).toFixed(2) }}
+                  </span>
+                </div>
+              </div>
+            </div>
           </div>
         </CardContent>
       </Card>

--- a/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
+++ b/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
@@ -41,6 +41,15 @@ describe('Knowledge Graph Manage Workspace - mode-aware controls', () => {
     expect(manageWorkspaceVue).toContain('active_extraction_operations_session_id')
   })
 
+  it('loads scoped session history with run metrics after clear chat', () => {
+    expect(manageWorkspaceVue).toContain('loadSessionHistory')
+    expect(manageWorkspaceVue).toContain('/sessions/${sessionMode.value}/history')
+    expect(manageWorkspaceVue).toContain('sessionHistory')
+    expect(manageWorkspaceVue).toContain('run_metrics')
+    expect(manageWorkspaceVue).toContain('Session History')
+  })
+
+
   it('uses shared conversation panel for bootstrap and extraction sessions', () => {
     expect(manageWorkspaceVue).toContain('SharedConversationPanel')
     expect(manageWorkspaceVue).toContain('sessionMode')
@@ -50,7 +59,7 @@ describe('Knowledge Graph Manage Workspace - mode-aware controls', () => {
   it('supports explicit Clear chat reset for extraction session', () => {
     expect(manageWorkspaceVue).toContain('clearChat')
     expect(manageWorkspaceVue).toContain('/sessions/${sessionMode.value}/clear-chat')
-    expect(manageWorkspaceVue).toContain('Clear chat')
+    expect(sharedConversationPanelVue).toContain('Clear chat')
   })
 
   it('provides tabbed lower operations area for extraction workflows', () => {


### PR DESCRIPTION
## Summary
- Adds `GET /extraction/knowledge-graphs/{kg_id}/sessions/{mode}/history` returning scoped session records with `updated_at`, archival state, and linked mutation-run metrics (tokens, cost, operation counts).
- Clear chat archives the prior session without deleting history; a new read port resolves run metadata from sync runs by session ID while preserving bounded-context isolation.
- KG manage workspace surfaces session history in the Session Pointers card and reloads history after clear chat.

Closes #719

## Test plan
- [x] `cd src/api && uv run pytest tests/unit/extraction/application/test_session_history_service.py tests/unit/extraction/presentation/test_routes.py -v`
- [x] `cd src/api && uv run pytest tests/integration/extraction/test_session_history_retention.py -v -m integration`
- [x] `cd src/dev-ui && npx vitest run app/tests/knowledge-graph-manage-workspace.test.ts`


Made with [Cursor](https://cursor.com)