### PR TITLE
feat(extraction): container-backed workload runtime adapters (sticky + ephemeral)

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -5,10 +5,14 @@ services:
     user: "${UID}:${GID}"
     environment:
       UV_CACHE_DIR: /tmp/uv-cache
+      KARTOGRAPH_EXTRACTION_RUNTIME_BACKEND: container
+      KARTOGRAPH_EXTRACTION_RUNTIME_CONTAINER_ENGINE: auto
     volumes:
       # Mount the entire app directory  (minus  venv) for hot-reload
       - ./src/api:/app:z
       - /app/.venv
+      # Allow API process to launch sibling extraction runtime containers locally
+      - /var/run/docker.sock:/var/run/docker.sock
     command:
       - /bin/bash
       - -c

--- a/env/api.env
+++ b/env/api.env
@@ -13,3 +13,7 @@ KARTOGRAPH_IAM_BOOTSTRAP_ADMIN_USERNAMES='["alice"]'
 KARTOGRAPH_IAM_SINGLE_TENANT_MODE=false
 # Generate with uv run python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 KARTOGRAPH_MGMT_ENCRYPTION_KEY="vwN4rUcH-KL-UyJsL8hc6apftRUTovwec6L2M5uF5OE="
+# Extraction runtime defaults to in-memory adapters. Set backend=container and
+# mount /var/run/docker.sock (see compose.dev.yaml) for local container execution.
+KARTOGRAPH_EXTRACTION_RUNTIME_BACKEND=memory
+KARTOGRAPH_EXTRACTION_RUNTIME_CONTAINER_ENGINE=auto

--- a/src/api/extraction/dependencies.py
+++ b/src/api/extraction/dependencies.py
@@ -1,5 +1,6 @@
 """FastAPI dependencies for Extraction services."""
 
+from functools import lru_cache
 from typing import Annotated
 
 from fastapi import Depends
@@ -14,7 +15,27 @@ from extraction.infrastructure.repositories import (
     ExtractionSessionRunMetricsReader,
     ExtractionSkillOverrideRepository,
 )
+from extraction.infrastructure.workload_runtime_factory import (
+    create_ephemeral_extraction_worker_launcher,
+    create_sticky_session_runtime_manager,
+)
+from extraction.ports.runtime import (
+    IEphemeralExtractionWorkerLauncher,
+    IStickySessionRuntimeManager,
+)
 from infrastructure.database.dependencies import get_write_session
+
+
+@lru_cache
+def get_sticky_session_runtime_manager() -> IStickySessionRuntimeManager:
+    """Return configured sticky session runtime manager."""
+    return create_sticky_session_runtime_manager()
+
+
+@lru_cache
+def get_ephemeral_extraction_worker_launcher() -> IEphemeralExtractionWorkerLauncher:
+    """Return configured ephemeral extraction worker launcher."""
+    return create_ephemeral_extraction_worker_launcher()
 
 
 def get_extraction_agent_session_service(

--- a/src/api/extraction/infrastructure/__init__.py
+++ b/src/api/extraction/infrastructure/__init__.py
@@ -1,5 +1,9 @@
 """Extraction infrastructure adapters and event handlers."""
 
+from extraction.infrastructure.container_workload_runtime import (
+    ContainerEphemeralExtractionWorkerLauncher,
+    ContainerStickySessionRuntimeManager,
+)
 from extraction.infrastructure.event_handler import ExtractionEventHandler
 from extraction.infrastructure.repositories import (
     ExtractionAgentSessionRepository,
@@ -13,14 +17,21 @@ from extraction.infrastructure.workload_runtime import (
     InMemoryStickySessionRuntimeManager,
     ScopedWorkloadCredentialIssuer,
 )
+from extraction.infrastructure.workload_runtime_factory import (
+    create_ephemeral_extraction_worker_launcher,
+    create_sticky_session_runtime_manager,
+)
 
 __all__ = [
     "ExtractionEventHandler",
     "ExtractionAgentSessionRepository",
     "ExtractionSkillOverrideRepository",
     "FilesystemExtractionRuntimeContextBuilder",
+    "ContainerStickySessionRuntimeManager",
+    "ContainerEphemeralExtractionWorkerLauncher",
     "InMemoryStickySessionRuntimeManager",
     "ScopedWorkloadCredentialIssuer",
     "InMemoryEphemeralExtractionWorkerLauncher",
+    "create_sticky_session_runtime_manager",
+    "create_ephemeral_extraction_worker_launcher",
 ]
-

--- a/src/api/extraction/infrastructure/container_workload_runtime.py
+++ b/src/api/extraction/infrastructure/container_workload_runtime.py
@@ -1,0 +1,236 @@
+"""Container-backed extraction workload runtime adapters."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+
+from ulid import ULID
+
+from extraction.ports.runtime import (
+    EphemeralWorkerLaunchRequest,
+    EphemeralWorkerLaunchResult,
+    IEphemeralExtractionWorkerLauncher,
+    IStickySessionRuntimeManager,
+    ScopedWorkloadCredentials,
+    StickySessionRuntimeLease,
+)
+from shared_kernel.container_runtime.ports import ContainerRunSpec, IContainerRuntime
+
+_CONTAINER_NAME_SAFE = re.compile(r"[^a-zA-Z0-9_.-]+")
+
+
+def _sanitize_container_name(prefix: str, identifier: str) -> str:
+    cleaned = _CONTAINER_NAME_SAFE.sub("-", identifier).strip("-")
+    name = f"{prefix}{cleaned}"
+    return name[:63].rstrip("-_.") or f"{prefix}runtime"
+
+
+class ContainerStickySessionRuntimeManager(IStickySessionRuntimeManager):
+    """Sticky runtime manager backed by real container lifecycle operations."""
+
+    def __init__(
+        self,
+        *,
+        container_runtime: IContainerRuntime,
+        sticky_image: str,
+        sticky_command: tuple[str, ...],
+        session_ttl: timedelta = timedelta(minutes=30),
+    ) -> None:
+        self._container_runtime = container_runtime
+        self._sticky_image = sticky_image
+        self._sticky_command = sticky_command
+        self._session_ttl = session_ttl
+        self._leases: dict[str, StickySessionRuntimeLease] = {}
+
+    def get_or_start_runtime(
+        self,
+        *,
+        session_id: str,
+        user_id: str,
+        knowledge_graph_id: str,
+        mode: str,
+    ) -> StickySessionRuntimeLease:
+        now = datetime.now(UTC)
+        existing = self._leases.get(session_id)
+        if (
+            existing is not None
+            and existing.expires_at > now
+            and self._container_runtime.is_running(existing.container_id)
+        ):
+            refreshed = replace(
+                existing,
+                last_activity_at=now,
+                expires_at=now + self._session_ttl,
+                status="active",
+            )
+            self._leases[session_id] = refreshed
+            return refreshed
+
+        if existing is not None:
+            self._terminate_container(existing.container_id)
+
+        lease = self._start_runtime(
+            session_id=session_id,
+            user_id=user_id,
+            knowledge_graph_id=knowledge_graph_id,
+            mode=mode,
+            now=now,
+        )
+        self._leases[session_id] = lease
+        return lease
+
+    def reset_runtime(
+        self,
+        *,
+        session_id: str,
+        user_id: str,
+        knowledge_graph_id: str,
+        mode: str,
+    ) -> StickySessionRuntimeLease:
+        existing = self._leases.pop(session_id, None)
+        if existing is not None:
+            self._terminate_container(existing.container_id)
+        return self.get_or_start_runtime(
+            session_id=session_id,
+            user_id=user_id,
+            knowledge_graph_id=knowledge_graph_id,
+            mode=mode,
+        )
+
+    def cleanup_expired(self, *, now: datetime) -> list[str]:
+        expired_sessions = [
+            session_id
+            for session_id, lease in self._leases.items()
+            if lease.expires_at <= now
+        ]
+        terminated: list[str] = []
+        for session_id in expired_sessions:
+            lease = self._leases.pop(session_id)
+            self._terminate_container(lease.container_id)
+            terminated.append(lease.container_id)
+        return terminated
+
+    def _start_runtime(
+        self,
+        *,
+        session_id: str,
+        user_id: str,
+        knowledge_graph_id: str,
+        mode: str,
+        now: datetime,
+    ) -> StickySessionRuntimeLease:
+        container_name = _sanitize_container_name("kartograph-sticky-", session_id)
+        launched = self._container_runtime.run(
+            ContainerRunSpec(
+                image=self._sticky_image,
+                name=container_name,
+                labels={
+                    "kartograph.runtime.kind": "sticky",
+                    "kartograph.session_id": session_id,
+                    "kartograph.user_id": user_id,
+                    "kartograph.knowledge_graph_id": knowledge_graph_id,
+                    "kartograph.mode": mode,
+                },
+                command=self._sticky_command,
+            )
+        )
+        return StickySessionRuntimeLease(
+            session_id=session_id,
+            container_id=launched.container_id,
+            user_id=user_id,
+            knowledge_graph_id=knowledge_graph_id,
+            mode=mode,
+            status="active",
+            last_activity_at=now,
+            expires_at=now + self._session_ttl,
+        )
+
+    def _terminate_container(self, container_id: str) -> None:
+        if self._container_runtime.is_running(container_id):
+            self._container_runtime.stop(container_id)
+        self._container_runtime.remove(container_id, force=True)
+
+
+class ContainerEphemeralExtractionWorkerLauncher(IEphemeralExtractionWorkerLauncher):
+    """Ephemeral worker launcher backed by real container lifecycle operations."""
+
+    def __init__(
+        self,
+        *,
+        container_runtime: IContainerRuntime,
+        worker_image: str,
+        worker_command: tuple[str, ...],
+    ) -> None:
+        self._container_runtime = container_runtime
+        self._worker_image = worker_image
+        self._worker_command = worker_command
+        self._active_workers: dict[str, tuple[EphemeralWorkerLaunchRequest, str]] = {}
+
+    @property
+    def active_worker_count(self) -> int:
+        return len(self._active_workers)
+
+    def worker_container_id(self, worker_id: str) -> str | None:
+        worker = self._active_workers.get(worker_id)
+        if worker is None:
+            return None
+        return worker[1]
+
+    def launch(
+        self,
+        *,
+        request: EphemeralWorkerLaunchRequest,
+        credentials: ScopedWorkloadCredentials,
+    ) -> EphemeralWorkerLaunchResult:
+        required_scopes = {
+            f"tenant:{request.tenant_id}",
+            f"knowledge_graph:{request.knowledge_graph_id}",
+            "workload:extraction",
+        }
+        available_scopes = set(credentials.scopes)
+        if not required_scopes.issubset(available_scopes):
+            raise ValueError("credentials scope does not satisfy workload requirements")
+        if credentials.expires_at <= datetime.now(UTC):
+            raise ValueError("credentials are expired")
+
+        worker_id = str(ULID())
+        container_name = _sanitize_container_name("kartograph-worker-", worker_id)
+        launched = self._container_runtime.run(
+            ContainerRunSpec(
+                image=self._worker_image,
+                name=container_name,
+                env={
+                    "KARTOGRAPH_WORKLOAD_TOKEN": credentials.token,
+                    "KARTOGRAPH_TENANT_ID": request.tenant_id,
+                    "KARTOGRAPH_KNOWLEDGE_GRAPH_ID": request.knowledge_graph_id,
+                    "KARTOGRAPH_SESSION_ID": request.session_id,
+                    "KARTOGRAPH_SYNC_RUN_ID": request.sync_run_id,
+                    "KARTOGRAPH_JOB_PACKAGE_ID": request.job_package_id,
+                },
+                labels={
+                    "kartograph.runtime.kind": "ephemeral",
+                    "kartograph.worker_id": worker_id,
+                    "kartograph.session_id": request.session_id,
+                    "kartograph.sync_run_id": request.sync_run_id,
+                    "kartograph.job_package_id": request.job_package_id,
+                },
+                command=self._worker_command,
+            )
+        )
+        self._active_workers[worker_id] = (request, launched.container_id)
+        return EphemeralWorkerLaunchResult(
+            worker_id=worker_id,
+            status="running",
+            credentials_expires_at=credentials.expires_at,
+        )
+
+    def complete_worker(self, worker_id: str) -> None:
+        worker = self._active_workers.pop(worker_id, None)
+        if worker is None:
+            return
+        container_id = worker[1]
+        if self._container_runtime.is_running(container_id):
+            self._container_runtime.stop(container_id)
+        self._container_runtime.remove(container_id, force=True)

--- a/src/api/extraction/infrastructure/workload_runtime_factory.py
+++ b/src/api/extraction/infrastructure/workload_runtime_factory.py
@@ -1,0 +1,58 @@
+"""Factory helpers for extraction workload runtime adapters."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from extraction.infrastructure.container_workload_runtime import (
+    ContainerEphemeralExtractionWorkerLauncher,
+    ContainerStickySessionRuntimeManager,
+)
+from extraction.infrastructure.workload_runtime import (
+    InMemoryEphemeralExtractionWorkerLauncher,
+    InMemoryStickySessionRuntimeManager,
+)
+from extraction.infrastructure.workload_runtime_settings import (
+    ExtractionWorkloadRuntimeSettings,
+    get_extraction_workload_runtime_settings,
+)
+from extraction.ports.runtime import (
+    IEphemeralExtractionWorkerLauncher,
+    IStickySessionRuntimeManager,
+)
+from shared_kernel.container_runtime.factory import create_container_runtime
+
+
+def create_sticky_session_runtime_manager(
+    settings: ExtractionWorkloadRuntimeSettings | None = None,
+) -> IStickySessionRuntimeManager:
+    """Build sticky runtime manager for configured backend."""
+    resolved = settings or get_extraction_workload_runtime_settings()
+    if resolved.backend == "memory":
+        return InMemoryStickySessionRuntimeManager(
+            session_ttl=timedelta(minutes=resolved.session_ttl_minutes)
+        )
+
+    container_runtime = create_container_runtime(resolved.container_engine)
+    return ContainerStickySessionRuntimeManager(
+        container_runtime=container_runtime,
+        sticky_image=resolved.sticky_image,
+        sticky_command=resolved.sticky_command,
+        session_ttl=timedelta(minutes=resolved.session_ttl_minutes),
+    )
+
+
+def create_ephemeral_extraction_worker_launcher(
+    settings: ExtractionWorkloadRuntimeSettings | None = None,
+) -> IEphemeralExtractionWorkerLauncher:
+    """Build ephemeral worker launcher for configured backend."""
+    resolved = settings or get_extraction_workload_runtime_settings()
+    if resolved.backend == "memory":
+        return InMemoryEphemeralExtractionWorkerLauncher()
+
+    container_runtime = create_container_runtime(resolved.container_engine)
+    return ContainerEphemeralExtractionWorkerLauncher(
+        container_runtime=container_runtime,
+        worker_image=resolved.worker_image,
+        worker_command=resolved.worker_command,
+    )

--- a/src/api/extraction/infrastructure/workload_runtime_settings.py
+++ b/src/api/extraction/infrastructure/workload_runtime_settings.py
@@ -1,0 +1,48 @@
+"""Settings for extraction workload runtime execution."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Literal
+
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class ExtractionWorkloadRuntimeSettings(BaseSettings):
+    """Container and in-memory extraction runtime configuration."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="KARTOGRAPH_EXTRACTION_RUNTIME_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    backend: Literal["memory", "container"] = Field(default="memory")
+    container_engine: Literal["auto", "docker", "podman"] = Field(default="auto")
+    sticky_image: str = Field(default="docker.io/library/busybox:1.36")
+    worker_image: str = Field(default="docker.io/library/busybox:1.36")
+    sticky_command: tuple[str, ...] = Field(default=("sleep", "3600"))
+    worker_command: tuple[str, ...] = Field(default=("sleep", "3600"))
+    session_ttl_minutes: int = Field(default=30, ge=1, le=24 * 60)
+
+    @field_validator("sticky_command", "worker_command", mode="before")
+    @classmethod
+    def _parse_command(cls, value: object) -> tuple[str, ...]:
+        if isinstance(value, tuple):
+            return value
+        if isinstance(value, list):
+            return tuple(str(part) for part in value)
+        if isinstance(value, str):
+            parts = value.split()
+            if not parts:
+                raise ValueError("command must not be empty")
+            return tuple(parts)
+        raise TypeError("command must be a string or sequence")
+
+
+@lru_cache
+def get_extraction_workload_runtime_settings() -> ExtractionWorkloadRuntimeSettings:
+    """Get cached extraction workload runtime settings."""
+    return ExtractionWorkloadRuntimeSettings()

--- a/src/api/shared_kernel/container_runtime/__init__.py
+++ b/src/api/shared_kernel/container_runtime/__init__.py
@@ -1,0 +1,19 @@
+"""Container runtime abstractions for launching and managing workload containers."""
+
+from shared_kernel.container_runtime.cli_runtime import CliContainerRuntime
+from shared_kernel.container_runtime.factory import create_container_runtime
+from shared_kernel.container_runtime.ports import (
+    ContainerRunResult,
+    ContainerRunSpec,
+    ContainerRuntimeError,
+    IContainerRuntime,
+)
+
+__all__ = [
+    "CliContainerRuntime",
+    "ContainerRunResult",
+    "ContainerRunSpec",
+    "ContainerRuntimeError",
+    "IContainerRuntime",
+    "create_container_runtime",
+]

--- a/src/api/shared_kernel/container_runtime/cli_runtime.py
+++ b/src/api/shared_kernel/container_runtime/cli_runtime.py
@@ -1,0 +1,87 @@
+"""CLI-backed container runtime using docker or podman."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Final
+
+from shared_kernel.container_runtime.ports import (
+    ContainerRunResult,
+    ContainerRunSpec,
+    ContainerRuntimeError,
+)
+
+
+class CliContainerRuntime:
+    """Launch and manage containers through a docker-compatible CLI."""
+
+    _RUNNING_TEMPLATE: Final[str] = "{{.State.Running}}"
+
+    def __init__(self, *, binary: str) -> None:
+        self._binary = binary
+
+    def run(self, spec: ContainerRunSpec) -> ContainerRunResult:
+        command = [self._binary, "run"]
+        if spec.detach:
+            command.append("--detach")
+        if spec.remove_on_exit:
+            command.append("--rm")
+        if spec.name is not None:
+            command.extend(["--name", spec.name])
+        for key, value in sorted(spec.labels.items()):
+            command.extend(["--label", f"{key}={value}"])
+        for key, value in sorted(spec.env.items()):
+            command.extend(["--env", f"{key}={value}"])
+        command.append(spec.image)
+        if spec.command:
+            command.extend(spec.command)
+
+        stdout = self._execute(command)
+        container_id = stdout.splitlines()[0].strip()
+        return ContainerRunResult(container_id=container_id, name=spec.name)
+
+    def stop(self, container_id: str, *, timeout_seconds: int = 10) -> None:
+        self._execute([self._binary, "stop", "-t", str(timeout_seconds), container_id])
+
+    def remove(self, container_id: str, *, force: bool = False) -> None:
+        command = [self._binary, "rm"]
+        if force:
+            command.append("-f")
+        command.append(container_id)
+        self._execute(command)
+
+    def is_running(self, container_id: str) -> bool:
+        result = subprocess.run(
+            [
+                self._binary,
+                "inspect",
+                "-f",
+                self._RUNNING_TEMPLATE,
+                container_id,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip()
+            if "no such" in detail.lower():
+                return False
+            raise ContainerRuntimeError(
+                f"{self._binary} inspect failed: {detail or 'unknown error'}"
+            )
+        return result.stdout.strip().lower() == "true"
+
+    def _execute(self, command: list[str]) -> str:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip() or "unknown error"
+            raise ContainerRuntimeError(
+                f"{self._binary} {' '.join(command[1:])} failed: {detail}"
+            )
+        return result.stdout

--- a/src/api/shared_kernel/container_runtime/factory.py
+++ b/src/api/shared_kernel/container_runtime/factory.py
@@ -1,0 +1,30 @@
+"""Factory helpers for container runtime backends."""
+
+from __future__ import annotations
+
+import shutil
+
+from shared_kernel.container_runtime.cli_runtime import CliContainerRuntime
+from shared_kernel.container_runtime.ports import ContainerRuntimeError, IContainerRuntime
+
+
+def create_container_runtime(engine: str = "auto") -> IContainerRuntime:
+    """Return a CLI container runtime for the requested engine."""
+    binary = _resolve_engine_binary(engine)
+    return CliContainerRuntime(binary=binary)
+
+
+def _resolve_engine_binary(engine: str) -> str:
+    if engine == "auto":
+        for candidate in ("docker", "podman"):
+            if shutil.which(candidate) is not None:
+                return candidate
+        raise ContainerRuntimeError("No docker or podman binary found on PATH")
+
+    if engine not in {"docker", "podman"}:
+        raise ContainerRuntimeError(f"Unsupported container engine: {engine}")
+
+    if shutil.which(engine) is None:
+        raise ContainerRuntimeError(f"{engine} binary not found on PATH")
+
+    return engine

--- a/src/api/shared_kernel/container_runtime/ports.py
+++ b/src/api/shared_kernel/container_runtime/ports.py
@@ -1,0 +1,51 @@
+"""Port contracts for container runtime backends."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+
+class ContainerRuntimeError(RuntimeError):
+    """Raised when a container runtime operation fails."""
+
+
+@dataclass(frozen=True)
+class ContainerRunSpec:
+    """Launch parameters for a detached container."""
+
+    image: str
+    name: str | None = None
+    env: dict[str, str] = field(default_factory=dict)
+    labels: dict[str, str] = field(default_factory=dict)
+    command: tuple[str, ...] | None = None
+    detach: bool = True
+    remove_on_exit: bool = False
+
+
+@dataclass(frozen=True)
+class ContainerRunResult:
+    """Result of a successful container launch."""
+
+    container_id: str
+    name: str | None
+
+
+class IContainerRuntime(Protocol):
+    """Backend-neutral container lifecycle operations."""
+
+    def run(self, spec: ContainerRunSpec) -> ContainerRunResult:
+        """Launch a container and return its identifier."""
+        ...
+
+    def stop(self, container_id: str, *, timeout_seconds: int = 10) -> None:
+        """Stop a running container."""
+        ...
+
+    def remove(self, container_id: str, *, force: bool = False) -> None:
+        """Remove a stopped container."""
+        ...
+
+    def is_running(self, container_id: str) -> bool:
+        """Return True when the container exists and is running."""
+        ...

--- a/src/api/tests/integration/conftest.py
+++ b/src/api/tests/integration/conftest.py
@@ -51,6 +51,10 @@ def pytest_configure(config):
         "markers",
         "keycloak: mark test as requiring Keycloak authentication server",
     )
+    config.addinivalue_line(
+        "markers",
+        "container_runtime: mark test as requiring docker/podman engine",
+    )
 
 
 @pytest.fixture(scope="session")

--- a/src/api/tests/integration/extraction/conftest.py
+++ b/src/api/tests/integration/extraction/conftest.py
@@ -1,3 +1,39 @@
 """Integration test fixtures for Extraction bounded context."""
 
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+import pytest
+
+from shared_kernel.container_runtime.factory import create_container_runtime
+
 pytest_plugins = ["tests.integration.management.conftest"]
+
+
+def _engine_available(engine: str) -> bool:
+    if shutil.which(engine) is None:
+        return False
+    result = subprocess.run(
+        [engine, "info"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+@pytest.fixture(scope="session")
+def container_runtime_engine() -> str:
+    """Return the container engine binary used for integration tests."""
+    for engine in ("docker", "podman"):
+        if _engine_available(engine):
+            return engine
+    pytest.skip("No docker/podman engine available for container runtime tests")
+
+
+@pytest.fixture
+def container_runtime(container_runtime_engine: str):
+    """Provide a CLI container runtime for integration tests."""
+    return create_container_runtime(container_runtime_engine)

--- a/src/api/tests/integration/extraction/test_container_workload_runtime.py
+++ b/src/api/tests/integration/extraction/test_container_workload_runtime.py
@@ -1,0 +1,174 @@
+"""Integration tests for container-backed extraction workload runtime adapters."""
+
+from __future__ import annotations
+
+import time
+from datetime import timedelta
+
+import pytest
+from ulid import ULID
+
+from extraction.infrastructure.container_workload_runtime import (
+    ContainerEphemeralExtractionWorkerLauncher,
+    ContainerStickySessionRuntimeManager,
+)
+from extraction.infrastructure.workload_runtime import ScopedWorkloadCredentialIssuer
+from extraction.ports.runtime import EphemeralWorkerLaunchRequest
+from shared_kernel.container_runtime.ports import IContainerRuntime
+
+pytestmark = [pytest.mark.integration, pytest.mark.container_runtime]
+
+BUSYBOX_IMAGE = "docker.io/library/busybox:1.36"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ensure_busybox_image(container_runtime_engine: str) -> None:
+    """Pull the lightweight image used by runtime integration tests."""
+    import subprocess
+
+    result = subprocess.run(
+        [container_runtime_engine, "image", "inspect", BUSYBOX_IMAGE],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pull = subprocess.run(
+            [container_runtime_engine, "pull", BUSYBOX_IMAGE],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if pull.returncode != 0:
+            pytest.skip(f"Unable to pull test image {BUSYBOX_IMAGE}: {pull.stderr}")
+
+
+@pytest.fixture
+def sticky_manager(container_runtime: IContainerRuntime) -> ContainerStickySessionRuntimeManager:
+    return ContainerStickySessionRuntimeManager(
+        container_runtime=container_runtime,
+        sticky_image=BUSYBOX_IMAGE,
+        sticky_command=("sleep", "3600"),
+        session_ttl=timedelta(seconds=30),
+    )
+
+
+@pytest.fixture
+def worker_launcher(
+    container_runtime: IContainerRuntime,
+) -> ContainerEphemeralExtractionWorkerLauncher:
+    return ContainerEphemeralExtractionWorkerLauncher(
+        container_runtime=container_runtime,
+        worker_image=BUSYBOX_IMAGE,
+        worker_command=("sleep", "3600"),
+    )
+
+
+class TestContainerStickySessionRuntimeIntegration:
+    def test_happy_path_reuses_sticky_container_until_reset(
+        self,
+        sticky_manager: ContainerStickySessionRuntimeManager,
+        container_runtime: IContainerRuntime,
+    ) -> None:
+        first = sticky_manager.get_or_start_runtime(
+            session_id=f"integration-session-1-{ULID()}",
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode="extraction_operations",
+        )
+        second = sticky_manager.get_or_start_runtime(
+            session_id=first.session_id,
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode="extraction_operations",
+        )
+
+        assert first.container_id == second.container_id
+        assert container_runtime.is_running(first.container_id)
+
+        rotated = sticky_manager.reset_runtime(
+            session_id=first.session_id,
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode="extraction_operations",
+        )
+
+        assert rotated.container_id != first.container_id
+        assert not container_runtime.is_running(first.container_id)
+        assert container_runtime.is_running(rotated.container_id)
+
+        sticky_manager.cleanup_expired(now=rotated.expires_at + timedelta(seconds=1))
+        assert not container_runtime.is_running(rotated.container_id)
+
+    def test_timeout_cleanup_terminates_expired_sticky_container(
+        self,
+        container_runtime: IContainerRuntime,
+    ) -> None:
+        manager = ContainerStickySessionRuntimeManager(
+            container_runtime=container_runtime,
+            sticky_image=BUSYBOX_IMAGE,
+            sticky_command=("sleep", "3600"),
+            session_ttl=timedelta(seconds=2),
+        )
+        lease = manager.get_or_start_runtime(
+            session_id=f"integration-session-timeout-{ULID()}",
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode="schema_bootstrap",
+        )
+        assert container_runtime.is_running(lease.container_id)
+
+        time.sleep(3)
+        terminated = manager.cleanup_expired(
+            now=lease.last_activity_at + timedelta(seconds=3)
+        )
+
+        assert terminated == [lease.container_id]
+        assert not container_runtime.is_running(lease.container_id)
+
+
+class TestContainerEphemeralWorkerIntegration:
+    def test_happy_path_launches_and_completes_worker(
+        self,
+        worker_launcher: ContainerEphemeralExtractionWorkerLauncher,
+        container_runtime: IContainerRuntime,
+    ) -> None:
+        issuer = ScopedWorkloadCredentialIssuer(default_ttl=timedelta(minutes=5))
+        credentials = issuer.issue(tenant_id="tenant-1", knowledge_graph_id="kg-1")
+        request = EphemeralWorkerLaunchRequest(
+            tenant_id="tenant-1",
+            knowledge_graph_id="kg-1",
+            session_id=f"integration-session-worker-{ULID()}",
+            sync_run_id="sync-1",
+            job_package_id="pkg-1",
+        )
+
+        result = worker_launcher.launch(request=request, credentials=credentials)
+        container_id = worker_launcher.worker_container_id(result.worker_id)
+
+        assert container_id is not None
+        assert container_runtime.is_running(container_id)
+
+        worker_launcher.complete_worker(result.worker_id)
+
+        assert worker_launcher.active_worker_count == 0
+        assert not container_runtime.is_running(container_id)
+
+    def test_failure_path_rejects_bad_credentials_without_launching_container(
+        self,
+        worker_launcher: ContainerEphemeralExtractionWorkerLauncher,
+    ) -> None:
+        issuer = ScopedWorkloadCredentialIssuer(default_ttl=timedelta(minutes=5))
+        wrong_scope = issuer.issue(tenant_id="tenant-2", knowledge_graph_id="kg-2")
+        request = EphemeralWorkerLaunchRequest(
+            tenant_id="tenant-1",
+            knowledge_graph_id="kg-1",
+            session_id=f"integration-session-worker-{ULID()}",
+            sync_run_id="sync-1",
+            job_package_id="pkg-1",
+        )
+
+        with pytest.raises(ValueError, match="scope"):
+            worker_launcher.launch(request=request, credentials=wrong_scope)
+
+        assert worker_launcher.active_worker_count == 0

--- a/src/api/tests/unit/extraction/infrastructure/test_container_workload_runtime.py
+++ b/src/api/tests/unit/extraction/infrastructure/test_container_workload_runtime.py
@@ -1,0 +1,181 @@
+"""Unit tests for container-backed extraction workload runtime adapters."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from extraction.infrastructure.container_workload_runtime import (
+    ContainerEphemeralExtractionWorkerLauncher,
+    ContainerStickySessionRuntimeManager,
+)
+from extraction.infrastructure.workload_runtime import ScopedWorkloadCredentialIssuer
+from extraction.ports.runtime import EphemeralWorkerLaunchRequest
+from shared_kernel.container_runtime.ports import ContainerRunResult, ContainerRunSpec
+
+
+class TestContainerStickySessionRuntimeManager:
+    def test_reuses_running_container_for_active_session(self) -> None:
+        runtime = MagicMock()
+        runtime.is_running.return_value = True
+        runtime.run.return_value = ContainerRunResult(
+            container_id="container-1",
+            name="kartograph-sticky-session-1",
+        )
+        manager = ContainerStickySessionRuntimeManager(
+            container_runtime=runtime,
+            sticky_image="busybox:1.36",
+            sticky_command=("sleep", "3600"),
+            session_ttl=timedelta(minutes=30),
+        )
+
+        first = manager.get_or_start_runtime(
+            session_id="session-1",
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode="extraction_operations",
+        )
+        second = manager.get_or_start_runtime(
+            session_id="session-1",
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode="extraction_operations",
+        )
+
+        assert first.container_id == second.container_id == "container-1"
+        runtime.run.assert_called_once()
+
+    def test_reset_stops_existing_container_and_starts_new_one(self) -> None:
+        runtime = MagicMock()
+        runtime.is_running.return_value = True
+        runtime.run.side_effect = [
+            ContainerRunResult(container_id="container-1", name="name-1"),
+            ContainerRunResult(container_id="container-2", name="name-2"),
+        ]
+        manager = ContainerStickySessionRuntimeManager(
+            container_runtime=runtime,
+            sticky_image="busybox:1.36",
+            sticky_command=("sleep", "3600"),
+            session_ttl=timedelta(minutes=30),
+        )
+        manager.get_or_start_runtime(
+            session_id="session-1",
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode="schema_bootstrap",
+        )
+
+        rotated = manager.reset_runtime(
+            session_id="session-1",
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode="schema_bootstrap",
+        )
+
+        assert rotated.container_id == "container-2"
+        runtime.stop.assert_called_once_with("container-1")
+        runtime.remove.assert_called_once_with("container-1", force=True)
+
+    def test_cleanup_expired_terminates_and_returns_container_ids(self) -> None:
+        runtime = MagicMock()
+        runtime.is_running.return_value = True
+        runtime.run.return_value = ContainerRunResult(
+            container_id="container-1",
+            name="name-1",
+        )
+        manager = ContainerStickySessionRuntimeManager(
+            container_runtime=runtime,
+            sticky_image="busybox:1.36",
+            sticky_command=("sleep", "3600"),
+            session_ttl=timedelta(minutes=5),
+        )
+        lease = manager.get_or_start_runtime(
+            session_id="session-1",
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode="schema_bootstrap",
+        )
+
+        terminated = manager.cleanup_expired(now=lease.expires_at + timedelta(seconds=1))
+
+        assert terminated == ["container-1"]
+
+
+class TestContainerEphemeralExtractionWorkerLauncher:
+    def test_launch_starts_worker_container_without_exposing_credentials(self) -> None:
+        runtime = MagicMock()
+        runtime.run.return_value = ContainerRunResult(
+            container_id="worker-container",
+            name="kartograph-worker-abc",
+        )
+        launcher = ContainerEphemeralExtractionWorkerLauncher(
+            container_runtime=runtime,
+            worker_image="busybox:1.36",
+            worker_command=("sleep", "3600"),
+        )
+        issuer = ScopedWorkloadCredentialIssuer(default_ttl=timedelta(minutes=10))
+        credentials = issuer.issue(tenant_id="tenant-1", knowledge_graph_id="kg-1")
+        request = EphemeralWorkerLaunchRequest(
+            tenant_id="tenant-1",
+            knowledge_graph_id="kg-1",
+            session_id="session-1",
+            sync_run_id="sync-1",
+            job_package_id="pkg-1",
+        )
+
+        result = launcher.launch(request=request, credentials=credentials)
+
+        assert result.worker_id
+        assert result.status == "running"
+        spec: ContainerRunSpec = runtime.run.call_args.args[0]
+        assert spec.env["KARTOGRAPH_WORKLOAD_TOKEN"] == credentials.token
+
+    def test_launch_rejects_invalid_credentials(self) -> None:
+        runtime = MagicMock()
+        launcher = ContainerEphemeralExtractionWorkerLauncher(
+            container_runtime=runtime,
+            worker_image="busybox:1.36",
+            worker_command=("sleep", "3600"),
+        )
+        issuer = ScopedWorkloadCredentialIssuer(default_ttl=timedelta(minutes=10))
+        wrong_scope = issuer.issue(tenant_id="tenant-2", knowledge_graph_id="kg-2")
+        request = EphemeralWorkerLaunchRequest(
+            tenant_id="tenant-1",
+            knowledge_graph_id="kg-1",
+            session_id="session-1",
+            sync_run_id="sync-1",
+            job_package_id="pkg-1",
+        )
+
+        with pytest.raises(ValueError, match="scope"):
+            launcher.launch(request=request, credentials=wrong_scope)
+
+    def test_complete_worker_terminates_running_container(self) -> None:
+        runtime = MagicMock()
+        runtime.is_running.return_value = True
+        runtime.run.return_value = ContainerRunResult(
+            container_id="worker-container",
+            name="kartograph-worker-abc",
+        )
+        launcher = ContainerEphemeralExtractionWorkerLauncher(
+            container_runtime=runtime,
+            worker_image="busybox:1.36",
+            worker_command=("sleep", "3600"),
+        )
+        issuer = ScopedWorkloadCredentialIssuer(default_ttl=timedelta(minutes=10))
+        credentials = issuer.issue(tenant_id="tenant-1", knowledge_graph_id="kg-1")
+        request = EphemeralWorkerLaunchRequest(
+            tenant_id="tenant-1",
+            knowledge_graph_id="kg-1",
+            session_id="session-1",
+            sync_run_id="sync-1",
+            job_package_id="pkg-1",
+        )
+        result = launcher.launch(request=request, credentials=credentials)
+
+        launcher.complete_worker(result.worker_id)
+
+        runtime.stop.assert_called_once_with("worker-container")
+        assert launcher.active_worker_count == 0

--- a/src/api/tests/unit/extraction/infrastructure/test_workload_runtime_factory.py
+++ b/src/api/tests/unit/extraction/infrastructure/test_workload_runtime_factory.py
@@ -1,0 +1,42 @@
+"""Unit tests for extraction workload runtime factory."""
+
+from __future__ import annotations
+
+from extraction.infrastructure.container_workload_runtime import (
+    ContainerEphemeralExtractionWorkerLauncher,
+    ContainerStickySessionRuntimeManager,
+)
+from extraction.infrastructure.workload_runtime import (
+    InMemoryEphemeralExtractionWorkerLauncher,
+    InMemoryStickySessionRuntimeManager,
+)
+from extraction.infrastructure.workload_runtime_factory import (
+    create_ephemeral_extraction_worker_launcher,
+    create_sticky_session_runtime_manager,
+)
+from extraction.infrastructure.workload_runtime_settings import (
+    ExtractionWorkloadRuntimeSettings,
+)
+
+
+class TestWorkloadRuntimeFactory:
+    def test_memory_backend_returns_in_memory_adapters(self) -> None:
+        settings = ExtractionWorkloadRuntimeSettings(backend="memory")
+
+        sticky = create_sticky_session_runtime_manager(settings)
+        worker = create_ephemeral_extraction_worker_launcher(settings)
+
+        assert isinstance(sticky, InMemoryStickySessionRuntimeManager)
+        assert isinstance(worker, InMemoryEphemeralExtractionWorkerLauncher)
+
+    def test_container_backend_returns_container_adapters(self) -> None:
+        settings = ExtractionWorkloadRuntimeSettings(
+            backend="container",
+            container_engine="docker",
+        )
+
+        sticky = create_sticky_session_runtime_manager(settings)
+        worker = create_ephemeral_extraction_worker_launcher(settings)
+
+        assert isinstance(sticky, ContainerStickySessionRuntimeManager)
+        assert isinstance(worker, ContainerEphemeralExtractionWorkerLauncher)

--- a/src/api/tests/unit/extraction/infrastructure/test_workload_runtime_settings.py
+++ b/src/api/tests/unit/extraction/infrastructure/test_workload_runtime_settings.py
@@ -1,0 +1,18 @@
+"""Unit tests for extraction workload runtime settings."""
+
+from __future__ import annotations
+
+from extraction.infrastructure.workload_runtime_settings import (
+    ExtractionWorkloadRuntimeSettings,
+)
+
+
+class TestExtractionWorkloadRuntimeSettings:
+    def test_parses_command_strings_into_tuple(self) -> None:
+        settings = ExtractionWorkloadRuntimeSettings(
+            sticky_command="sleep 3600",
+            worker_command="sleep 120",
+        )
+
+        assert settings.sticky_command == ("sleep", "3600")
+        assert settings.worker_command == ("sleep", "120")

--- a/src/api/tests/unit/shared_kernel/container_runtime/test_cli_runtime.py
+++ b/src/api/tests/unit/shared_kernel/container_runtime/test_cli_runtime.py
@@ -1,0 +1,80 @@
+"""Unit tests for CLI-backed container runtime."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from shared_kernel.container_runtime.cli_runtime import CliContainerRuntime
+from shared_kernel.container_runtime.ports import ContainerRunSpec, ContainerRuntimeError
+
+
+class TestCliContainerRuntime:
+    def test_run_launches_detached_container_with_labels_and_env(self) -> None:
+        runtime = CliContainerRuntime(binary="docker")
+
+        with patch("shared_kernel.container_runtime.cli_runtime.subprocess.run") as run:
+            run.return_value = MagicMock(returncode=0, stdout="abc123\n", stderr="")
+
+            result = runtime.run(
+                ContainerRunSpec(
+                    image="busybox:1.36",
+                    name="kartograph-sticky-session-1",
+                    env={"KARTOGRAPH_WORKLOAD_TOKEN": "secret"},
+                    labels={
+                        "kartograph.runtime.kind": "sticky",
+                        "kartograph.session_id": "session-1",
+                    },
+                    command=("sleep", "3600"),
+                )
+            )
+
+        assert result.container_id == "abc123"
+        assert result.name == "kartograph-sticky-session-1"
+        command = run.call_args.args[0]
+        assert command[0] == "docker"
+        assert "run" in command
+        assert "--detach" in command
+        assert "busybox:1.36" in command
+
+    def test_run_raises_when_cli_fails(self) -> None:
+        runtime = CliContainerRuntime(binary="docker")
+
+        with patch("shared_kernel.container_runtime.cli_runtime.subprocess.run") as run:
+            run.return_value = MagicMock(
+                returncode=125,
+                stdout="",
+                stderr="image not found",
+            )
+
+            with pytest.raises(ContainerRuntimeError, match="image not found"):
+                runtime.run(ContainerRunSpec(image="missing:latest"))
+
+    def test_stop_remove_and_is_running_delegate_to_cli(self) -> None:
+        runtime = CliContainerRuntime(binary="podman")
+
+        with patch("shared_kernel.container_runtime.cli_runtime.subprocess.run") as run:
+            run.side_effect = [
+                MagicMock(returncode=0, stdout="", stderr=""),
+                MagicMock(returncode=0, stdout="", stderr=""),
+                MagicMock(returncode=0, stdout="true\n", stderr=""),
+            ]
+
+            runtime.stop("abc123", timeout_seconds=5)
+            runtime.remove("abc123", force=True)
+            assert runtime.is_running("abc123") is True
+
+        assert run.call_args_list[0].args[0][:3] == ["podman", "stop", "-t"]
+
+    def test_is_running_returns_false_for_missing_container(self) -> None:
+        runtime = CliContainerRuntime(binary="docker")
+
+        with patch("shared_kernel.container_runtime.cli_runtime.subprocess.run") as run:
+            run.return_value = MagicMock(
+                returncode=1,
+                stdout="",
+                stderr="Error: No such object: abc123",
+            )
+
+            assert runtime.is_running("abc123") is False


### PR DESCRIPTION
## Summary

**Partial — does not fully close #716.** This PR delivers a docker/podman CLI slice for local development and testable container lifecycle semantics. Remaining gaps are listed below.

- Add shared `IContainerRuntime` port plus `CliContainerRuntime` (docker/podman auto-detection).
- Add `ContainerStickySessionRuntimeManager` and `ContainerEphemeralExtractionWorkerLauncher` implementing extraction runtime ports with reuse/reset/timeout and worker termination semantics.
- Add `ExtractionWorkloadRuntimeSettings`, factory helpers, and FastAPI dependency wiring to select memory vs container backends.
- Enable local dev container execution via `compose.dev.yaml` (`KARTOGRAPH_EXTRACTION_RUNTIME_BACKEND=container` + docker socket mount) and document defaults in `env/api.env`.

### Remaining gaps (why this is partial)

- Kubernetes/production orchestrator adapter is not implemented (local CLI only).
- Runtime adapters are not yet invoked from agent session flows or extraction job orchestration; dependencies/factory are ready but callers still use in-memory paths by default.
- Container images default to `busybox` placeholders rather than dedicated extraction agent runtime images with skills/context mounts.

## Test plan

- [x] `uv run pytest tests/unit/shared_kernel/container_runtime -v`
- [x] `uv run pytest tests/unit/extraction/infrastructure/test_container_workload_runtime.py tests/unit/extraction/infrastructure/test_workload_runtime_factory.py tests/unit/extraction/infrastructure/test_workload_runtime_settings.py -v`
- [x] `uv run pytest tests/integration/extraction/test_container_workload_runtime.py -v -m "integration and container_runtime"`
- [ ] Wire container runtime into session/job execution paths (follow-up)
- [ ] Add production orchestrator adapter + real agent images (follow-up)


Made with [Cursor](https://cursor.com)