### PR TITLE
feat(management): graph-native canonical schema source (partial #718)

### DIFF
--- a/src/api/graph/infrastructure/models/__init__.py
+++ b/src/api/graph/infrastructure/models/__init__.py
@@ -1,0 +1,1 @@
+"""Graph infrastructure SQLAlchemy models."""

--- a/src/api/graph/infrastructure/models/knowledge_graph_type_definition.py
+++ b/src/api/graph/infrastructure/models/knowledge_graph_type_definition.py
@@ -1,0 +1,32 @@
+"""SQLAlchemy model for KG-scoped graph type definitions."""
+
+from __future__ import annotations
+
+from sqlalchemy import String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from infrastructure.database.models import Base
+
+
+class KnowledgeGraphTypeDefinitionModel(Base):
+    """Persisted type definition for a knowledge graph schema layer."""
+
+    __tablename__ = "knowledge_graph_type_definitions"
+    __table_args__ = (
+        UniqueConstraint(
+            "knowledge_graph_id",
+            "entity_type",
+            "label",
+            name="uq_kg_type_definitions_kg_entity_label",
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(String(26), primary_key=True)
+    knowledge_graph_id: Mapped[str] = mapped_column(String(26), nullable=False, index=True)
+    entity_type: Mapped[str] = mapped_column(String(16), nullable=False)
+    label: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str] = mapped_column(String(2048), nullable=False, default="")
+    required_properties: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
+    optional_properties: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
+    metadata_json: Mapped[dict | None] = mapped_column("metadata", JSONB, nullable=True)

--- a/src/api/graph/infrastructure/noop_mutation_applier.py
+++ b/src/api/graph/infrastructure/noop_mutation_applier.py
@@ -1,0 +1,14 @@
+"""No-op mutation applier for schema-only DEFINE batches."""
+
+from __future__ import annotations
+
+from graph.domain.value_objects import MutationOperation, MutationResult
+
+
+class NoOpMutationApplier:
+    """Accept mutation batches without touching the graph database."""
+
+    def apply_batch(self, operations: list[MutationOperation]) -> MutationResult:
+        """Report success for schema-only batches."""
+        _ = operations
+        return MutationResult(success=True, operations_applied=0)

--- a/src/api/graph/infrastructure/postgres_kg_type_definition_store.py
+++ b/src/api/graph/infrastructure/postgres_kg_type_definition_store.py
@@ -1,0 +1,117 @@
+"""Postgres-backed canonical schema storage for knowledge graphs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from ulid import ULID
+
+from graph.domain.value_objects import EntityType, TypeDefinition
+from graph.infrastructure.models.knowledge_graph_type_definition import (
+    KnowledgeGraphTypeDefinitionModel,
+)
+
+
+@dataclass(frozen=True)
+class StoredKnowledgeGraphTypeDefinition:
+    """Canonical type definition row projected for cross-context mapping."""
+
+    label: str
+    entity_type: str
+    description: str
+    required_properties: tuple[str, ...]
+    optional_properties: tuple[str, ...]
+    metadata: dict[str, Any]
+
+
+class PostgresKnowledgeGraphTypeDefinitionStore:
+    """Async persistence for KG-scoped canonical type definitions."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def delete_all_for_kg(self, kg_id: str) -> None:
+        """Remove all type definitions for a knowledge graph."""
+        stmt = delete(KnowledgeGraphTypeDefinitionModel).where(
+            KnowledgeGraphTypeDefinitionModel.knowledge_graph_id == kg_id
+        )
+        await self._session.execute(stmt)
+
+    async def upsert_type_definition(
+        self,
+        *,
+        kg_id: str,
+        type_def: TypeDefinition,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Insert or replace a single type definition row."""
+        entity_type = type_def.entity_type.value
+        stmt = select(KnowledgeGraphTypeDefinitionModel).where(
+            KnowledgeGraphTypeDefinitionModel.knowledge_graph_id == kg_id,
+            KnowledgeGraphTypeDefinitionModel.entity_type == entity_type,
+            KnowledgeGraphTypeDefinitionModel.label == type_def.label,
+        )
+        result = await self._session.execute(stmt)
+        existing = result.scalar_one_or_none()
+
+        payload = {
+            "description": type_def.description,
+            "required_properties": sorted(type_def.required_properties),
+            "optional_properties": sorted(type_def.optional_properties),
+            "metadata_json": metadata,
+        }
+
+        if existing is None:
+            model = KnowledgeGraphTypeDefinitionModel(
+                id=str(ULID()),
+                knowledge_graph_id=kg_id,
+                entity_type=entity_type,
+                label=type_def.label,
+                **payload,
+            )
+            self._session.add(model)
+        else:
+            existing.description = payload["description"]
+            existing.required_properties = payload["required_properties"]
+            existing.optional_properties = payload["optional_properties"]
+            existing.metadata_json = payload["metadata_json"]
+
+        await self._session.flush()
+
+    async def list_for_kg(self, kg_id: str) -> list[StoredKnowledgeGraphTypeDefinition]:
+        """Return all canonical type definitions for a knowledge graph."""
+        stmt = (
+            select(KnowledgeGraphTypeDefinitionModel)
+            .where(KnowledgeGraphTypeDefinitionModel.knowledge_graph_id == kg_id)
+            .order_by(
+                KnowledgeGraphTypeDefinitionModel.entity_type,
+                KnowledgeGraphTypeDefinitionModel.label,
+            )
+        )
+        result = await self._session.execute(stmt)
+        return [self._to_stored(row) for row in result.scalars().all()]
+
+    @staticmethod
+    def to_type_definition(stored: StoredKnowledgeGraphTypeDefinition) -> TypeDefinition:
+        """Convert a stored projection to a graph TypeDefinition."""
+        return TypeDefinition(
+            label=stored.label,
+            entity_type=EntityType(stored.entity_type),
+            description=stored.description,
+            required_properties=set(stored.required_properties),
+            optional_properties=set(stored.optional_properties),
+        )
+
+    @staticmethod
+    def _to_stored(model: KnowledgeGraphTypeDefinitionModel) -> StoredKnowledgeGraphTypeDefinition:
+        return StoredKnowledgeGraphTypeDefinition(
+            label=model.label,
+            entity_type=model.entity_type,
+            description=model.description,
+            required_properties=tuple(model.required_properties or []),
+            optional_properties=tuple(model.optional_properties or []),
+            metadata=model.metadata_json or {},
+        )

--- a/src/api/infrastructure/canonical_schema/__init__.py
+++ b/src/api/infrastructure/canonical_schema/__init__.py
@@ -1,0 +1,1 @@
+"""Cross-context canonical schema wiring."""

--- a/src/api/infrastructure/canonical_schema/graph_canonical_schema_repository.py
+++ b/src/api/infrastructure/canonical_schema/graph_canonical_schema_repository.py
@@ -1,0 +1,122 @@
+"""Graph-backed implementation of Management canonical schema port."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from graph.application.services.graph_mutation_service import GraphMutationService
+from graph.domain.value_objects import EntityType, MutationOperation
+from graph.infrastructure.noop_mutation_applier import NoOpMutationApplier
+from graph.infrastructure.postgres_kg_type_definition_store import (
+    PostgresKnowledgeGraphTypeDefinitionStore,
+)
+from graph.infrastructure.type_definition_repository import InMemoryTypeDefinitionRepository
+from infrastructure.canonical_schema.ontology_mutation_builder import (
+    edge_type_metadata,
+    node_type_metadata,
+    ontology_config_to_define_operations,
+)
+from infrastructure.canonical_schema.ontology_projection import (
+    stored_definitions_to_ontology_config,
+)
+from management.domain.value_objects import OntologyConfig
+from management.ports.canonical_schema import ICanonicalSchemaRepository
+from management.ports.exceptions import CanonicalSchemaMutationError
+
+
+class _CollectingTypeDefinitionRepository(InMemoryTypeDefinitionRepository):
+    """In-memory repository used while applying canonical schema mutations."""
+
+    pass
+
+
+class GraphCanonicalSchemaRepository(ICanonicalSchemaRepository):
+    """Persist and read canonical schema through mutation-log DEFINE operations."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+        self._store = PostgresKnowledgeGraphTypeDefinitionStore(session)
+
+    async def get_ontology(self, kg_id: str) -> OntologyConfig | None:
+        rows = await self._store.list_for_kg(kg_id)
+        if not rows:
+            return None
+        return stored_definitions_to_ontology_config(rows)
+
+    async def replace_ontology(self, kg_id: str, config: OntologyConfig) -> None:
+        await self._store.delete_all_for_kg(kg_id)
+        await self._apply_operations(
+            kg_id, ontology_config_to_define_operations(config), config
+        )
+
+    async def apply_mutation_log(self, kg_id: str, jsonl_content: str) -> None:
+        operations = self._parse_jsonl(jsonl_content)
+        if not operations:
+            return
+
+        existing = await self.get_ontology(kg_id) or OntologyConfig()
+        await self._apply_operations(kg_id, operations, existing)
+
+    async def _apply_operations(
+        self,
+        kg_id: str,
+        operations: list[MutationOperation],
+        config: OntologyConfig,
+    ) -> None:
+        metadata_by_key = _metadata_map_for_config(config)
+        repo = _CollectingTypeDefinitionRepository()
+
+        for row in await self._store.list_for_kg(kg_id):
+            repo.save(self._store.to_type_definition(row))
+
+        service = GraphMutationService(
+            mutation_applier=NoOpMutationApplier(),
+            type_definition_repository=repo,
+        )
+        result = service.apply_mutations(operations, knowledge_graph_id=kg_id)
+        if not result.success:
+            message = "; ".join(result.errors) if result.errors else "mutation failed"
+            raise CanonicalSchemaMutationError(message)
+
+        for type_def in repo.get_all():
+            metadata = metadata_by_key.get((type_def.label, type_def.entity_type.value))
+            await self._store.upsert_type_definition(
+                kg_id=kg_id,
+                type_def=type_def,
+                metadata=metadata,
+            )
+
+    @staticmethod
+    def _parse_jsonl(jsonl_content: str) -> list[MutationOperation]:
+        operations: list[MutationOperation] = []
+        for line_num, line in enumerate(jsonl_content.strip().split("\n"), start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                operations.append(MutationOperation(**json.loads(stripped)))
+            except json.JSONDecodeError as exc:
+                raise CanonicalSchemaMutationError(
+                    f"JSON parse error on line {line_num}: {exc}"
+                ) from exc
+            except ValidationError as exc:
+                raise CanonicalSchemaMutationError(
+                    f"Validation error on line {line_num}: {exc}"
+                ) from exc
+        return operations
+
+
+def _metadata_map_for_config(
+    config: OntologyConfig,
+) -> dict[tuple[str, str], dict[str, Any]]:
+    """Build lookup for authoring metadata preserved outside graph TypeDefinition."""
+    metadata: dict[tuple[str, str], dict[str, Any]] = {}
+    for node_type in config.node_types:
+        metadata[(node_type.label, EntityType.NODE.value)] = node_type_metadata(node_type)
+    for edge_type in config.edge_types:
+        metadata[(edge_type.label, EntityType.EDGE.value)] = edge_type_metadata(edge_type)
+    return metadata

--- a/src/api/infrastructure/canonical_schema/ontology_mutation_builder.py
+++ b/src/api/infrastructure/canonical_schema/ontology_mutation_builder.py
@@ -1,0 +1,56 @@
+"""Bridge Management ontology configs to graph DEFINE mutation operations."""
+
+from __future__ import annotations
+
+from graph.domain.value_objects import EntityType, MutationOperation, MutationOperationType
+from management.domain.value_objects import OntologyConfig
+
+
+def ontology_config_to_define_operations(
+    config: OntologyConfig,
+) -> list[MutationOperation]:
+    """Convert an ontology config into DEFINE mutation operations."""
+    operations: list[MutationOperation] = []
+
+    for node_type in config.node_types:
+        operations.append(
+            MutationOperation(
+                op=MutationOperationType.DEFINE,
+                type=EntityType.NODE,
+                label=node_type.label,
+                description=node_type.description or node_type.label,
+                required_properties=set(node_type.required_properties),
+                optional_properties=set(node_type.optional_properties),
+            )
+        )
+
+    for edge_type in config.edge_types:
+        operations.append(
+            MutationOperation(
+                op=MutationOperationType.DEFINE,
+                type=EntityType.EDGE,
+                label=edge_type.label,
+                description=edge_type.description or edge_type.label,
+                required_properties=set(edge_type.properties),
+                optional_properties=set(),
+            )
+        )
+
+    return operations
+
+
+def node_type_metadata(node_type) -> dict:
+    """Serialize node-type authoring metadata for canonical storage."""
+    return {
+        "prepopulated": node_type.prepopulated,
+        "prepopulated_instance_count": node_type.prepopulated_instance_count,
+    }
+
+
+def edge_type_metadata(edge_type) -> dict:
+    """Serialize edge-type authoring metadata for canonical storage."""
+    return {
+        "source_labels": list(edge_type.source_labels),
+        "target_labels": list(edge_type.target_labels),
+        "properties": list(edge_type.properties),
+    }

--- a/src/api/infrastructure/canonical_schema/ontology_projection.py
+++ b/src/api/infrastructure/canonical_schema/ontology_projection.py
@@ -1,0 +1,50 @@
+"""Map stored canonical schema rows to Management ontology configs."""
+
+from __future__ import annotations
+
+from graph.infrastructure.postgres_kg_type_definition_store import (
+    StoredKnowledgeGraphTypeDefinition,
+)
+from management.domain.value_objects import (
+    EdgeTypeDefinition,
+    NodeTypeDefinition,
+    OntologyConfig,
+)
+
+
+def stored_definitions_to_ontology_config(
+    stored_definitions: list[StoredKnowledgeGraphTypeDefinition],
+) -> OntologyConfig:
+    """Project graph-native type definitions to Management OntologyConfig."""
+    node_types: list[NodeTypeDefinition] = []
+    edge_types: list[EdgeTypeDefinition] = []
+
+    for stored in stored_definitions:
+        if stored.entity_type == "node":
+            node_types.append(
+                NodeTypeDefinition(
+                    label=stored.label,
+                    description=stored.description,
+                    required_properties=stored.required_properties,
+                    optional_properties=stored.optional_properties,
+                    prepopulated=bool(stored.metadata.get("prepopulated", False)),
+                    prepopulated_instance_count=int(
+                        stored.metadata.get("prepopulated_instance_count", 0)
+                    ),
+                )
+            )
+        elif stored.entity_type == "edge":
+            edge_types.append(
+                EdgeTypeDefinition(
+                    label=stored.label,
+                    description=stored.description,
+                    source_labels=tuple(stored.metadata.get("source_labels", [])),
+                    target_labels=tuple(stored.metadata.get("target_labels", [])),
+                    properties=tuple(stored.metadata.get("properties", [])),
+                )
+            )
+
+    return OntologyConfig(
+        node_types=tuple(node_types),
+        edge_types=tuple(edge_types),
+    )

--- a/src/api/infrastructure/migrations/versions/fb1c2d3e4f5a_create_kg_type_definitions_table.py
+++ b/src/api/infrastructure/migrations/versions/fb1c2d3e4f5a_create_kg_type_definitions_table.py
@@ -1,0 +1,63 @@
+"""Create knowledge_graph_type_definitions table for canonical schema storage.
+
+Revision ID: fb1c2d3e4f5a
+Revises: fa0b1c2d3e4f
+Create Date: 2026-05-22 10:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "fb1c2d3e4f5a"
+down_revision = "fa0b1c2d3e4f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create table for graph-native canonical type definitions."""
+    op.create_table(
+        "knowledge_graph_type_definitions",
+        sa.Column("id", sa.String(length=26), nullable=False),
+        sa.Column("knowledge_graph_id", sa.String(length=26), nullable=False),
+        sa.Column("entity_type", sa.String(length=16), nullable=False),
+        sa.Column("label", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.String(length=2048), nullable=False, server_default=""),
+        sa.Column(
+            "required_properties",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "optional_properties",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("metadata", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "knowledge_graph_id",
+            "entity_type",
+            "label",
+            name="uq_kg_type_definitions_kg_entity_label",
+        ),
+    )
+    op.create_index(
+        "ix_knowledge_graph_type_definitions_knowledge_graph_id",
+        "knowledge_graph_type_definitions",
+        ["knowledge_graph_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop canonical type definition table."""
+    op.drop_index(
+        "ix_knowledge_graph_type_definitions_knowledge_graph_id",
+        table_name="knowledge_graph_type_definitions",
+    )
+    op.drop_table("knowledge_graph_type_definitions")

--- a/src/api/management/application/services/knowledge_graph_service.py
+++ b/src/api/management/application/services/knowledge_graph_service.py
@@ -41,6 +41,7 @@ from management.ports.repositories import (
     IDataSourceSyncRunRepository,
     IKnowledgeGraphRepository,
 )
+from management.ports.canonical_schema import ICanonicalSchemaRepository
 from management.ports.secret_store import ISecretStoreRepository
 from shared_kernel.authorization.protocols import AuthorizationProvider
 from shared_kernel.authorization.types import (
@@ -69,6 +70,7 @@ class KnowledgeGraphService:
         data_source_repository: IDataSourceRepository | None = None,
         sync_run_repository: IDataSourceSyncRunRepository | None = None,
         secret_store: ISecretStoreRepository | None = None,
+        canonical_schema_repository: ICanonicalSchemaRepository | None = None,
     ) -> None:
         """Initialize KnowledgeGraphService with dependencies.
 
@@ -80,6 +82,7 @@ class KnowledgeGraphService:
             probe: Optional domain probe for observability
             data_source_repository: Optional DS repository for cascade delete
             secret_store: Optional secret store for credential cleanup on cascade delete
+            canonical_schema_repository: Optional graph-native canonical schema store
         """
         self._session = session
         self._kg_repo = knowledge_graph_repository
@@ -89,6 +92,7 @@ class KnowledgeGraphService:
         self._ds_repo = data_source_repository
         self._sync_run_repo = sync_run_repository
         self._secret_store = secret_store
+        self._canonical_schema_repo = canonical_schema_repository
 
     def _compute_next_run_at_utc(
         self,
@@ -764,7 +768,7 @@ class KnowledgeGraphService:
         if not has_view:
             return None
 
-        return await self._kg_repo.get_ontology(kg_id)
+        return await self._resolve_canonical_ontology(kg_id)
 
     async def save_ontology(
         self,
@@ -809,22 +813,33 @@ class KnowledgeGraphService:
         if kg is None or kg.tenant_id != self._scope_to_tenant:
             raise KnowledgeGraphNotFoundError(f"Knowledge graph {kg_id} not found")
 
-        await self._kg_repo.save_ontology(kg_id, config)
+        if self._canonical_schema_repo is not None:
+            await self._canonical_schema_repo.replace_ontology(kg_id, config)
+        else:
+            await self._kg_repo.save_ontology(kg_id, config)
         await self._session.commit()
 
         return config
 
+    async def _resolve_canonical_ontology(self, kg_id: str) -> OntologyConfig | None:
+        """Load canonical schema from graph-native storage with JSONB fallback."""
+        if self._canonical_schema_repo is not None:
+            canonical = await self._canonical_schema_repo.get_ontology(kg_id)
+            if canonical is not None:
+                return canonical
+        return await self._kg_repo.get_ontology(kg_id)
+
     def _evaluate_workspace_readiness(
-        self, kg: KnowledgeGraph
+        self, ontology: OntologyConfig | None
     ) -> WorkspaceReadinessStatus:
-        """Evaluate transition readiness flags for workspace status projection."""
-        node_type_count = len(kg.ontology.node_types) if kg.ontology else 0
-        edge_type_count = len(kg.ontology.edge_types) if kg.ontology else 0
+        """Evaluate transition readiness flags from canonical schema state."""
+        node_type_count = len(ontology.node_types) if ontology else 0
+        edge_type_count = len(ontology.edge_types) if ontology else 0
         prepopulated_without_instances: tuple[str, ...] = ()
-        if kg.ontology is not None:
+        if ontology is not None:
             prepopulated_without_instances = tuple(
                 node_type.label
-                for node_type in kg.ontology.node_types
+                for node_type in ontology.node_types
                 if node_type.prepopulated and node_type.prepopulated_instance_count <= 0
             )
 
@@ -870,7 +885,8 @@ class KnowledgeGraphService:
         if not has_view:
             return None
 
-        readiness = self._evaluate_workspace_readiness(kg)
+        ontology = await self._resolve_canonical_ontology(kg_id)
+        readiness = self._evaluate_workspace_readiness(ontology)
         transition_eligible = (
             kg.workspace_mode == WorkspaceMode.SCHEMA_BOOTSTRAP and readiness.is_ready
         )
@@ -915,7 +931,8 @@ class KnowledgeGraphService:
         if kg is None or kg.tenant_id != self._scope_to_tenant:
             raise KnowledgeGraphNotFoundError(f"Knowledge graph {kg_id} not found")
 
-        readiness = self._evaluate_workspace_readiness(kg)
+        ontology = await self._resolve_canonical_ontology(kg_id)
+        readiness = self._evaluate_workspace_readiness(ontology)
         transition_eligible = (
             kg.workspace_mode == WorkspaceMode.SCHEMA_BOOTSTRAP and readiness.is_ready
         )
@@ -945,7 +962,8 @@ class KnowledgeGraphService:
         if kg is None or kg.tenant_id != self._scope_to_tenant:
             raise KnowledgeGraphNotFoundError(f"Knowledge graph {kg_id} not found")
 
-        readiness = self._evaluate_workspace_readiness(kg)
+        ontology = await self._resolve_canonical_ontology(kg_id)
+        readiness = self._evaluate_workspace_readiness(ontology)
         if not readiness.is_ready:
             joined_reasons = "; ".join(readiness.blocking_reasons)
             raise ValueError(

--- a/src/api/management/dependencies/knowledge_graph.py
+++ b/src/api/management/dependencies/knowledge_graph.py
@@ -25,6 +25,9 @@ from management.infrastructure.repositories import (
     FernetSecretStore,
     KnowledgeGraphRepository,
 )
+from infrastructure.canonical_schema.graph_canonical_schema_repository import (
+    GraphCanonicalSchemaRepository,
+)
 from shared_kernel.authorization.protocols import AuthorizationProvider
 
 
@@ -62,4 +65,5 @@ def get_knowledge_graph_service(
         authz=authz,
         scope_to_tenant=current_user.tenant_id.value,
         probe=DefaultKnowledgeGraphServiceProbe(),
+        canonical_schema_repository=GraphCanonicalSchemaRepository(session),
     )

--- a/src/api/management/ports/canonical_schema.py
+++ b/src/api/management/ports/canonical_schema.py
@@ -1,0 +1,24 @@
+"""Port for graph-native canonical schema access in Management."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from management.domain.value_objects import OntologyConfig
+
+
+@runtime_checkable
+class ICanonicalSchemaRepository(Protocol):
+    """Read/write canonical schema state stored as graph type definitions."""
+
+    async def get_ontology(self, kg_id: str) -> OntologyConfig | None:
+        """Return canonical schema for a knowledge graph, if any exists."""
+        ...
+
+    async def replace_ontology(self, kg_id: str, config: OntologyConfig) -> None:
+        """Replace canonical schema via mutation-log DEFINE operations."""
+        ...
+
+    async def apply_mutation_log(self, kg_id: str, jsonl_content: str) -> None:
+        """Apply additive schema/entity mutations from JSONL content."""
+        ...

--- a/src/api/management/ports/exceptions.py
+++ b/src/api/management/ports/exceptions.py
@@ -48,3 +48,9 @@ class UnauthorizedError(Exception):
     """
 
     pass
+
+
+class CanonicalSchemaMutationError(Exception):
+    """Raised when canonical schema mutation-log application fails."""
+
+    pass

--- a/src/api/tests/fakes/canonical_schema.py
+++ b/src/api/tests/fakes/canonical_schema.py
@@ -1,0 +1,28 @@
+"""In-memory fake for ICanonicalSchemaRepository."""
+
+from __future__ import annotations
+
+from management.domain.value_objects import OntologyConfig
+
+
+class InMemoryCanonicalSchemaRepository:
+    """Stores canonical schema per knowledge graph for unit tests."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, OntologyConfig] = {}
+        self.replaced: list[tuple[str, OntologyConfig]] = []
+        self.applied_logs: list[tuple[str, str]] = []
+
+    async def get_ontology(self, kg_id: str) -> OntologyConfig | None:
+        return self._store.get(kg_id)
+
+    async def replace_ontology(self, kg_id: str, config: OntologyConfig) -> None:
+        self.replaced.append((kg_id, config))
+        self._store[kg_id] = config
+
+    async def apply_mutation_log(self, kg_id: str, jsonl_content: str) -> None:
+        self.applied_logs.append((kg_id, jsonl_content))
+
+    def seed(self, kg_id: str, config: OntologyConfig) -> None:
+        """Preload canonical schema for a knowledge graph."""
+        self._store[kg_id] = config

--- a/src/api/tests/integration/management/conftest.py
+++ b/src/api/tests/integration/management/conftest.py
@@ -106,6 +106,9 @@ async def clean_management_data(
             )
             await async_session.execute(text("DELETE FROM data_source_sync_runs"))
             await async_session.execute(text("DELETE FROM data_sources"))
+            await async_session.execute(
+                text("DELETE FROM knowledge_graph_type_definitions")
+            )
             await async_session.execute(text("DELETE FROM knowledge_graphs"))
             await async_session.commit()
         except ProgrammingError:

--- a/src/api/tests/integration/management/test_canonical_schema_source.py
+++ b/src/api/tests/integration/management/test_canonical_schema_source.py
@@ -1,0 +1,209 @@
+"""Integration tests for canonical graph-native schema storage."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from sqlalchemy import text
+
+from graph.domain.value_objects import EntityType, MutationOperationType
+from infrastructure.canonical_schema.graph_canonical_schema_repository import (
+    GraphCanonicalSchemaRepository,
+)
+from management.application.services.knowledge_graph_service import KnowledgeGraphService
+from management.domain.aggregates import KnowledgeGraph
+from management.domain.value_objects import EdgeTypeDefinition, NodeTypeDefinition, OntologyConfig
+from tests.fakes.authorization import InMemoryAuthorizationProvider
+
+pytestmark = pytest.mark.integration
+
+
+async def _table_exists(async_session, table_name: str) -> bool:
+    result = await async_session.execute(
+        text(
+            """
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_name = :table_name
+            """
+        ),
+        {"table_name": table_name},
+    )
+    return result.scalar_one_or_none() is not None
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_schema_persisted_in_canonical_store_and_readiness(
+    async_session,
+    clean_management_data: None,
+    knowledge_graph_repository,
+    test_tenant: str,
+    test_workspace: str,
+) -> None:
+    """Bootstrap ontology flows through mutation-log DEFINE path into canonical store."""
+    if not await _table_exists(async_session, "knowledge_graph_type_definitions"):
+        pytest.skip("knowledge_graph_type_definitions table is missing")
+
+    await async_session.rollback()
+
+    user_id = "user-canonical-schema-001"
+    authz = InMemoryAuthorizationProvider()
+    canonical_repo = GraphCanonicalSchemaRepository(async_session)
+    kg_service = KnowledgeGraphService(
+        session=async_session,
+        knowledge_graph_repository=knowledge_graph_repository,
+        authz=authz,
+        scope_to_tenant=test_tenant,
+        canonical_schema_repository=canonical_repo,
+    )
+
+    knowledge_graph = KnowledgeGraph.create(
+        tenant_id=test_tenant,
+        workspace_id=test_workspace,
+        name="Canonical Schema KG",
+        description="Bootstrap canonical schema",
+        created_by=user_id,
+    )
+    ontology_config = OntologyConfig(
+        node_types=(
+            NodeTypeDefinition(label="Repository"),
+            NodeTypeDefinition(
+                label="SeedNode",
+                prepopulated=True,
+                prepopulated_instance_count=1,
+            ),
+        ),
+        edge_types=(
+            EdgeTypeDefinition(
+                label="CONTAINS",
+                source_labels=("Repository",),
+                target_labels=("SeedNode",),
+            ),
+        ),
+    )
+
+    async with async_session.begin():
+        await knowledge_graph_repository.save(knowledge_graph)
+
+    await authz.write_relationship(
+        f"knowledge_graph:{knowledge_graph.id.value}",
+        "admin",
+        f"user:{user_id}",
+    )
+
+    await kg_service.save_ontology(
+        user_id=user_id,
+        kg_id=knowledge_graph.id.value,
+        config=ontology_config,
+    )
+
+    canonical = await canonical_repo.get_ontology(knowledge_graph.id.value)
+    assert canonical is not None
+    assert {node.label for node in canonical.node_types} == {"Repository", "SeedNode"}
+
+    row_count = await async_session.execute(
+        text(
+            """
+            SELECT COUNT(*) AS count
+            FROM knowledge_graph_type_definitions
+            WHERE knowledge_graph_id = :kg_id
+            """
+        ),
+        {"kg_id": knowledge_graph.id.value},
+    )
+    assert row_count.scalar_one() == 3
+
+    status = await kg_service.get_workspace_status(
+        user_id=user_id,
+        kg_id=knowledge_graph.id.value,
+    )
+    assert status is not None
+    assert status.transition_eligible is True
+
+
+@pytest.mark.asyncio
+async def test_additive_schema_evolution_in_extraction_mode(
+    async_session,
+    clean_management_data: None,
+    knowledge_graph_repository,
+    test_tenant: str,
+    test_workspace: str,
+) -> None:
+    """Extraction mode accepts additive DEFINE mutations via mutation log."""
+    if not await _table_exists(async_session, "knowledge_graph_type_definitions"):
+        pytest.skip("knowledge_graph_type_definitions table is missing")
+
+    await async_session.rollback()
+
+    user_id = "user-canonical-schema-002"
+    authz = InMemoryAuthorizationProvider()
+    canonical_repo = GraphCanonicalSchemaRepository(async_session)
+    kg_service = KnowledgeGraphService(
+        session=async_session,
+        knowledge_graph_repository=knowledge_graph_repository,
+        authz=authz,
+        scope_to_tenant=test_tenant,
+        canonical_schema_repository=canonical_repo,
+    )
+
+    knowledge_graph = KnowledgeGraph.create(
+        tenant_id=test_tenant,
+        workspace_id=test_workspace,
+        name="Schema Evolution KG",
+        description="Additive schema evolution",
+        created_by=user_id,
+    )
+    bootstrap_config = OntologyConfig(
+        node_types=(NodeTypeDefinition(label="Repository"),),
+        edge_types=(
+            EdgeTypeDefinition(
+                label="CONTAINS",
+                source_labels=("Repository",),
+                target_labels=("Repository",),
+            ),
+        ),
+    )
+
+    async with async_session.begin():
+        await knowledge_graph_repository.save(knowledge_graph)
+
+    await authz.write_relationship(
+        f"knowledge_graph:{knowledge_graph.id.value}",
+        "admin",
+        f"user:{user_id}",
+    )
+    await kg_service.save_ontology(
+        user_id=user_id,
+        kg_id=knowledge_graph.id.value,
+        config=bootstrap_config,
+    )
+    await kg_service.transition_workspace_to_extraction(
+        user_id=user_id,
+        kg_id=knowledge_graph.id.value,
+    )
+
+    additive_define = {
+        "op": MutationOperationType.DEFINE.value,
+        "type": EntityType.NODE.value,
+        "label": "Service",
+        "description": "A deployable service",
+        "required_properties": ["slug", "name"],
+        "optional_properties": [],
+    }
+    await canonical_repo.apply_mutation_log(
+        knowledge_graph.id.value,
+        json.dumps(additive_define),
+    )
+    await async_session.commit()
+
+    canonical = await canonical_repo.get_ontology(knowledge_graph.id.value)
+    assert canonical is not None
+    assert {node.label for node in canonical.node_types} == {"Repository", "Service"}
+
+    status = await kg_service.get_workspace_status(
+        user_id=user_id,
+        kg_id=knowledge_graph.id.value,
+    )
+    assert status is not None
+    assert status.workspace_mode.value == "extraction_operations"

--- a/src/api/tests/unit/infrastructure/canonical_schema/test_ontology_mutation_builder.py
+++ b/src/api/tests/unit/infrastructure/canonical_schema/test_ontology_mutation_builder.py
@@ -1,0 +1,42 @@
+"""Unit tests for ontology to DEFINE mutation conversion."""
+
+from __future__ import annotations
+
+from infrastructure.canonical_schema.ontology_mutation_builder import (
+    ontology_config_to_define_operations,
+)
+from management.domain.value_objects import (
+    EdgeTypeDefinition,
+    NodeTypeDefinition,
+    OntologyConfig,
+)
+
+
+class TestOntologyConfigToDefineOperations:
+    def test_converts_node_and_edge_types(self):
+        config = OntologyConfig(
+            node_types=(NodeTypeDefinition(label="Repository", description="Repo"),),
+            edge_types=(
+                EdgeTypeDefinition(
+                    label="CONTAINS",
+                    description="Contains relationship",
+                    source_labels=("Repository",),
+                    target_labels=("Repository",),
+                    properties=("weight",),
+                ),
+            ),
+        )
+
+        operations = ontology_config_to_define_operations(config)
+
+        assert len(operations) == 2
+        node_op = operations[0]
+        edge_op = operations[1]
+        assert node_op.op == "DEFINE"
+        assert node_op.type == "node"
+        assert node_op.label == "Repository"
+        assert node_op.description == "Repo"
+        assert edge_op.op == "DEFINE"
+        assert edge_op.type == "edge"
+        assert edge_op.label == "CONTAINS"
+        assert edge_op.required_properties == {"weight"}

--- a/src/api/tests/unit/management/application/test_canonical_schema_service.py
+++ b/src/api/tests/unit/management/application/test_canonical_schema_service.py
@@ -1,0 +1,134 @@
+"""Unit tests for canonical schema integration in KnowledgeGraphService."""
+
+from __future__ import annotations
+
+import pytest
+
+from management.application.services.knowledge_graph_service import KnowledgeGraphService
+from management.domain.value_objects import (
+    EdgeTypeDefinition,
+    NodeTypeDefinition,
+    OntologyConfig,
+)
+from tests.fakes.authorization import InMemoryAuthorizationProvider
+from tests.fakes.canonical_schema import InMemoryCanonicalSchemaRepository
+from tests.fakes.management import (
+    InMemoryDataSourceRepository,
+    InMemoryKnowledgeGraphRepository,
+    InMemorySecretStoreRepository,
+    RecordingKnowledgeGraphServiceProbe,
+)
+from tests.unit.management.application.test_knowledge_graph_service import (
+    _grant_kg_edit,
+    _grant_kg_view,
+    _make_kg,
+)
+
+
+@pytest.fixture
+def canonical_schema_repo():
+    return InMemoryCanonicalSchemaRepository()
+
+
+@pytest.fixture
+def service_with_canonical(
+    mock_session, kg_repo, authz, canonical_schema_repo, tenant_id
+):
+    return KnowledgeGraphService(
+        session=mock_session,
+        knowledge_graph_repository=kg_repo,
+        data_source_repository=InMemoryDataSourceRepository(),
+        secret_store=InMemorySecretStoreRepository(),
+        authz=authz,
+        scope_to_tenant=tenant_id,
+        probe=RecordingKnowledgeGraphServiceProbe(),
+        canonical_schema_repository=canonical_schema_repo,
+    )
+
+
+@pytest.fixture
+def mock_session():
+    from unittest.mock import AsyncMock, MagicMock
+
+    session = MagicMock()
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    return session
+
+
+@pytest.fixture
+def kg_repo():
+    return InMemoryKnowledgeGraphRepository()
+
+
+@pytest.fixture
+def authz():
+    return InMemoryAuthorizationProvider()
+
+
+@pytest.fixture
+def tenant_id():
+    return "tenant-123"
+
+
+@pytest.fixture
+def user_id():
+    return "user-456"
+
+
+class TestKnowledgeGraphServiceCanonicalSchema:
+    @pytest.mark.asyncio
+    async def test_save_ontology_writes_to_canonical_repository(
+        self, service_with_canonical, canonical_schema_repo, authz, kg_repo, user_id
+    ):
+        kg = _make_kg()
+        kg_repo.seed(kg)
+        await _grant_kg_edit(authz, kg.id.value, user_id)
+        config = OntologyConfig(
+            node_types=(NodeTypeDefinition(label="Repository"),),
+            edge_types=(
+                EdgeTypeDefinition(
+                    label="CONTAINS",
+                    source_labels=("Repository",),
+                    target_labels=("Repository",),
+                ),
+            ),
+        )
+
+        await service_with_canonical.save_ontology(
+            user_id=user_id,
+            kg_id=kg.id.value,
+            config=config,
+        )
+
+        assert len(canonical_schema_repo.replaced) == 1
+        assert canonical_schema_repo.replaced[0][0] == kg.id.value
+
+    @pytest.mark.asyncio
+    async def test_workspace_readiness_uses_canonical_schema(
+        self, service_with_canonical, canonical_schema_repo, authz, kg_repo, user_id
+    ):
+        kg = _make_kg()
+        kg_repo.seed(kg)
+        canonical_schema_repo.seed(
+            kg.id.value,
+            OntologyConfig(
+                node_types=(NodeTypeDefinition(label="Repository"),),
+                edge_types=(
+                    EdgeTypeDefinition(
+                        label="CONTAINS",
+                        source_labels=("Repository",),
+                        target_labels=("Repository",),
+                    ),
+                ),
+            ),
+        )
+        await _grant_kg_view(authz, kg.id.value, user_id)
+
+        result = await service_with_canonical.get_workspace_status(
+            user_id=user_id,
+            kg_id=kg.id.value,
+        )
+
+        assert result is not None
+        assert result.transition_eligible is True

--- a/src/api/tests/unit/management/application/test_knowledge_graph_service.py
+++ b/src/api/tests/unit/management/application/test_knowledge_graph_service.py
@@ -156,6 +156,13 @@ def _make_kg(
     return kg
 
 
+async def _seed_stored_ontology(kg, kg_repo, config: OntologyConfig) -> None:
+    """Attach ontology to aggregate and persisted JSONB fallback store."""
+    kg.set_ontology(config)
+    kg_repo.seed(kg)
+    await kg_repo.save_ontology(kg.id.value, config)
+
+
 def _make_ds(
     ds_id: str = "ds-001",
     kg_id: str = "kg-001",
@@ -445,19 +452,17 @@ class TestKnowledgeGraphServiceWorkspaceStatus:
     ):
         """Should project mode/readiness flags and default null session pointers."""
         kg = _make_kg()
-        kg.set_ontology(
-            OntologyConfig(
-                node_types=(NodeTypeDefinition(label="Repository"),),
-                edge_types=(
-                    EdgeTypeDefinition(
-                        label="CONTAINS",
-                        source_labels=("Repository",),
-                        target_labels=("Repository",),
-                    ),
+        ontology_config = OntologyConfig(
+            node_types=(NodeTypeDefinition(label="Repository"),),
+            edge_types=(
+                EdgeTypeDefinition(
+                    label="CONTAINS",
+                    source_labels=("Repository",),
+                    target_labels=("Repository",),
                 ),
-            )
+            ),
         )
-        kg_repo.seed(kg)
+        await _seed_stored_ontology(kg, kg_repo, ontology_config)
         await _grant_kg_view(authz, kg.id.value, user_id)
 
         result = await service.get_workspace_status(user_id=user_id, kg_id=kg.id.value)
@@ -501,25 +506,23 @@ class TestKnowledgeGraphServiceWorkspaceStatus:
     ):
         """Should block transition when prepopulated type has zero instances."""
         kg = _make_kg()
-        kg.set_ontology(
-            OntologyConfig(
-                node_types=(
-                    NodeTypeDefinition(
-                        label="Repository",
-                        prepopulated=True,
-                        prepopulated_instance_count=0,
-                    ),
+        ontology_config = OntologyConfig(
+            node_types=(
+                NodeTypeDefinition(
+                    label="Repository",
+                    prepopulated=True,
+                    prepopulated_instance_count=0,
                 ),
-                edge_types=(
-                    EdgeTypeDefinition(
-                        label="CONTAINS",
-                        source_labels=("Repository",),
-                        target_labels=("Repository",),
-                    ),
+            ),
+            edge_types=(
+                EdgeTypeDefinition(
+                    label="CONTAINS",
+                    source_labels=("Repository",),
+                    target_labels=("Repository",),
                 ),
-            )
+            ),
         )
-        kg_repo.seed(kg)
+        await _seed_stored_ontology(kg, kg_repo, ontology_config)
         await _grant_kg_view(authz, kg.id.value, user_id)
 
         result = await service.get_workspace_status(user_id=user_id, kg_id=kg.id.value)
@@ -562,19 +565,17 @@ class TestKnowledgeGraphServiceWorkspaceCommands:
         self, service, authz, kg_repo, user_id
     ):
         kg = _make_kg()
-        kg.set_ontology(
-            OntologyConfig(
-                node_types=(NodeTypeDefinition(label="Repository"),),
-                edge_types=(
-                    EdgeTypeDefinition(
-                        label="CONTAINS",
-                        source_labels=("Repository",),
-                        target_labels=("Repository",),
-                    ),
+        ontology_config = OntologyConfig(
+            node_types=(NodeTypeDefinition(label="Repository"),),
+            edge_types=(
+                EdgeTypeDefinition(
+                    label="CONTAINS",
+                    source_labels=("Repository",),
+                    target_labels=("Repository",),
                 ),
-            )
+            ),
         )
-        kg_repo.seed(kg)
+        await _seed_stored_ontology(kg, kg_repo, ontology_config)
         await _grant_kg_view(authz, kg.id.value, user_id)
 
         with pytest.raises(UnauthorizedError):
@@ -588,19 +589,17 @@ class TestKnowledgeGraphServiceWorkspaceCommands:
         self, service, authz, kg_repo, user_id
     ):
         kg = _make_kg()
-        kg.set_ontology(
-            OntologyConfig(
-                node_types=(NodeTypeDefinition(label="Repository"),),
-                edge_types=(
-                    EdgeTypeDefinition(
-                        label="CONTAINS",
-                        source_labels=("Repository",),
-                        target_labels=("Repository",),
-                    ),
+        ontology_config = OntologyConfig(
+            node_types=(NodeTypeDefinition(label="Repository"),),
+            edge_types=(
+                EdgeTypeDefinition(
+                    label="CONTAINS",
+                    source_labels=("Repository",),
+                    target_labels=("Repository",),
                 ),
-            )
+            ),
         )
-        kg_repo.seed(kg)
+        await _seed_stored_ontology(kg, kg_repo, ontology_config)
         await _grant_kg_edit(authz, kg.id.value, user_id)
 
         result = await service.transition_workspace_to_extraction(


### PR DESCRIPTION
## Summary
- Introduce KG-scoped canonical schema storage (`knowledge_graph_type_definitions`) populated through mutation-log DEFINE operations.
- Wire Management ontology save/read and workspace readiness checks to the canonical schema repository, with JSONB ontology fallback for unmigrated data.
- Add integration coverage for bootstrap schema persistence and additive DEFINE evolution in extraction mode.

Partial for #718

### Remaining gap
- Graph schema HTTP/MCP paths still read from the global in-memory type-definition repository.
- Extraction bootstrap agent sessions are not yet fully routed through canonical schema writes (Management API path is covered).
- Legacy `knowledge_graphs.ontology` JSONB is no longer written when canonical repo is enabled, but not removed/migrated wholesale.

## Test plan
- [x] `uv run pytest tests/unit/infrastructure/canonical_schema -v`
- [x] `uv run pytest tests/unit/management/application/test_canonical_schema_service.py -v`
- [x] `uv run pytest tests/unit/management/application/test_knowledge_graph_service.py::TestKnowledgeGraphServiceWorkspaceStatus -v`
- [x] `uv run pytest tests/unit/management/application/test_knowledge_graph_service.py::TestKnowledgeGraphServiceWorkspaceCommands -v`
- [x] `uv run pytest tests/unit/graph/test_architecture.py tests/unit/management/test_architecture.py -v`
- [ ] `uv run pytest tests/integration/management/test_canonical_schema_source.py -v -m integration` (requires migration `fb1c2d3e4f5a`)


Made with [Cursor](https://cursor.com)