### PR TITLE
feat(extraction): streaming chat turn service and NDJSON endpoint

### DIFF
--- a/src/api/extraction/application/__init__.py
+++ b/src/api/extraction/application/__init__.py
@@ -5,9 +5,15 @@ and port contracts. They do not directly depend on infrastructure.
 """
 
 from extraction.application.agent_session_service import ExtractionAgentSessionService
+from extraction.application.chat_turn_service import ExtractionChatTurnService
 from extraction.application.skill_resolution_service import (
     ExtractionSkillResolutionService,
+    ResolvedExtractionSkillPack,
 )
 
-__all__ = ["ExtractionAgentSessionService", "ExtractionSkillResolutionService"]
-
+__all__ = [
+    "ExtractionAgentSessionService",
+    "ExtractionChatTurnService",
+    "ExtractionSkillResolutionService",
+    "ResolvedExtractionSkillPack",
+]

--- a/src/api/extraction/application/agent_session_service.py
+++ b/src/api/extraction/application/agent_session_service.py
@@ -17,6 +17,7 @@ from extraction.ports.repositories import (
     IExtractionAgentSessionRepository,
     IExtractionSessionRunMetricsReader,
 )
+from extraction.ports.runtime import IStickySessionRuntimeManager
 
 
 @dataclass(frozen=True)
@@ -35,10 +36,12 @@ class ExtractionAgentSessionService:
         repository: IExtractionAgentSessionRepository,
         skill_resolution_service: ExtractionSkillResolutionService | None = None,
         run_metrics_reader: IExtractionSessionRunMetricsReader | None = None,
+        sticky_runtime_manager: IStickySessionRuntimeManager | None = None,
     ) -> None:
         self._repository = repository
         self._skill_resolution_service = skill_resolution_service
         self._run_metrics_reader = run_metrics_reader
+        self._sticky_runtime_manager = sticky_runtime_manager
 
     @staticmethod
     def _build_bootstrap_intake_prompt() -> str:
@@ -96,6 +99,12 @@ class ExtractionAgentSessionService:
         await self._repository.save(session)
         return session
 
+    async def save_session(self, session: ExtractionAgentSession) -> ExtractionAgentSession:
+        """Persist session mutations after a chat turn."""
+        session.updated_at = datetime.now(UTC)
+        await self._repository.save(session)
+        return session
+
     async def clear_chat(
         self,
         user_id: str,
@@ -108,6 +117,13 @@ class ExtractionAgentSessionService:
             mode=mode,
         )
         if active is not None:
+            if self._sticky_runtime_manager is not None:
+                self._sticky_runtime_manager.reset_runtime(
+                    session_id=active.id,
+                    user_id=user_id,
+                    knowledge_graph_id=knowledge_graph_id,
+                    mode=mode.value,
+                )
             active.archive()
             await self._repository.save(active)
 

--- a/src/api/extraction/application/chat_turn_service.py
+++ b/src/api/extraction/application/chat_turn_service.py
@@ -1,0 +1,158 @@
+"""Orchestrates graph-management chat turns with sticky runtime and streaming events."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
+
+from extraction.application.agent_session_service import ExtractionAgentSessionService
+from extraction.application.job_package_gate import resolve_job_package_gate
+from extraction.application.skill_resolution_service import ExtractionSkillResolutionService
+from extraction.domain.value_objects import (
+    ExtractionSessionMode,
+    GraphManagementUiMode,
+    SessionJobPackagePhase,
+)
+from extraction.ports.chat_agent import IExtractionChatAgent
+from extraction.ports.ingestion_readiness import IIngestionReadinessReader
+from extraction.ports.runtime import IStickySessionRuntimeManager
+
+
+class ExtractionChatTurnService:
+    """Coordinates sticky runtime, JobPackage gating, and agent execution."""
+
+    def __init__(
+        self,
+        *,
+        session_service: ExtractionAgentSessionService,
+        skill_resolution_service: ExtractionSkillResolutionService,
+        ingestion_readiness_reader: IIngestionReadinessReader,
+        sticky_runtime_manager: IStickySessionRuntimeManager,
+        chat_agent: IExtractionChatAgent,
+    ) -> None:
+        self._session_service = session_service
+        self._skill_resolution_service = skill_resolution_service
+        self._ingestion_readiness_reader = ingestion_readiness_reader
+        self._sticky_runtime_manager = sticky_runtime_manager
+        self._chat_agent = chat_agent
+
+    async def stream_chat_turn(
+        self,
+        *,
+        user_id: str,
+        knowledge_graph_id: str,
+        mode: ExtractionSessionMode,
+        ui_mode: GraphManagementUiMode,
+        message: str,
+    ) -> AsyncIterator[dict[str, Any]]:
+        trimmed = message.strip()
+        if not trimmed:
+            yield {
+                "type": "done",
+                "ok": False,
+                "error": {
+                    "code": "EMPTY_MESSAGE",
+                    "message": "Message must not be empty.",
+                },
+            }
+            return
+
+        session = await self._session_service.get_or_create_active_session(
+            user_id=user_id,
+            knowledge_graph_id=knowledge_graph_id,
+            mode=mode,
+        )
+
+        resolved_skills = await self._skill_resolution_service.resolve_for_graph_management_turn(
+            knowledge_graph_id=knowledge_graph_id,
+            mode=mode,
+            ui_mode=ui_mode,
+        )
+        session.runtime_context["agent_configuration"] = {
+            "system_prompt": resolved_skills.system_prompt,
+            "prompt_hierarchy": list(resolved_skills.prompt_hierarchy),
+            "guardrails": list(resolved_skills.guardrails),
+            "skills": dict(resolved_skills.skills),
+            "graph_management_ui_mode": ui_mode.value,
+        }
+
+        lease = self._sticky_runtime_manager.get_or_start_runtime(
+            session_id=session.id,
+            user_id=user_id,
+            knowledge_graph_id=knowledge_graph_id,
+            mode=mode.value,
+        )
+        session.runtime_context["sticky_runtime"] = {
+            "container_id": lease.container_id,
+            "status": lease.status,
+            "expires_at": lease.expires_at.isoformat(),
+        }
+
+        yield {
+            "type": "thinking",
+            "recent": [
+                "Contacting Graph Management Assistant…",
+                f"Sticky container {lease.container_id[:8]} active",
+            ],
+        }
+
+        readiness = await self._ingestion_readiness_reader.read_for_knowledge_graph(
+            knowledge_graph_id=knowledge_graph_id,
+        )
+        gate = resolve_job_package_gate(ui_mode=ui_mode, readiness=readiness)
+        session.runtime_context["job_package"] = {
+            "phase": gate.phase.value,
+            "data_source_count": readiness.data_source_count,
+            "prepared_source_count": readiness.prepared_source_count,
+        }
+
+        session.message_history.append({"role": "user", "content": trimmed})
+        session.updated_at = datetime.now(UTC)
+
+        if gate.phase == SessionJobPackagePhase.AWAITING_PREPARE:
+            wait_message = gate.wait_message or "Waiting for JobPackage ingestion context."
+            session.runtime_context["activity_lines"] = [wait_message]
+            yield {
+                "type": "wait",
+                "phase": gate.phase.value,
+                "message": wait_message,
+            }
+            yield {
+                "type": "thinking",
+                "recent": ["Waiting for JobPackage ingestion context…", wait_message],
+            }
+            assistant_reply = (
+                f"**Waiting for ingestion context**\n\n{wait_message}\n\n"
+                "I'll respond with full repository-aware guidance once JobPackage "
+                "material is prepared for this knowledge graph."
+            )
+            session.message_history.append({"role": "assistant", "content": assistant_reply})
+            session.updated_at = datetime.now(UTC)
+            await self._session_service.save_session(session)
+            yield {"type": "done", "ok": True, "reply": assistant_reply, "wait": True}
+            return
+
+        session.runtime_context["job_package"]["phase"] = SessionJobPackagePhase.READY.value
+        thinking_lines: list[str] = []
+        assistant_reply: str | None = None
+        async for event in self._chat_agent.stream_turn(
+            session=session,
+            user_message=trimmed,
+            ui_mode=ui_mode,
+        ):
+            if event.get("type") == "thinking":
+                recent = event.get("recent")
+                if isinstance(recent, list):
+                    thinking_lines = [str(line) for line in recent if str(line).strip()]
+                    session.runtime_context["activity_lines"] = thinking_lines
+            if event.get("type") == "done":
+                if event.get("ok") is True and event.get("reply"):
+                    assistant_reply = str(event["reply"])
+            yield event
+
+        if assistant_reply:
+            session.message_history.append({"role": "assistant", "content": assistant_reply})
+            session.updated_at = datetime.now(UTC)
+            session.runtime_context.pop("activity_lines", None)
+            await self._session_service.save_session(session)

--- a/src/api/extraction/application/job_package_gate.py
+++ b/src/api/extraction/application/job_package_gate.py
@@ -1,0 +1,53 @@
+"""Pure helpers for JobPackage readiness gating in chat turns."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from extraction.domain.value_objects import (
+    GraphManagementUiMode,
+    IngestionReadinessSnapshot,
+    SessionJobPackagePhase,
+)
+
+
+@dataclass(frozen=True)
+class JobPackageGateDecision:
+    """Resolved JobPackage gate for one chat turn."""
+
+    phase: SessionJobPackagePhase
+    wait_message: str | None = None
+
+
+def resolve_job_package_gate(
+    *,
+    ui_mode: GraphManagementUiMode,
+    readiness: IngestionReadinessSnapshot,
+) -> JobPackageGateDecision:
+    """Return whether a chat turn must wait for JobPackage context."""
+    if ui_mode in {
+        GraphManagementUiMode.INITIAL_SCHEMA_DESIGN,
+        GraphManagementUiMode.ONE_OFF_MUTATIONS,
+    }:
+        return JobPackageGateDecision(phase=SessionJobPackagePhase.NOT_REQUIRED)
+
+    if readiness.data_source_count == 0:
+        return JobPackageGateDecision(
+            phase=SessionJobPackagePhase.AWAITING_PREPARE,
+            wait_message=(
+                "Waiting for a connected data source. Add and prepare data sources "
+                "under Data sources before extraction job chat can run."
+            ),
+        )
+
+    if readiness.prepared_source_count < readiness.data_source_count:
+        return JobPackageGateDecision(
+            phase=SessionJobPackagePhase.AWAITING_PREPARE,
+            wait_message=(
+                "Waiting for JobPackage ingestion context. Prepare all data sources "
+                f"({readiness.prepared_source_count}/{readiness.data_source_count} ready) "
+                "so the sticky session container can load repository files."
+            ),
+        )
+
+    return JobPackageGateDecision(phase=SessionJobPackagePhase.READY)

--- a/src/api/extraction/application/skill_resolution_service.py
+++ b/src/api/extraction/application/skill_resolution_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from extraction.domain.value_objects import ExtractionSessionMode
+from extraction.domain.value_objects import ExtractionSessionMode, GraphManagementUiMode
 from extraction.ports.repositories import IExtractionSkillOverrideRepository
 
 
@@ -87,6 +87,27 @@ _GLOBAL_SKILL_TEMPLATES: dict[ExtractionSessionMode, dict[str, str]] = {
 }
 
 
+_UI_MODE_SKILL_OVERLAYS: dict[GraphManagementUiMode, dict[str, str]] = {
+    GraphManagementUiMode.INITIAL_SCHEMA_DESIGN: {
+        "ui_mode_framing": (
+            "Focus on schema bootstrap: entity/relationship modeling, intake, and "
+            "prepopulation guidance before extraction jobs."
+        ),
+    },
+    GraphManagementUiMode.EXTRACTION_JOBS: {
+        "ui_mode_framing": (
+            "Focus on extraction job setup, JobPackage-aware file targeting, and "
+            "incremental sync planning."
+        ),
+    },
+    GraphManagementUiMode.ONE_OFF_MUTATIONS: {
+        "ui_mode_framing": (
+            "Focus on scoped one-off graph mutations with mutation-log auditability."
+        ),
+    },
+}
+
+
 class ExtractionSkillResolutionService:
     """Resolve session skills from global templates + KG overrides."""
 
@@ -121,5 +142,27 @@ class ExtractionSkillResolutionService:
             prompt_hierarchy=tuple(prompt_settings["prompt_hierarchy"]),
             guardrails=tuple(prompt_settings["guardrails"]),
             skills=resolved,
+        )
+
+    async def resolve_for_graph_management_turn(
+        self,
+        *,
+        knowledge_graph_id: str,
+        mode: ExtractionSessionMode,
+        ui_mode: GraphManagementUiMode,
+    ) -> ResolvedExtractionSkillPack:
+        """Resolve base session skills plus graph-management UI mode overlay."""
+        base = await self.resolve_for_session(
+            knowledge_graph_id=knowledge_graph_id,
+            mode=mode,
+        )
+        overlay = dict(_UI_MODE_SKILL_OVERLAYS.get(ui_mode, {}))
+        merged_skills = dict(base.skills)
+        merged_skills.update(overlay)
+        return ResolvedExtractionSkillPack(
+            system_prompt=base.system_prompt,
+            prompt_hierarchy=base.prompt_hierarchy,
+            guardrails=base.guardrails,
+            skills=merged_skills,
         )
 

--- a/src/api/extraction/dependencies.py
+++ b/src/api/extraction/dependencies.py
@@ -8,8 +8,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from extraction.application import (
     ExtractionAgentSessionService,
+    ExtractionChatTurnService,
     ExtractionSkillResolutionService,
 )
+from extraction.infrastructure.deterministic_chat_agent import DeterministicExtractionChatAgent
+from extraction.infrastructure.ingestion_readiness_reader import SqlIngestionReadinessReader
 from extraction.infrastructure.repositories import (
     ExtractionAgentSessionRepository,
     ExtractionSessionRunMetricsReader,
@@ -40,6 +43,9 @@ def get_ephemeral_extraction_worker_launcher() -> IEphemeralExtractionWorkerLaun
 
 def get_extraction_agent_session_service(
     session: Annotated[AsyncSession, Depends(get_write_session)],
+    sticky_runtime_manager: Annotated[
+        IStickySessionRuntimeManager, Depends(get_sticky_session_runtime_manager)
+    ],
 ) -> ExtractionAgentSessionService:
     """Get ExtractionAgentSessionService instance."""
     skill_resolution_service = ExtractionSkillResolutionService(
@@ -49,4 +55,30 @@ def get_extraction_agent_session_service(
         repository=ExtractionAgentSessionRepository(session=session),
         skill_resolution_service=skill_resolution_service,
         run_metrics_reader=ExtractionSessionRunMetricsReader(session=session),
+        sticky_runtime_manager=sticky_runtime_manager,
+    )
+
+
+def get_extraction_chat_turn_service(
+    session: Annotated[AsyncSession, Depends(get_write_session)],
+    sticky_runtime_manager: Annotated[
+        IStickySessionRuntimeManager, Depends(get_sticky_session_runtime_manager)
+    ],
+) -> ExtractionChatTurnService:
+    """Get ExtractionChatTurnService instance."""
+    skill_resolution_service = ExtractionSkillResolutionService(
+        override_repository=ExtractionSkillOverrideRepository()
+    )
+    session_service = ExtractionAgentSessionService(
+        repository=ExtractionAgentSessionRepository(session=session),
+        skill_resolution_service=skill_resolution_service,
+        run_metrics_reader=ExtractionSessionRunMetricsReader(session=session),
+        sticky_runtime_manager=sticky_runtime_manager,
+    )
+    return ExtractionChatTurnService(
+        session_service=session_service,
+        skill_resolution_service=skill_resolution_service,
+        ingestion_readiness_reader=SqlIngestionReadinessReader(session=session),
+        sticky_runtime_manager=sticky_runtime_manager,
+        chat_agent=DeterministicExtractionChatAgent(),
     )

--- a/src/api/extraction/domain/value_objects.py
+++ b/src/api/extraction/domain/value_objects.py
@@ -21,6 +21,30 @@ class BootstrapIntakePath(StrEnum):
     GUIDED_CO_DESIGN = "guided_co_design"
 
 
+class GraphManagementUiMode(StrEnum):
+    """Graph-management UI mode overlay for chat skill framing."""
+
+    INITIAL_SCHEMA_DESIGN = "initial-schema-design"
+    EXTRACTION_JOBS = "extraction-jobs"
+    ONE_OFF_MUTATIONS = "one-off-mutations"
+
+
+class SessionJobPackagePhase(StrEnum):
+    """JobPackage readiness phase for sticky session chat turns."""
+
+    NOT_REQUIRED = "not_required"
+    AWAITING_PREPARE = "awaiting_job_package"
+    READY = "ready"
+
+
+@dataclass(frozen=True)
+class IngestionReadinessSnapshot:
+    """Read-only ingestion prepare counts for a knowledge graph."""
+
+    data_source_count: int
+    prepared_source_count: int
+
+
 @dataclass(frozen=True)
 class ExtractionSessionRunMetric:
     """Run-level metrics linked to an extraction session."""

--- a/src/api/extraction/infrastructure/deterministic_chat_agent.py
+++ b/src/api/extraction/infrastructure/deterministic_chat_agent.py
@@ -1,0 +1,46 @@
+"""Deterministic chat agent for tracer-bullet chat turn execution."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from extraction.domain.entities.agent_session import ExtractionAgentSession
+from extraction.domain.value_objects import GraphManagementUiMode
+
+
+class DeterministicExtractionChatAgent:
+    """Tracer-bullet agent that simulates thinking lines and a structured reply."""
+
+    async def stream_turn(
+        self,
+        *,
+        session: ExtractionAgentSession,
+        user_message: str,
+        ui_mode: GraphManagementUiMode,
+    ) -> AsyncIterator[dict[str, Any]]:
+        yield {
+            "type": "thinking",
+            "recent": [
+                "Starting sticky session Claude agent runtime…",
+                f"Applying {ui_mode.value} skill overlay",
+            ],
+        }
+        yield {
+            "type": "thinking",
+            "recent": [
+                "Starting sticky session Claude agent runtime…",
+                f"Applying {ui_mode.value} skill overlay",
+                "Reviewing session message history",
+            ],
+        }
+        skills = session.runtime_context.get("agent_configuration", {}).get("skills", {})
+        skill_keys = ", ".join(sorted(skills.keys())[:3]) or "default skills"
+        reply = (
+            f"**Graph Management Assistant ({ui_mode.value})**\n\n"
+            f"I received your message and loaded skills: {skill_keys}.\n\n"
+            f"> {user_message.strip()}\n\n"
+            "This is a tracer-bullet reply. The sticky container runtime will invoke "
+            "the Claude Agent SDK with JobPackage context in a follow-up change."
+        )
+        yield {"type": "done", "ok": True, "reply": reply}

--- a/src/api/extraction/infrastructure/ingestion_readiness_reader.py
+++ b/src/api/extraction/infrastructure/ingestion_readiness_reader.py
@@ -1,0 +1,36 @@
+"""SQL reader for ingestion prepare counts without importing Management."""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from extraction.domain.value_objects import IngestionReadinessSnapshot
+
+
+class SqlIngestionReadinessReader:
+    """Reads prepared data source counts from the shared data_sources table."""
+
+    def __init__(self, *, session: AsyncSession) -> None:
+        self._session = session
+
+    async def read_for_knowledge_graph(
+        self, *, knowledge_graph_id: str
+    ) -> IngestionReadinessSnapshot:
+        result = await self._session.execute(
+            text(
+                """
+                SELECT
+                  COUNT(*) AS total,
+                  COUNT(*) FILTER (WHERE last_prepared_commit IS NOT NULL) AS prepared
+                FROM data_sources
+                WHERE knowledge_graph_id = :knowledge_graph_id
+                """
+            ),
+            {"knowledge_graph_id": knowledge_graph_id},
+        )
+        row = result.one()
+        return IngestionReadinessSnapshot(
+            data_source_count=int(row.total or 0),
+            prepared_source_count=int(row.prepared or 0),
+        )

--- a/src/api/extraction/ports/chat_agent.py
+++ b/src/api/extraction/ports/chat_agent.py
@@ -1,0 +1,23 @@
+"""Port contract for graph-management chat agent execution."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any, Protocol
+
+from extraction.domain.entities.agent_session import ExtractionAgentSession
+from extraction.domain.value_objects import GraphManagementUiMode
+
+
+class IExtractionChatAgent(Protocol):
+    """Runs one conversational turn inside a sticky session runtime."""
+
+    def stream_turn(
+        self,
+        *,
+        session: ExtractionAgentSession,
+        user_message: str,
+        ui_mode: GraphManagementUiMode,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Yield NDJSON-style event dictionaries ending with a terminal done event."""
+        ...

--- a/src/api/extraction/ports/ingestion_readiness.py
+++ b/src/api/extraction/ports/ingestion_readiness.py
@@ -1,0 +1,17 @@
+"""Port for reading ingestion prepare readiness without importing Management."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from extraction.domain.value_objects import IngestionReadinessSnapshot
+
+
+class IIngestionReadinessReader(Protocol):
+    """Read-only ingestion prepare counts for JobPackage gating."""
+
+    async def read_for_knowledge_graph(
+        self, *, knowledge_graph_id: str
+    ) -> IngestionReadinessSnapshot:
+        """Return data source totals and prepared counts for one knowledge graph."""
+        ...

--- a/src/api/extraction/presentation/models.py
+++ b/src/api/extraction/presentation/models.py
@@ -13,6 +13,7 @@ from extraction.domain.value_objects import (
     BootstrapIntakePath,
     ExtractionSessionMode,
     ExtractionSessionRunMetric,
+    GraphManagementUiMode,
 )
 
 
@@ -129,3 +130,10 @@ class BootstrapIntakePathSelectionRequest(BaseModel):
         default=None,
         description="Optional user summary of capabilities and schema goals",
     )
+
+
+class ExtractionChatTurnRequest(BaseModel):
+    """Request model for a graph-management chat turn."""
+
+    message: str = Field(min_length=1)
+    graph_management_ui_mode: GraphManagementUiMode = GraphManagementUiMode.INITIAL_SCHEMA_DESIGN

--- a/src/api/extraction/presentation/routes.py
+++ b/src/api/extraction/presentation/routes.py
@@ -2,15 +2,22 @@
 
 from __future__ import annotations
 
+import json
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import StreamingResponse
 
 from extraction.application import ExtractionAgentSessionService
-from extraction.dependencies import get_extraction_agent_session_service
+from extraction.application.chat_turn_service import ExtractionChatTurnService
+from extraction.dependencies import (
+    get_extraction_agent_session_service,
+    get_extraction_chat_turn_service,
+)
 from extraction.domain.value_objects import ExtractionSessionMode
 from extraction.presentation.models import (
     BootstrapIntakePathSelectionRequest,
+    ExtractionChatTurnRequest,
     ExtractionSessionHistoryItemResponse,
     ExtractionSessionHistoryResponse,
     ExtractionSessionListResponse,
@@ -153,6 +160,36 @@ async def clear_chat(
         mode=mode,
     )
     return ExtractionSessionResponse.from_domain(session)
+
+
+@router.post(
+    "/knowledge-graphs/{knowledge_graph_id}/sessions/{mode}/chat",
+)
+async def stream_chat_turn(
+    knowledge_graph_id: str,
+    mode: ExtractionSessionMode,
+    request: ExtractionChatTurnRequest,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    service: Annotated[ExtractionChatTurnService, Depends(get_extraction_chat_turn_service)],
+    authz: Annotated[AuthorizationProvider, Depends(get_spicedb_client)],
+) -> StreamingResponse:
+    await _assert_kg_edit_permission(
+        authz=authz,
+        current_user=current_user,
+        knowledge_graph_id=knowledge_graph_id,
+    )
+
+    async def event_stream():
+        async for event in service.stream_chat_turn(
+            user_id=current_user.user_id.value,
+            knowledge_graph_id=knowledge_graph_id,
+            mode=mode,
+            ui_mode=request.graph_management_ui_mode,
+            message=request.message,
+        ):
+            yield json.dumps(event) + "\n"
+
+    return StreamingResponse(event_stream(), media_type="application/x-ndjson")
 
 
 @router.post(

--- a/src/api/tests/unit/extraction/application/test_chat_turn_service.py
+++ b/src/api/tests/unit/extraction/application/test_chat_turn_service.py
@@ -1,0 +1,151 @@
+"""Unit tests for ExtractionChatTurnService."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from extraction.application.agent_session_service import ExtractionAgentSessionService
+from extraction.application.chat_turn_service import ExtractionChatTurnService
+from extraction.application.skill_resolution_service import ExtractionSkillResolutionService
+from extraction.domain.entities.agent_session import ExtractionAgentSession
+from extraction.domain.value_objects import (
+    ExtractionSessionMode,
+    GraphManagementUiMode,
+    IngestionReadinessSnapshot,
+)
+from extraction.infrastructure.deterministic_chat_agent import DeterministicExtractionChatAgent
+from extraction.infrastructure.workload_runtime import InMemoryStickySessionRuntimeManager
+
+
+class _InMemoryAgentSessionRepository:
+    def __init__(self) -> None:
+        self._sessions: dict[str, ExtractionAgentSession] = {}
+
+    async def save(self, session: ExtractionAgentSession) -> None:
+        self._sessions[session.id] = replace(session)
+
+    async def get_by_id(self, session_id: str) -> ExtractionAgentSession | None:
+        session = self._sessions.get(session_id)
+        return replace(session) if session else None
+
+    async def find_active_by_scope(
+        self,
+        user_id: str,
+        knowledge_graph_id: str,
+        mode: ExtractionSessionMode,
+    ) -> ExtractionAgentSession | None:
+        for session in self._sessions.values():
+            if (
+                session.user_id == user_id
+                and session.knowledge_graph_id == knowledge_graph_id
+                and session.mode == mode
+                and session.archived_at is None
+            ):
+                return replace(session)
+        return None
+
+    async def list_by_scope(
+        self,
+        user_id: str,
+        knowledge_graph_id: str,
+        mode: ExtractionSessionMode | None = None,
+    ) -> list[ExtractionAgentSession]:
+        return []
+
+
+class _StaticIngestionReadinessReader:
+    def __init__(self, snapshot: IngestionReadinessSnapshot) -> None:
+        self._snapshot = snapshot
+
+    async def read_for_knowledge_graph(
+        self, *, knowledge_graph_id: str
+    ) -> IngestionReadinessSnapshot:
+        return self._snapshot
+
+
+class _StaticSkillResolutionService:
+    async def resolve_for_graph_management_turn(self, **kwargs):
+        return type(
+            "_Resolved",
+            (),
+            {
+                "system_prompt": "system",
+                "prompt_hierarchy": ("platform",),
+                "guardrails": ("scope",),
+                "skills": {"ui_mode_framing": "test overlay"},
+            },
+        )()
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_turn_persists_assistant_reply() -> None:
+    repo = _InMemoryAgentSessionRepository()
+    sticky = InMemoryStickySessionRuntimeManager()
+    session_service = ExtractionAgentSessionService(repository=repo)
+    service = ExtractionChatTurnService(
+        session_service=session_service,
+        skill_resolution_service=_StaticSkillResolutionService(),
+        ingestion_readiness_reader=_StaticIngestionReadinessReader(
+            IngestionReadinessSnapshot(1, 1),
+        ),
+        sticky_runtime_manager=sticky,
+        chat_agent=DeterministicExtractionChatAgent(),
+    )
+
+    events = [
+        event
+        async for event in service.stream_chat_turn(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode=ExtractionSessionMode.SCHEMA_BOOTSTRAP,
+            ui_mode=GraphManagementUiMode.INITIAL_SCHEMA_DESIGN,
+            message="Help me design entity types",
+        )
+    ]
+
+    assert events[-1]["type"] == "done"
+    assert events[-1]["ok"] is True
+    active = await repo.find_active_by_scope("user-1", "kg-1", ExtractionSessionMode.SCHEMA_BOOTSTRAP)
+    assert active is not None
+    assert active.message_history[-2]["role"] == "user"
+    assert active.message_history[-1]["role"] == "assistant"
+    assert active.runtime_context["sticky_runtime"]["container_id"]
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_turn_wait_when_job_package_unprepared() -> None:
+    repo = _InMemoryAgentSessionRepository()
+    sticky = InMemoryStickySessionRuntimeManager()
+    session_service = ExtractionAgentSessionService(repository=repo)
+    service = ExtractionChatTurnService(
+        session_service=session_service,
+        skill_resolution_service=_StaticSkillResolutionService(),
+        ingestion_readiness_reader=_StaticIngestionReadinessReader(
+            IngestionReadinessSnapshot(2, 0),
+        ),
+        sticky_runtime_manager=sticky,
+        chat_agent=DeterministicExtractionChatAgent(),
+    )
+
+    events = [
+        event
+        async for event in service.stream_chat_turn(
+            user_id="user-1",
+            knowledge_graph_id="kg-1",
+            mode=ExtractionSessionMode.EXTRACTION_OPERATIONS,
+            ui_mode=GraphManagementUiMode.EXTRACTION_JOBS,
+            message="Run extraction on repo files",
+        )
+    ]
+
+    assert any(event.get("type") == "wait" for event in events)
+    done = events[-1]
+    assert done["ok"] is True
+    assert done.get("wait") is True
+    active = await repo.find_active_by_scope(
+        "user-1", "kg-1", ExtractionSessionMode.EXTRACTION_OPERATIONS
+    )
+    assert active is not None
+    assert active.runtime_context["job_package"]["phase"] == "awaiting_job_package"

--- a/src/api/tests/unit/extraction/application/test_job_package_gate.py
+++ b/src/api/tests/unit/extraction/application/test_job_package_gate.py
@@ -1,0 +1,38 @@
+"""Unit tests for JobPackage gate resolution."""
+
+from __future__ import annotations
+
+from extraction.application.job_package_gate import (
+    IngestionReadinessSnapshot,
+    resolve_job_package_gate,
+)
+from extraction.domain.value_objects import (
+    GraphManagementUiMode,
+    SessionJobPackagePhase,
+)
+
+
+def test_schema_design_does_not_require_job_package() -> None:
+    decision = resolve_job_package_gate(
+        ui_mode=GraphManagementUiMode.INITIAL_SCHEMA_DESIGN,
+        readiness=IngestionReadinessSnapshot(0, 0),
+    )
+    assert decision.phase == SessionJobPackagePhase.NOT_REQUIRED
+
+
+def test_extraction_jobs_waits_without_prepared_sources() -> None:
+    decision = resolve_job_package_gate(
+        ui_mode=GraphManagementUiMode.EXTRACTION_JOBS,
+        readiness=IngestionReadinessSnapshot(data_source_count=2, prepared_source_count=1),
+    )
+    assert decision.phase == SessionJobPackagePhase.AWAITING_PREPARE
+    assert decision.wait_message is not None
+    assert "JobPackage" in decision.wait_message
+
+
+def test_extraction_jobs_ready_when_all_prepared() -> None:
+    decision = resolve_job_package_gate(
+        ui_mode=GraphManagementUiMode.EXTRACTION_JOBS,
+        readiness=IngestionReadinessSnapshot(data_source_count=2, prepared_source_count=2),
+    )
+    assert decision.phase == SessionJobPackagePhase.READY


### PR DESCRIPTION
## Summary
- Add `ExtractionChatTurnService` with sticky runtime lease, JobPackage readiness gate, and UI-mode skill overlays
- Expose `POST /extraction/knowledge-graphs/{kgId}/sessions/{mode}/chat` as NDJSON (`thinking`, `wait`, `done`)
- Ship tracer-bullet `DeterministicExtractionChatAgent` until Claude SDK sticky containers land (#742)

## Issues
Closes #739
Closes #740

## Test plan
- [x] `cd src/api && uv run pytest tests/unit/extraction/ -v`
- [ ] Manual: POST chat turn with prepared/unprepared data sources in Extraction Jobs mode

Made with [Cursor](https://cursor.com)