### PR TITLE
feat(ui): wire Graph Management Assistant to streaming chat API

### DIFF
--- a/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
+++ b/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
@@ -96,7 +96,11 @@ import {
   type MutationLogEntryPreviewPage,
   type MutationLogRunRecord,
 } from '@/utils/kgMutationLogs'
+import { streamExtractionChatTurn } from '@/utils/kgExtractionChat'
 import { useGraphApi } from '@/composables/api/useGraphApi'
+
+const runtimeConfig = useRuntimeConfig()
+const { accessToken } = useAuth()
 
 interface WorkspaceReadinessStatus {
   has_minimum_entity_types: boolean
@@ -180,7 +184,7 @@ interface ExtractionSessionHistoryItem {
 const route = useRoute()
 const { hasTenant, tenantVersion } = useTenant()
 const { extractErrorMessage } = useErrorHandler()
-const { apiFetch } = useApiClient()
+const { apiFetch, currentTenantId } = useApiClient()
 const graphApi = useGraphApi()
 const kgId = computed(() => String(route.params.kgId ?? ''))
 const kgIdentity = ref<KnowledgeGraphIdentity | null>(null)
@@ -441,12 +445,7 @@ const nextSteps = computed(() => {
   return steps
 })
 
-const sessionActivityLines = computed(() => {
-  const context = extractionSession.value?.runtime_context ?? {}
-  const candidate = context.activity_lines ?? context.ndjson_activity_lines ?? context.thinking_lines
-  if (!Array.isArray(candidate)) return []
-  return candidate.filter((line): line is string => typeof line === 'string' && line.trim().length > 0)
-})
+const sessionActivityLines = ref<string[]>([])
 
 async function loadKgIdentity() {
   if (!hasTenant.value || !kgId.value) return
@@ -777,6 +776,7 @@ async function loadExtractionSession() {
     extractionSession.value = await apiFetch<ExtractionSessionResponse>(
       `/extraction/knowledge-graphs/${kgId.value}/sessions/${sharedSessionMode.value}/active`,
     )
+    syncActivityLinesFromSession()
     sessionForbidden.value = false
     sessionForbiddenReason.value = null
   } catch (err) {
@@ -871,7 +871,19 @@ function onMutationRunKeydown(event: KeyboardEvent, runId: string) {
   handleActivatableKeydown(event, () => selectMutationLogRun(runId))
 }
 
-function sendChatMessage(message: string) {
+function syncActivityLinesFromSession() {
+  const context = extractionSession.value?.runtime_context ?? {}
+  const candidate = context.activity_lines ?? context.ndjson_activity_lines ?? context.thinking_lines
+  if (Array.isArray(candidate)) {
+    sessionActivityLines.value = candidate.filter(
+      (line): line is string => typeof line === 'string' && line.trim().length > 0,
+    )
+  } else {
+    sessionActivityLines.value = []
+  }
+}
+
+async function sendChatMessage(message: string) {
   if (sessionForbidden.value || !shouldApplyMutationResult(sessionForbidden.value)) {
     toast.error('Chat unavailable', {
       description: sessionForbiddenReason.value
@@ -880,21 +892,55 @@ function sendChatMessage(message: string) {
     return
   }
 
+  const trimmed = message.trim()
+  if (!trimmed || !kgId.value) return
+
   sendingChat.value = true
-  try {
-    const nextHistory = appendLocalChatMessage(extractionSession.value, message)
-    extractionSession.value = {
-      ...(extractionSession.value ?? {
-        id: 'local-session',
-        runtime_context: {},
-        updated_at: new Date().toISOString(),
-      }),
-      message_history: nextHistory,
+  sessionActivityLines.value = ['Contacting Graph Management Assistant…']
+  draftMessage.value = ''
+
+  const optimisticHistory = appendLocalChatMessage(extractionSession.value, trimmed)
+  extractionSession.value = {
+    ...(extractionSession.value ?? {
+      id: 'pending-session',
+      runtime_context: {},
       updated_at: new Date().toISOString(),
+    }),
+    message_history: optimisticHistory,
+    updated_at: new Date().toISOString(),
+  }
+
+  try {
+    for await (const event of streamExtractionChatTurn({
+      apiBaseUrl: String(runtimeConfig.public.apiBaseUrl ?? ''),
+      accessToken: accessToken.value,
+      tenantId: currentTenantId.value,
+      kgId: kgId.value,
+      sessionMode: sharedSessionMode.value,
+      uiMode: graphManagementMode.value,
+      message: trimmed,
+    })) {
+      if (event.type === 'thinking' && Array.isArray(event.recent)) {
+        sessionActivityLines.value = event.recent.filter(Boolean)
+      }
+      if (event.type === 'wait') {
+        sessionActivityLines.value = event.message
+          ? [event.message]
+          : ['Waiting for JobPackage ingestion context…']
+      }
+      if (event.type === 'done' && event.ok !== true) {
+        throw new Error(event.error?.message ?? 'Graph Management Assistant returned an error.')
+      }
     }
-    draftMessage.value = ''
+    await loadExtractionSession()
+  } catch (err) {
+    toast.error('Failed to send message', {
+      description: extractErrorMessage(err),
+    })
+    await loadExtractionSession()
   } finally {
     sendingChat.value = false
+    syncActivityLinesFromSession()
   }
 }
 

--- a/src/dev-ui/app/tests/kg-extraction-chat.test.ts
+++ b/src/dev-ui/app/tests/kg-extraction-chat.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { streamExtractionChatTurn } from '../utils/kgExtractionChat'
+
+describe('kgExtractionChat', () => {
+  it('targets the extraction chat NDJSON endpoint with UI mode in body', async () => {
+    const originalFetch = globalThis.fetch
+    const calls: Array<{ url: string; init?: RequestInit }> = []
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(input), init })
+      const body = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"type":"done","ok":true,"reply":"hi"}\n'))
+          controller.close()
+        },
+      })
+      return new Response(body, { status: 200, headers: { 'Content-Type': 'application/x-ndjson' } })
+    }) as typeof fetch
+
+    try {
+      const events = []
+      for await (const event of streamExtractionChatTurn({
+        apiBaseUrl: 'http://api.test',
+        accessToken: 'token',
+        tenantId: 'tenant-1',
+        kgId: 'kg-1',
+        sessionMode: 'schema_bootstrap',
+        uiMode: 'initial-schema-design',
+        message: 'Hello',
+      })) {
+        events.push(event)
+      }
+
+      expect(events).toEqual([{ type: 'done', ok: true, reply: 'hi' }])
+      expect(calls[0]?.url).toContain('/extraction/knowledge-graphs/kg-1/sessions/schema_bootstrap/chat')
+      expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({
+        message: 'Hello',
+        graph_management_ui_mode: 'initial-schema-design',
+      })
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})

--- a/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
+++ b/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
@@ -552,6 +552,7 @@ describe('KG-MANAGE-017 - chat input keyboard contract', () => {
     expect(sharedConversationPanelVue).toContain('@keydown.enter="handleComposerEnter"')
     expect(sharedConversationPanelVue).toContain('Shift+Enter for a new line')
     expect(sharedConversationPanelVue).toContain("emit('sendMessage'")
+    expect(manageWorkspaceVue).toContain('streamExtractionChatTurn')
     expect(manageWorkspaceVue).toContain('@send-message="sendChatMessage"')
   })
 })

--- a/src/dev-ui/app/utils/kgExtractionChat.ts
+++ b/src/dev-ui/app/utils/kgExtractionChat.ts
@@ -1,0 +1,82 @@
+/** Stream graph-management chat turns over NDJSON. */
+
+import type { GraphManagementMode } from '@/utils/kgGraphManagement'
+
+export interface ExtractionChatStreamEvent {
+  type: 'thinking' | 'wait' | 'done'
+  recent?: string[]
+  phase?: string
+  message?: string
+  ok?: boolean
+  reply?: string | null
+  wait?: boolean
+  error?: { code: string; message: string }
+}
+
+export interface StreamExtractionChatOptions {
+  apiBaseUrl: string
+  accessToken: string | null
+  tenantId: string | null
+  kgId: string
+  sessionMode: 'schema_bootstrap' | 'extraction_operations'
+  uiMode: GraphManagementMode
+  message: string
+}
+
+export async function* streamExtractionChatTurn(
+  options: StreamExtractionChatOptions,
+): AsyncGenerator<ExtractionChatStreamEvent> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/x-ndjson',
+  }
+  if (options.accessToken) {
+    headers.Authorization = `Bearer ${options.accessToken}`
+  }
+  if (options.tenantId) {
+    headers['X-Tenant-ID'] = options.tenantId
+  }
+
+  const response = await fetch(
+    `${options.apiBaseUrl}/extraction/knowledge-graphs/${encodeURIComponent(options.kgId)}/sessions/${options.sessionMode}/chat`,
+    {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        message: options.message,
+        graph_management_ui_mode: options.uiMode,
+      }),
+    },
+  )
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '')
+    throw new Error(body || `${response.status} ${response.statusText}`)
+  }
+
+  const reader = response.body?.getReader()
+  if (!reader) {
+    throw new Error('No response body from Graph Management Assistant')
+  }
+
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+    const parts = buffer.split('\n')
+    buffer = parts.pop() ?? ''
+    for (const line of parts) {
+      const trimmed = line.trim()
+      if (!trimmed) continue
+      yield JSON.parse(trimmed) as ExtractionChatStreamEvent
+    }
+  }
+
+  const tail = buffer.trim()
+  if (tail) {
+    yield JSON.parse(tail) as ExtractionChatStreamEvent
+  }
+}


### PR DESCRIPTION
## Summary
- Add NDJSON stream client (`streamExtractionChatTurn`) for graph-management chat turns
- Wire `manage.vue` send handler to the streaming API with thinking/wait activity transparency
- Add unit tests for stream client and workspace chat integration

## Issues
Closes #741

## Test plan
- [x] `cd src/dev-ui && npm test -- app/tests/kg-extraction-chat.test.ts app/tests/knowledge-graph-manage-workspace.test.ts`
- [ ] Manual: send chat message in Schema Design mode and verify assistant reply + activity lines
- [ ] Manual: Extraction Jobs mode with unprepared data sources shows wait messaging

Made with [Cursor](https://cursor.com)