### PR TITLE
feat(ui): add Refresh data bulk action to KG data-sources overview

### DIFF
--- a/src/dev-ui/app/pages/knowledge-graphs/[kgId]/data-sources/index.vue
+++ b/src/dev-ui/app/pages/knowledge-graphs/[kgId]/data-sources/index.vue
@@ -295,8 +295,8 @@ async function loadKnowledgeGraph() {
   }
 }
 
-async function loadDataSources(options: { silent?: boolean } = {}) {
-  if (!hasTenant.value) return
+async function loadDataSources(options: { silent?: boolean } = {}): Promise<boolean> {
+  if (!hasTenant.value) return true
   const silent = options.silent ?? dataSources.value.length > 0
   if (silent) {
     refreshing.value = true
@@ -324,16 +324,25 @@ async function loadDataSources(options: { silent?: boolean } = {}) {
       }
     }
     dataSources.value = sources
+    return true
   } catch {
     if (!silent) {
       dataSources.value = []
     }
+    return false
   } finally {
     if (silent) {
       refreshing.value = false
     } else {
       loading.value = false
     }
+  }
+}
+
+async function refreshDataSources() {
+  const ok = await loadDataSources({ silent: true })
+  if (!ok) {
+    toast.error('Failed to refresh data sources')
   }
 }
 
@@ -652,6 +661,16 @@ watch(tenantVersion, async () => {
                 </CardTitle>
               </div>
               <div class="flex flex-wrap gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  :disabled="refreshing || checkingAllCommits || preparingAll"
+                  @click="refreshDataSources"
+                >
+                  <Loader2 v-if="refreshing" class="mr-2 size-4 animate-spin" />
+                  <RefreshCw v-else class="mr-2 size-4" />
+                  Refresh data
+                </Button>
                 <Button
                   variant="outline"
                   size="sm"

--- a/src/dev-ui/app/tests/kg-data-sources-phase1.test.ts
+++ b/src/dev-ui/app/tests/kg-data-sources-phase1.test.ts
@@ -40,7 +40,9 @@ describe('KG data sources phase1 layout', () => {
     expect(phase1Vue).toContain('step=graph-management')
   })
 
-  it('renders bulk commit check and prepare actions', () => {
+  it('renders bulk refresh, commit check, and prepare actions', () => {
+    expect(phase1Vue).toContain('Refresh data')
+    expect(phase1Vue).toContain('refreshDataSources')
     expect(phase1Vue).toContain('Check for new commits')
     expect(phase1Vue).toContain('Prepare data sources')
     expect(phase1Vue).toContain('prepareAllDataSources')
@@ -62,6 +64,10 @@ describe('KG data sources phase1 layout', () => {
     expect(phase1Vue).toContain('loadDataSources({ silent: true })')
     expect(phase1Vue).toContain('refreshing')
     expect(phase1Vue).toContain('Updating…')
+  })
+
+  it('shows error toast when manual refresh fails', () => {
+    expect(phase1Vue).toContain("toast.error('Failed to refresh data sources')")
   })
 
   it('shows unpulled commit columns', () => {


### PR DESCRIPTION
## Summary

- Add a **Refresh data** bulk action button on the KG data-sources overview page, placed first in the existing flex-wrap toolbar alongside **Check for new commits** and **Prepare data sources**.
- Wire the button to `refreshDataSources()`, which calls `loadDataSources({ silent: true })` for API-only reload (no commit-refs refresh, no sync trigger).
- Reuse the existing `refreshing` ref for loading/disabled state and spinner; show an error toast when reload fails.
- Extend `loadDataSources` to return a success boolean so the manual refresh handler can surface failures without affecting silent polling behavior.

## Issue

Closes #747

## Decisions (via ask_user)

- Button order: **Refresh data** first, then commit check, then prepare (worker choice per issue — layout matches existing outline/primary toolbar patterns).
- No user questions were required; issue acceptance criteria were sufficient.

## Test plan

- [x] `vitest run app/tests/kg-data-sources-phase1.test.ts` — 13 tests passed
- [ ] Manual: open `/knowledge-graphs/[kgId]/data-sources`, click **Refresh data** — table reloads, title shows "Updating…" briefly, no commit-refs or sync API calls
- [ ] Manual: simulate API failure — error toast appears
- [ ] Manual: narrow viewport — three buttons wrap cleanly in toolbar

## Risks / follow-ups

- During active polling, the Refresh data button also shows the shared `refreshing` spinner (intentional per issue; same state as silent reloads).

Made with [Cursor](https://cursor.com)