### PR TITLE
feat(extraction): pace multi-deliverable GMA requests one phase per turn

### DIFF
--- a/specs/extraction/chat-turns.spec.md
+++ b/specs/extraction/chat-turns.spec.md
@@ -94,3 +94,12 @@ The system SHALL expose schema, mutation, and workspace tooling appropriate for 
 - WHEN a follow-up chat message is processed
 - THEN the system prompt omits the full skill prose block
 - AND still includes live workspace readiness and a short tools summary
+
+### Requirement: Multi-Deliverable Turn Pacing
+The system SHALL instruct the Graph Management Assistant to pace multi-item bootstrap requests across turns.
+
+#### Scenario: One phase per turn by default
+- GIVEN the user sends one message with multiple bootstrap deliverables
+- WHEN the Graph Management Assistant processes the turn
+- THEN schema bootstrap guardrails require completing at most one bootstrap phase
+- AND the assistant asks whether to continue automatically or one phase at a time

--- a/src/api/extraction/application/skill_resolution_service.py
+++ b/src/api/extraction/application/skill_resolution_service.py
@@ -39,6 +39,19 @@ _GLOBAL_PROMPT_SETTINGS: dict[ExtractionSessionMode, dict[str, object]] = {
             "Keep recommendations scoped to the active knowledge graph.",
             "Use kartograph_* schema tools for ontology and JSONL mutations; never probe /management or /graph HTTP routes manually.",
             "Format user-facing replies in GitHub-flavored Markdown (headings, lists, fenced code blocks, tables) for readability in the chat UI.",
+            (
+                "When the user gives multiple deliverables in one message (three or more bullets, "
+                "or any mix of ontology edits + bulk prepopulation + relationships), do not execute "
+                "the full list in one turn. Complete one phase only, summarize what finished, then "
+                "ask whether to continue through the rest automatically or one phase at a time. "
+                "Default to one phase per turn unless the user explicitly requests doing everything."
+            ),
+            (
+                "Bootstrap phases (in order): (1) ontology/types/properties, (2) entity instances "
+                "in dependency order, (3) relationship instances, (4) readiness verification via "
+                "kartograph_get_workspace_readiness. Stop after each phase when multiple deliverables "
+                "were requested."
+            ),
         ),
     },
     ExtractionSessionMode.EXTRACTION_OPERATIONS: {

--- a/src/api/tests/unit/extraction/application/test_skill_resolution_service.py
+++ b/src/api/tests/unit/extraction/application/test_skill_resolution_service.py
@@ -45,6 +45,9 @@ class TestExtractionSkillResolutionService:
         assert "goal" in resolved.system_prompt.lower()
         assert len(resolved.prompt_hierarchy) > 0
         assert len(resolved.guardrails) > 0
+        guardrails_text = " ".join(resolved.guardrails)
+        assert "one phase per turn" in guardrails_text
+        assert "readiness verification" in guardrails_text
 
     async def test_extraction_mode_uses_extraction_defaults(self):
         service = ExtractionSkillResolutionService(


### PR DESCRIPTION
## Summary
- Add schema-bootstrap guardrails for multi-item user messages
- Require one bootstrap phase per turn by default, then ask the user how to proceed
- Document phased order: ontology → entities → relationships → readiness

Closes #751

## Test plan
- [x] `uv run pytest tests/unit/extraction/application/test_skill_resolution_service.py`


Made with [Cursor](https://cursor.com)