### PR TITLE
feat(extraction): codify six-phase GMA schema bootstrap workflow

### DIFF
--- a/specs/graph/schema-authoring.spec.md
+++ b/specs/graph/schema-authoring.spec.md
@@ -68,6 +68,20 @@ The system SHALL enforce `prepopulated=true` as a transition-blocking readiness 
 - WHEN readiness is evaluated
 - THEN validation fails and transition to extraction mode is blocked
 
+### Requirement: Opinionated Bootstrap Workflow
+The system SHALL guide the Graph Management Assistant through a six-phase schema bootstrap workflow.
+
+#### Scenario: Goals before schema
+- GIVEN a new schema bootstrap conversation
+- WHEN the assistant begins intake
+- THEN it asks for questions the graph must answer before proposing entity types
+
+#### Scenario: Phased bootstrap guidance
+- GIVEN schema bootstrap skills are resolved for a graph-management turn
+- WHEN the agent system prompt is assembled
+- THEN it includes the six phases: goals, discovery, schema Q&A, prepopulation planning, confirmed save, bulk implementation
+- AND instructs not to conflate schema design with prepopulation implementation
+
 ### Requirement: Workload Bulk Instance Authoring
 The system SHALL support bulk instance authoring for the Graph Management Assistant via workspace files and strict CREATE semantics.
 

--- a/src/api/extraction/application/schema_authoring_guide.py
+++ b/src/api/extraction/application/schema_authoring_guide.py
@@ -7,7 +7,19 @@ Use the Kartograph schema tools — never probe undocumented HTTP routes.
 Use Read, Grep, Glob, and Bash against the session workspace mount. Prebuilt generator scripts
 live under `instance_generators/` (see README there).
 
-## Workflow
+## Bootstrap workflow (6 phases)
+
+Complete these in order. Do not mix schema design, prepopulation planning, and bulk
+implementation in the same turn when the user gave multiple deliverables.
+
+1. **Understand goals** — Ask what questions the graph must answer; collect 3–5 stakeholder use cases.
+2. **Workspace discovery** — Glob/Grep under `repository-files/`; report file counts, extensions, and code patterns.
+3. **Draft schema + validation Q&A** — Propose entity types, properties, and relationships; confirm each edge direction (X → rel → Y); cite workspace examples.
+4. **Prepopulation planning** — Decide prepopulated vs manual per type; required properties; generator/extraction strategy.
+5. **Save ontology** — `kartograph_save_schema_ontology` only after the user confirms the full schema.
+6. **Implement prepopulation** — Bash generators → `json_*_to_jsonl.py` → validate-from-file → apply-from-file; entities before edges; verify readiness.
+
+## Tool workflow
 
 1. Call `kartograph_get_schema_authoring_guide` (this document).
 2. Call `kartograph_get_workspace_readiness` to see prepopulated gaps and live instance counts.

--- a/src/api/extraction/application/skill_resolution_service.py
+++ b/src/api/extraction/application/skill_resolution_service.py
@@ -24,8 +24,9 @@ _GLOBAL_PROMPT_SETTINGS: dict[ExtractionSessionMode, dict[str, object]] = {
             "You are the Graph Management Assistant for schema bootstrap. "
             "Use Kartograph schema tools to read and write entity/relationship types "
             "and instances — do not discover or call raw HTTP API routes. "
-            "Start by understanding user goals, then model the ontology and apply changes "
-            "with kartograph_get_schema_ontology and kartograph_save_schema_ontology."
+            "Follow the six-phase bootstrap workflow (goals → discovery → schema Q&A → "
+            "prepopulation planning → confirmed ontology save → bulk implementation). "
+            "Do not conflate schema design, prepopulation planning, and implementation."
         ),
         "prompt_hierarchy": (
             "platform_security_constraints",
@@ -64,10 +65,24 @@ _GLOBAL_PROMPT_SETTINGS: dict[ExtractionSessionMode, dict[str, object]] = {
 _GLOBAL_SKILL_TEMPLATES: dict[ExtractionSessionMode, dict[str, str]] = {
     ExtractionSessionMode.SCHEMA_BOOTSTRAP: {
         "capabilities_intake": (
-            "Ask for goals once, then co-design or propose a first-pass schema."
+            "Phase 1 — Understand goals: ask what questions the graph must answer; collect "
+            "3–5 concrete stakeholder use cases before proposing types."
+        ),
+        "bootstrap_workflow": (
+            "Opinionated schema bootstrap phases (complete in order; one phase per turn when "
+            "the user gave multiple deliverables): "
+            "(1) Understand goals — 3–5 questions the graph must answer. "
+            "(2) Workspace discovery — Glob/Grep on repository-files/, cite file counts and patterns. "
+            "(3) Draft schema + Q&A — propose types/properties/relationships; validate each edge as "
+            "X → rel → Y; show workspace examples. "
+            "(4) Prepopulation planning — which types/relationships are prepopulated vs manual; "
+            "required properties and generator strategy. "
+            "(5) Save ontology — kartograph_save_schema_ontology only after user confirms the full schema. "
+            "(6) Implement prepopulation — generators → json_*_to_jsonl → validate-from-file → "
+            "apply-from-file; entities first, then edges; verify with kartograph_get_workspace_readiness."
         ),
         "schema_workflow": (
-            "Call kartograph_get_schema_authoring_guide when you need shapes or mutation rules. "
+            "Call kartograph_get_schema_authoring_guide when you need shapes, phases, or mutation rules. "
             "Read/save ontology via kartograph_get_schema_ontology and kartograph_save_schema_ontology."
         ),
         "prepopulation": (

--- a/src/api/tests/unit/extraction/application/test_schema_authoring_guide.py
+++ b/src/api/tests/unit/extraction/application/test_schema_authoring_guide.py
@@ -1,0 +1,13 @@
+"""Unit tests for schema authoring guide content."""
+
+from __future__ import annotations
+
+from extraction.application.schema_authoring_guide import SCHEMA_AUTHORING_GUIDE
+
+
+def test_authoring_guide_documents_six_phase_bootstrap_workflow() -> None:
+    assert "## Bootstrap workflow (6 phases)" in SCHEMA_AUTHORING_GUIDE
+    assert "Understand goals" in SCHEMA_AUTHORING_GUIDE
+    assert "Workspace discovery" in SCHEMA_AUTHORING_GUIDE
+    assert "Save ontology" in SCHEMA_AUTHORING_GUIDE
+    assert "Implement prepopulation" in SCHEMA_AUTHORING_GUIDE

--- a/src/api/tests/unit/extraction/application/test_skill_resolution_service.py
+++ b/src/api/tests/unit/extraction/application/test_skill_resolution_service.py
@@ -36,9 +36,13 @@ class TestExtractionSkillResolutionService:
 
         assert set(resolved.skills.keys()) >= {
             "capabilities_intake",
+            "bootstrap_workflow",
             "schema_workflow",
             "prepopulation",
         }
+        assert "six-phase" in resolved.skills["bootstrap_workflow"].lower() or "6" in resolved.skills["bootstrap_workflow"]
+        assert "Workspace discovery" in resolved.skills["bootstrap_workflow"]
+        assert "3–5" in resolved.skills["capabilities_intake"]
         assert "instance_generators" in resolved.skills["prepopulation"]
         assert "kartograph_get_schema_authoring_guide" in resolved.skills["schema_workflow"]
         assert "capabilities_intake" in resolved.skills


### PR DESCRIPTION
## Summary
- Add `bootstrap_workflow` skill with six explicit phases (goals → discovery → schema Q&A → prep planning → confirmed save → bulk impl)
- Update schema bootstrap system prompt and `capabilities_intake` for use-cases-first intake
- Document phases in `schema_authoring_guide.py` (separate from tool workflow)
- Spec scenarios + unit tests

Closes #752

## Test plan
- [x] `uv run pytest tests/unit/extraction/application/test_skill_resolution_service.py`
- [x] `uv run pytest tests/unit/extraction/application/test_schema_authoring_guide.py`


Made with [Cursor](https://cursor.com)