### PR TITLE
feat(graph): bidirectional relationship pairs with twin edge instances

### DIFF
--- a/specs/graph/bidirectional-relationships.spec.md
+++ b/specs/graph/bidirectional-relationships.spec.md
@@ -1,0 +1,158 @@
+# Bidirectional Relationships
+
+## Purpose
+Relationship types in Kartograph are directed edges. Many bootstrap and query use cases need traversal from either endpoint without debating arrow direction at authoring time. This spec defines **paired relationship types** (primary + inverse) and **twin edge instances** so that every bidirectional relationship is materialized as two explicit graph edges with distinct labels, validated for parity, and visible in schema design artifacts.
+
+This complements schema authoring: the Graph Management Assistant authors the primary direction; the platform materializes the inverse type and twin instances by default.
+
+## Design principles
+
+- **Explicit over implicit:** Twin edges are separate mutation log lines and separate AGE edges — auditable and idempotent.
+- **Opt-out, not opt-in:** New relationship types default to bidirectional pairing. Causal or asymmetric relationships (e.g. `depends_on`, `created_by`) set `bidirectional: false`.
+- **Distinct inverse labels:** Primary and inverse use different edge labels (e.g. `contains` / `contained_in`), not the same label reversed. Semantics and UI already assume this (`reverse_relationship_type` in design artifacts).
+- **No hyperedge shortcut:** Pairing is always between two node types with one primary direction declared in ontology.
+
+## Requirements
+
+### Requirement: Bidirectional pairing metadata on relationship types
+The system SHALL store bidirectional pairing metadata on canonical relationship type definitions.
+
+#### Scenario: Default bidirectional on new relationship type
+- GIVEN a new relationship type `Repository → contains → Test` is added to the ontology
+- AND `bidirectional` is omitted
+- WHEN the ontology is saved
+- THEN the relationship type is stored with `bidirectional=true`
+- AND an inverse relationship type is created or linked: `Test → contained_in → Repository` (inverse label derived or explicit)
+- AND design artifacts expose `reverse_relationship_type` and `reverse_relationship_description` for the primary row
+
+#### Scenario: Opt out of bidirectional pairing
+- GIVEN a relationship type `Service → depends_on → Service` with `bidirectional=false`
+- WHEN the ontology is saved
+- THEN no inverse relationship type is auto-generated
+- AND instance twin validation does not apply to that label
+
+#### Scenario: Explicit inverse label
+- GIVEN a primary relationship type with `bidirectional=true` and `inverse_label="housed_in"`
+- WHEN the ontology is saved
+- THEN the inverse type uses label `housed_in` with swapped `source_labels` and `target_labels`
+- AND metadata links `inverse_of` on the inverse type back to the primary label
+
+### Requirement: Inverse type materialization on ontology save
+The system SHALL ensure every bidirectional primary relationship type has a corresponding inverse type definition before instances are created.
+
+#### Scenario: Auto-generate missing inverse type
+- GIVEN ontology save includes `repository|contains|test` as a bidirectional primary
+- AND no inverse type exists yet
+- WHEN save completes
+- THEN canonical schema includes `test|contained_in|repository` (or explicit `inverse_label`)
+- AND both types share pairing metadata (`bidirectional_pair_key`)
+
+#### Scenario: Reject invalid inverse pairing
+- GIVEN a relationship type references `inverse_label` that already exists with incompatible endpoints
+- WHEN ontology save is attempted
+- THEN validation fails with a clear error
+
+### Requirement: Twin edge instances on CREATE
+The system SHALL create paired edge instances for bidirectional relationship types when a primary edge instance is created.
+
+#### Scenario: Primary CREATE expands to twin CREATE
+- GIVEN bidirectional relationship `contains` from Repository node R to Test node T
+- WHEN a CREATE edge mutation is applied for `R -[contains]-> T`
+- THEN the mutation batch also CREATEs `T -[contained_in]-> R` in the same atomic apply
+- AND both edges receive distinct deterministic ids
+- AND inverse edge properties copy non-directional fields from the primary; directional fields may be omitted on the inverse
+
+#### Scenario: Bulk JSONL primary-only input
+- GIVEN a JSONL file with only primary-direction edge CREATE lines for bidirectional types
+- WHEN mutations are validated or applied via workload tools
+- THEN the preflight/expansion layer adds inverse CREATE lines before apply
+- AND validate reports the expanded operation count
+
+#### Scenario: Idempotent re-apply
+- GIVEN twin edges for pair (R, T) already exist
+- WHEN the same primary CREATE is submitted again under strict CREATE semantics
+- THEN validation rejects the duplicate primary CREATE
+- AND no orphan inverse edge is created
+
+### Requirement: Twin instance validation
+The system SHALL validate that bidirectional relationship instances exist in pairs.
+
+#### Scenario: Readiness reports missing inverse instance
+- GIVEN a bidirectional primary edge instance exists without its inverse twin
+- WHEN workspace readiness or design artifacts are evaluated
+- THEN a blocking or warning reason identifies the orphan primary edge (source slug, target slug, label)
+- AND transition eligibility may be blocked when strict pairing mode is enabled for bootstrap
+
+#### Scenario: Balanced pairing passes validation
+- GIVEN every primary `contains` edge has a matching `contained_in` edge between the same node ids (reversed)
+- WHEN twin validation runs
+- THEN no pairing defects are reported
+
+### Requirement: Authoring guidance
+The system SHALL instruct the Graph Management Assistant to author primary direction only for bidirectional types.
+
+#### Scenario: GMA authors one direction
+- GIVEN schema bootstrap with bidirectional relationship types
+- WHEN the assistant plans prepopulation
+- THEN it emits generator output for the primary label only
+- AND relies on platform twin expansion for inverse instances
+- AND does not ask the user to confirm arrow direction when `bidirectional=true` unless `bidirectional=false` is set
+
+## Data model (canonical type metadata)
+
+Primary relationship type (`edge`, entity_type=edge):
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `bidirectional` | `true` | Whether twin inverse type + instances are required |
+| `inverse_label` | derived | Label of inverse edge type; default `{primary}_inverse` or linguistic map |
+| `bidirectional_pair_key` | derived | Stable key `source\|primary\|target` linking primary and inverse rows |
+
+Inverse relationship type (auto-generated):
+
+| Field | Meaning |
+|-------|---------|
+| `inverse_of` | Primary label this type mirrors |
+| `bidirectional` | `true` |
+| `auto_generated` | `true` — hide from GMA authoring prompts or show as read-only twin |
+
+## Inverse label derivation (default)
+
+When `inverse_label` is not provided and `bidirectional=true`:
+
+1. Use a small built-in map for common verbs (`contains` → `contained_in`, `defines` → `defined_by`, `implements` → `implemented_by`).
+2. Otherwise default to `{primary_label}_inverse` (snake_case).
+
+Authors MAY override `inverse_label` in ontology JSON.
+
+## Write path summary
+
+```
+Ontology save (Management → canonical schema)
+  → pairing expander adds/updates inverse type definitions
+
+Edge CREATE (Graph / Extraction workload)
+  → twin expander adds inverse CREATE to batch
+  → mutation applier executes both in one transaction
+
+Readiness (Management / Extraction)
+  → twin validator checks primary/inverse instance parity
+```
+
+## Read path summary
+
+- **Design artifacts:** populate `reverse_relationship_type` from pairing metadata (UI already renders it).
+- **Relationship listing:** workload list tools may group primary + inverse counts or report twin balance.
+- **Queries:** agents traverse using the label appropriate to start node type; both directions always exist when bidirectional.
+
+## Out of scope (initial tracer)
+
+- Automatic linguistic inference beyond the small verb map.
+- Symmetric edges with the **same** label in both directions (conflicts with distinct-semantics principle).
+- Retroactive twin backfill job for graphs authored before this feature (separate migration spec).
+- Graph query MCP auto-expanding undirected traversals (clients use explicit labels).
+
+## Migration notes
+
+- Existing ontologies without pairing metadata: treat as `bidirectional=false` until re-saved or migrated.
+- Existing orphan edge instances: report in readiness; optional backfill command in a follow-up.

--- a/specs/graph/schema-authoring.spec.md
+++ b/specs/graph/schema-authoring.spec.md
@@ -93,3 +93,16 @@ The system SHALL support bulk instance authoring for the Graph Management Assist
 - THEN example generator scripts and JSONL converter helpers are present
 - AND the assistant may add custom generator scripts alongside them
 
+### Requirement: Bidirectional Relationship Pairing
+The system SHALL default new relationship types to bidirectional pairing. See [Bidirectional Relationships](bidirectional-relationships.spec.md).
+
+#### Scenario: Ontology save creates inverse type
+- GIVEN a primary relationship type with `bidirectional=true`
+- WHEN the ontology is saved
+- THEN the inverse relationship type is stored with swapped endpoints
+
+#### Scenario: Primary edge CREATE expands to twin
+- GIVEN a bidirectional relationship type exists in the ontology
+- WHEN a primary-direction edge CREATE mutation is applied via workload tools
+- THEN an inverse edge CREATE is applied in the same batch
+

--- a/specs/index.spec.md
+++ b/specs/index.spec.md
@@ -30,6 +30,7 @@ The persistence and query engine for property graph data.
 | [Queries](graph/queries.spec.md) | Reading nodes, edges, and subgraphs |
 | [Schema](graph/schema.spec.md) | Type definitions and schema management |
 | [Schema Authoring](graph/schema-authoring.spec.md) | Bootstrap and ongoing schema authoring lifecycle |
+| [Bidirectional Relationships](graph/bidirectional-relationships.spec.md) | Paired inverse relationship types and twin edge instances |
 | [Bulk Loading](graph/bulk-loading.spec.md) | High-throughput graph ingestion |
 
 ### [Management](management/) — Control Plane

--- a/src/api/extraction/application/schema_authoring_guide.py
+++ b/src/api/extraction/application/schema_authoring_guide.py
@@ -57,10 +57,16 @@ Each entry in `edge_types`:
   "properties": [],
   "prepopulated": true,
   "prepopulated_instance_count": 0,
-  "instance_generator": "my_edges.py"
+  "instance_generator": "my_edges.py",
+  "bidirectional": true,
+  "inverse_label": "contained_in"
 }
 ```
 
+- `bidirectional`: default `true` for new relationship types — platform auto-creates inverse type and twin edge instances.
+- `inverse_label`: optional override; otherwise derived (`contains` → `contained_in`, else `{label}_inverse`).
+- Set `bidirectional: false` for asymmetric edges (`depends_on`, `created_by`).
+- Author **primary direction only** in generators; inverse instances are created automatically on apply.
 - `source_labels` / `target_labels`: allowed node type labels for edge endpoints.
 - `instance_generator`: optional script under `instance_generators/` for relationship prepopulation.
 - `prepopulated`: when true, bootstrap transition requires at least one instance of this

--- a/src/api/extraction/application/skill_resolution_service.py
+++ b/src/api/extraction/application/skill_resolution_service.py
@@ -73,7 +73,9 @@ _GLOBAL_SKILL_TEMPLATES: dict[ExtractionSessionMode, dict[str, str]] = {
         "prepopulation": (
             "For prepopulated types: set instance_generator on the type when helpful, run script "
             "under instance_generators/ with Bash, convert with json_*_to_jsonl helpers, validate "
-            "then apply-from-file. CREATE cannot duplicate existing instances — use UPDATE to edit."
+            "then apply-from-file. CREATE cannot duplicate existing instances — use UPDATE to edit. "
+            "Bidirectional relationships default on: author primary-direction edges only; platform "
+            "creates inverse type + twin instances. Set bidirectional=false for asymmetric edges."
         ),
     },
     ExtractionSessionMode.EXTRACTION_OPERATIONS: {

--- a/src/api/extraction/presentation/workload_routes.py
+++ b/src/api/extraction/presentation/workload_routes.py
@@ -18,7 +18,9 @@ from infrastructure.extraction_workload.dependencies import (
     get_workload_schema_service,
 )
 from management.domain.ontology_prepopulation import PrepopulationValidationError
+from management.domain.relationship_pairing import ontology_config_from_authoring_payload
 from management.domain.value_objects import OntologyConfig
+from management.ports.exceptions import CanonicalSchemaMutationError
 
 router = APIRouter(prefix="/workloads", tags=["extraction-workloads"])
 
@@ -184,13 +186,13 @@ async def workload_save_schema_ontology(
     schema_service: Annotated[IWorkloadSchemaService, Depends(get_workload_schema_service)] = ...,
 ) -> WorkloadOntologyResponse:
     _require_chat_scope(auth)
-    config = OntologyConfig.from_dict(request.model_dump())
+    config = ontology_config_from_authoring_payload(request.model_dump())
     try:
         saved = await schema_service.replace_ontology(
             knowledge_graph_id=auth.knowledge_graph_id,
             config=config,
         )
-    except PrepopulationValidationError as e:
+    except (PrepopulationValidationError, CanonicalSchemaMutationError) as e:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=str(e),

--- a/src/api/infrastructure/canonical_schema/graph_canonical_schema_repository.py
+++ b/src/api/infrastructure/canonical_schema/graph_canonical_schema_repository.py
@@ -24,6 +24,10 @@ from infrastructure.canonical_schema.ontology_projection import (
     stored_definitions_to_ontology_config,
 )
 from management.domain.ontology_prepopulation import validate_ontology_prepopulation
+from management.domain.relationship_pairing import (
+    RelationshipPairingError,
+    expand_ontology_bidirectional_pairs,
+)
 from management.domain.value_objects import OntologyConfig
 from management.ports.canonical_schema import ICanonicalSchemaRepository
 from management.ports.exceptions import CanonicalSchemaMutationError
@@ -49,6 +53,10 @@ class GraphCanonicalSchemaRepository(ICanonicalSchemaRepository):
         return stored_definitions_to_ontology_config(rows)
 
     async def replace_ontology(self, kg_id: str, config: OntologyConfig) -> None:
+        try:
+            config = expand_ontology_bidirectional_pairs(config)
+        except RelationshipPairingError as exc:
+            raise CanonicalSchemaMutationError(str(exc)) from exc
         validate_ontology_prepopulation(config)
         await self._store.delete_all_for_kg(kg_id)
         await self._apply_operations(

--- a/src/api/infrastructure/canonical_schema/ontology_mutation_builder.py
+++ b/src/api/infrastructure/canonical_schema/ontology_mutation_builder.py
@@ -61,4 +61,14 @@ def edge_type_metadata(edge_type) -> dict:
     }
     if edge_type.instance_generator:
         metadata["instance_generator"] = edge_type.instance_generator
+    if edge_type.bidirectional:
+        metadata["bidirectional"] = True
+    if edge_type.inverse_label:
+        metadata["inverse_label"] = edge_type.inverse_label
+    if edge_type.inverse_of:
+        metadata["inverse_of"] = edge_type.inverse_of
+    if edge_type.auto_generated:
+        metadata["auto_generated"] = True
+    if edge_type.bidirectional_pair_key:
+        metadata["bidirectional_pair_key"] = edge_type.bidirectional_pair_key
     return metadata

--- a/src/api/infrastructure/canonical_schema/ontology_projection.py
+++ b/src/api/infrastructure/canonical_schema/ontology_projection.py
@@ -58,6 +58,13 @@ def stored_definitions_to_ontology_config(
                     instance_generator=_optional_metadata_str(
                         stored.metadata.get("instance_generator")
                     ),
+                    bidirectional=bool(stored.metadata.get("bidirectional", False)),
+                    inverse_label=_optional_metadata_str(stored.metadata.get("inverse_label")),
+                    inverse_of=_optional_metadata_str(stored.metadata.get("inverse_of")),
+                    auto_generated=bool(stored.metadata.get("auto_generated", False)),
+                    bidirectional_pair_key=_optional_metadata_str(
+                        stored.metadata.get("bidirectional_pair_key")
+                    ),
                 )
             )
 

--- a/src/api/infrastructure/extraction_workload/mutation_preflight.py
+++ b/src/api/infrastructure/extraction_workload/mutation_preflight.py
@@ -6,6 +6,10 @@ from graph.domain.value_objects import EntityType, MutationOperation, MutationOp
 from management.ports.exceptions import CanonicalSchemaMutationError
 
 from extraction.ports.workload_graph import IWorkloadGraphReader
+from infrastructure.extraction_workload.twin_edge_expansion import (
+    expand_twin_edge_mutation_operations,
+)
+from management.domain.value_objects import OntologyConfig
 
 
 def parse_mutation_jsonl(jsonl_content: str) -> list[MutationOperation]:
@@ -16,6 +20,27 @@ def parse_mutation_jsonl(jsonl_content: str) -> list[MutationOperation]:
     return GraphWorkloadGraphMutationWriter.parse_jsonl(jsonl_content)
 
 
+async def prepare_mutation_operations(
+    *,
+    jsonl_content: str,
+    tenant_id: str,
+    ontology: OntologyConfig | None,
+) -> tuple[list[MutationOperation] | None, list[str]]:
+    """Parse JSONL and expand bidirectional twin edge CREATE operations."""
+    try:
+        operations = parse_mutation_jsonl(jsonl_content)
+    except CanonicalSchemaMutationError as exc:
+        return None, [str(exc)]
+
+    if ontology is not None:
+        operations = expand_twin_edge_mutation_operations(
+            operations,
+            ontology=ontology,
+            tenant_id=tenant_id,
+        )
+    return operations, []
+
+
 async def validate_mutation_jsonl(
     *,
     jsonl_content: str,
@@ -23,12 +48,17 @@ async def validate_mutation_jsonl(
     knowledge_graph_id: str,
     graph_reader: IWorkloadGraphReader | None,
     existing_type_keys: frozenset[tuple[str, str]],
+    ontology: OntologyConfig | None = None,
 ) -> list[str]:
     """Return validation errors; empty list means the batch may be applied."""
-    try:
-        operations = parse_mutation_jsonl(jsonl_content)
-    except CanonicalSchemaMutationError as exc:
-        return [str(exc)]
+    operations, errors = await prepare_mutation_operations(
+        jsonl_content=jsonl_content,
+        tenant_id=tenant_id,
+        ontology=ontology,
+    )
+    if errors:
+        return errors
+    assert operations is not None
 
     errors: list[str] = []
     seen_create_ids: dict[str, int] = {}

--- a/src/api/infrastructure/extraction_workload/schema_service.py
+++ b/src/api/infrastructure/extraction_workload/schema_service.py
@@ -14,6 +14,7 @@ from infrastructure.extraction_workload.graph_mutation_writer import (
 )
 from infrastructure.extraction_workload.mutation_preflight import (
     parse_mutation_jsonl,
+    prepare_mutation_operations,
     validate_mutation_jsonl,
 )
 from infrastructure.extraction_workload.workspace_readiness import (
@@ -70,18 +71,23 @@ class GraphWorkloadSchemaService:
         knowledge_graph_id: str,
         jsonl: str,
     ) -> dict[str, object]:
+        ontology = await self.get_ontology(knowledge_graph_id=knowledge_graph_id)
         errors = await validate_mutation_jsonl(
             jsonl_content=jsonl,
             tenant_id=tenant_id,
             knowledge_graph_id=knowledge_graph_id,
             graph_reader=self._graph_reader,
             existing_type_keys=await self._existing_type_keys(knowledge_graph_id),
+            ontology=ontology,
         )
         operation_count = 0
-        try:
-            operation_count = len(parse_mutation_jsonl(jsonl))
-        except CanonicalSchemaMutationError:
-            operation_count = 0
+        expanded_ops, prep_errors = await prepare_mutation_operations(
+            jsonl_content=jsonl,
+            tenant_id=tenant_id,
+            ontology=ontology,
+        )
+        if not prep_errors and expanded_ops is not None:
+            operation_count = len(expanded_ops)
         return {
             "valid": not errors,
             "errors": errors,
@@ -95,18 +101,27 @@ class GraphWorkloadSchemaService:
         knowledge_graph_id: str,
         jsonl: str,
     ) -> dict[str, object]:
+        ontology = await self.get_ontology(knowledge_graph_id=knowledge_graph_id)
         preflight_errors = await validate_mutation_jsonl(
             jsonl_content=jsonl,
             tenant_id=tenant_id,
             knowledge_graph_id=knowledge_graph_id,
             graph_reader=self._graph_reader,
             existing_type_keys=await self._existing_type_keys(knowledge_graph_id),
+            ontology=ontology,
         )
         if preflight_errors:
             return {"applied": False, "errors": preflight_errors}
 
+        operations, prep_errors = await prepare_mutation_operations(
+            jsonl_content=jsonl,
+            tenant_id=tenant_id,
+            ontology=ontology,
+        )
+        if prep_errors:
+            return {"applied": False, "errors": prep_errors}
+        assert operations is not None
         try:
-            operations = parse_mutation_jsonl(jsonl)
             define_ops, instance_ops = GraphWorkloadGraphMutationWriter.split_operations(
                 operations
             )

--- a/src/api/infrastructure/extraction_workload/twin_edge_expansion.py
+++ b/src/api/infrastructure/extraction_workload/twin_edge_expansion.py
@@ -1,0 +1,27 @@
+"""Expand workload mutation operations with bidirectional twin edge CREATE lines."""
+
+from __future__ import annotations
+
+from graph.domain.value_objects import MutationOperation
+from management.domain.relationship_pairing import expand_twin_edge_creates
+from management.domain.value_objects import OntologyConfig
+
+
+def expand_twin_edge_mutation_operations(
+    operations: list[MutationOperation],
+    *,
+    ontology: OntologyConfig,
+    tenant_id: str,
+) -> list[MutationOperation]:
+    """Append inverse edge CREATE MutationOperations for bidirectional types."""
+    dict_rows = [
+        operation.model_dump(mode="json", exclude_none=True) for operation in operations
+    ]
+    expanded_rows = expand_twin_edge_creates(
+        dict_rows,
+        ontology=ontology,
+        tenant_id=tenant_id,
+    )
+    if len(expanded_rows) == len(operations):
+        return operations
+    return [MutationOperation.model_validate(row) for row in expanded_rows]

--- a/src/api/infrastructure/extraction_workload/workspace_readiness.py
+++ b/src/api/infrastructure/extraction_workload/workspace_readiness.py
@@ -9,6 +9,11 @@ from management.application.workspace_readiness import (
     prepopulated_gaps_from_live_counts,
 )
 from management.domain.ontology_prepopulation import relationship_readiness_key
+from management.domain.relationship_pairing import (
+    bidirectional_pair_key,
+    resolve_inverse_label_for_primary,
+    twin_validation_errors,
+)
 from management.domain.value_objects import EdgeTypeDefinition, NodeTypeDefinition, OntologyConfig
 
 
@@ -97,6 +102,47 @@ async def build_workload_readiness_snapshot(
         blocking_reasons.append(
             "Live graph missing prepopulated relationship instances: "
             + ", ".join(live_relationship_gaps)
+        )
+
+    if ontology is not None and graph_reader is not None:
+        bidirectional_counts: dict[str, int] = {}
+        for edge_type in ontology.edge_types:
+            if edge_type.auto_generated or edge_type.inverse_of or not edge_type.bidirectional:
+                continue
+            if not edge_type.source_labels or not edge_type.target_labels:
+                continue
+            source_label = edge_type.source_labels[0]
+            target_label = edge_type.target_labels[0]
+            primary_key = bidirectional_pair_key(
+                source_label=source_label,
+                relationship_label=edge_type.label,
+                target_label=target_label,
+            )
+            inverse_label = resolve_inverse_label_for_primary(edge_type)
+            inverse_key = bidirectional_pair_key(
+                source_label=target_label,
+                relationship_label=inverse_label,
+                target_label=source_label,
+            )
+            bidirectional_counts[primary_key] = await graph_reader.count_relationship_instances(
+                tenant_id=tenant_id,
+                knowledge_graph_id=knowledge_graph_id,
+                relationship_type=edge_type.label,
+                source_entity_type=source_label,
+                target_entity_type=target_label,
+            )
+            bidirectional_counts[inverse_key] = await graph_reader.count_relationship_instances(
+                tenant_id=tenant_id,
+                knowledge_graph_id=knowledge_graph_id,
+                relationship_type=inverse_label,
+                source_entity_type=target_label,
+                target_entity_type=source_label,
+            )
+        blocking_reasons.extend(
+            twin_validation_errors(
+                ontology=ontology,
+                relationship_counts=bidirectional_counts,
+            )
         )
 
     transition_eligible = (

--- a/src/api/management/application/design_artifacts.py
+++ b/src/api/management/application/design_artifacts.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Any
 
-from management.domain.value_objects import OntologyConfig
+from management.domain.relationship_pairing import resolve_inverse_label_for_primary
+from management.domain.value_objects import EdgeTypeDefinition, OntologyConfig
 
 _SYSTEM_NODE_PROPERTIES = frozenset(
     {
@@ -26,6 +27,14 @@ def _instance_properties(raw: dict[str, Any]) -> dict[str, Any]:
         for key, value in raw.items()
         if key not in _SYSTEM_NODE_PROPERTIES and not key.startswith("_")
     }
+
+
+def _reverse_relationship_label(edge_type: EdgeTypeDefinition) -> str | None:
+    if edge_type.auto_generated or edge_type.inverse_of:
+        return None
+    if not edge_type.bidirectional:
+        return None
+    return resolve_inverse_label_for_primary(edge_type)
 
 
 def build_design_artifacts(
@@ -156,14 +165,17 @@ def build_design_artifacts(
                         composite_key = key
                         type_instances = instances
                         break
+            reverse_label = _reverse_relationship_label(edge_type)
             relationships.append(
                 {
                     "key": composite_key,
                     "source_entity_type": source_label,
                     "target_entity_type": target_label,
                     "relationship_type": edge_type.label,
-                    "reverse_relationship_type": None,
-                    "reverse_relationship_description": None,
+                    "reverse_relationship_type": reverse_label,
+                    "reverse_relationship_description": (
+                        f"Inverse of `{edge_type.label}`" if reverse_label else None
+                    ),
                     "prepopulated_instances": edge_type.prepopulated,
                     "description": edge_type.description or None,
                     "instance_count": len(type_instances),

--- a/src/api/management/domain/relationship_pairing.py
+++ b/src/api/management/domain/relationship_pairing.py
@@ -1,0 +1,267 @@
+"""Bidirectional relationship pairing for ontology authoring and edge instances."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from management.domain.value_objects import EdgeTypeDefinition, OntologyConfig
+
+_INVERSE_LABEL_MAP: dict[str, str] = {
+    "contains": "contained_in",
+    "defines": "defined_by",
+    "implements": "implemented_by",
+    "covers": "covered_by",
+    "owns": "owned_by",
+    "uses": "used_by",
+}
+
+
+class RelationshipPairingError(ValueError):
+    """Raised when bidirectional pairing metadata is inconsistent."""
+
+
+def derive_inverse_label(primary_label: str) -> str:
+    """Derive a default inverse edge label from the primary label."""
+    normalized = primary_label.strip().lower()
+    return _INVERSE_LABEL_MAP.get(normalized, f"{normalized}_inverse")
+
+
+def bidirectional_pair_key(*, source_label: str, relationship_label: str, target_label: str) -> str:
+    """Stable identifier for a directed relationship type in design artifacts."""
+    return f"{source_label}|{relationship_label}|{target_label}"
+
+
+def resolve_inverse_label_for_primary(edge_type: EdgeTypeDefinition) -> str:
+    """Return the inverse label for a primary bidirectional edge type."""
+    if edge_type.inverse_label:
+        return edge_type.inverse_label.strip().lower()
+    return derive_inverse_label(edge_type.label)
+
+
+def build_inverse_edge_type(primary: EdgeTypeDefinition) -> EdgeTypeDefinition:
+    """Build the auto-generated inverse edge type for a primary relationship."""
+    if not primary.source_labels or not primary.target_labels:
+        raise RelationshipPairingError(
+            f"Relationship type `{primary.label}` requires source_labels and target_labels "
+            "for bidirectional pairing"
+        )
+    inverse_label = resolve_inverse_label_for_primary(primary)
+    source = primary.source_labels[0]
+    target = primary.target_labels[0]
+    description = (
+        f"Inverse of `{primary.label}` ({target} → {source}); auto-generated for bidirectional pairing."
+    )
+    return EdgeTypeDefinition(
+        label=inverse_label,
+        description=description,
+        source_labels=(target,),
+        target_labels=(source,),
+        properties=primary.properties,
+        prepopulated=primary.prepopulated,
+        prepopulated_instance_count=0,
+        instance_generator=primary.instance_generator,
+        bidirectional=True,
+        inverse_of=primary.label,
+        auto_generated=True,
+        bidirectional_pair_key=bidirectional_pair_key(
+            source_label=target,
+            relationship_label=inverse_label,
+            target_label=source,
+        ),
+    )
+
+
+def _is_primary_bidirectional_edge(edge_type: EdgeTypeDefinition) -> bool:
+    return edge_type.bidirectional and not edge_type.auto_generated and not edge_type.inverse_of
+
+
+def expand_ontology_bidirectional_pairs(config: OntologyConfig) -> OntologyConfig:
+    """Ensure every primary bidirectional edge type has a linked inverse type definition."""
+    edge_types = list(config.edge_types)
+    by_label = {edge.label: edge for edge in edge_types}
+
+    for primary in list(edge_types):
+        if not _is_primary_bidirectional_edge(primary):
+            continue
+        if not primary.source_labels or not primary.target_labels:
+            raise RelationshipPairingError(
+                f"Relationship type `{primary.label}` cannot be bidirectional without "
+                "source_labels and target_labels"
+            )
+
+        inverse_label = resolve_inverse_label_for_primary(primary)
+        source = primary.source_labels[0]
+        target = primary.target_labels[0]
+        pair_key = bidirectional_pair_key(
+            source_label=source,
+            relationship_label=primary.label,
+            target_label=target,
+        )
+
+        existing_inverse = by_label.get(inverse_label)
+        if existing_inverse is not None:
+            if existing_inverse.inverse_of and existing_inverse.inverse_of != primary.label:
+                raise RelationshipPairingError(
+                    f"inverse_label `{inverse_label}` already exists and is paired with "
+                    f"`{existing_inverse.inverse_of}`, not `{primary.label}`"
+                )
+            continue
+
+        inverse = build_inverse_edge_type(primary)
+        edge_types.append(inverse)
+        by_label[inverse.label] = inverse
+
+        # Rebuild primary with pairing metadata (frozen dataclass)
+        index = edge_types.index(primary)
+        edge_types[index] = EdgeTypeDefinition(
+            label=primary.label,
+            description=primary.description,
+            source_labels=primary.source_labels,
+            target_labels=primary.target_labels,
+            properties=primary.properties,
+            prepopulated=primary.prepopulated,
+            prepopulated_instance_count=primary.prepopulated_instance_count,
+            instance_generator=primary.instance_generator,
+            bidirectional=True,
+            inverse_label=inverse_label,
+            auto_generated=False,
+            inverse_of=None,
+            bidirectional_pair_key=pair_key,
+        )
+        by_label[primary.label] = edge_types[index]
+
+    return OntologyConfig(
+        node_types=config.node_types,
+        edge_types=tuple(edge_types),
+        approved_at=config.approved_at,
+    )
+
+
+def deterministic_twin_edge_id(
+    *,
+    relationship_label: str,
+    start_id: str,
+    end_id: str,
+    tenant_id: str = "",
+) -> str:
+    """Match json_relationships_to_jsonl deterministic edge id rules."""
+    normalized_label = relationship_label.strip().lower()
+    combined = f"{tenant_id}:{start_id.strip()}:{normalized_label}:{end_id.strip()}"
+    digest = hashlib.sha256(combined.encode()).hexdigest()[:16]
+    return f"{normalized_label}:{digest}"
+
+
+def _primary_edge_by_label(ontology: OntologyConfig) -> dict[str, EdgeTypeDefinition]:
+    return {
+        edge.label: edge
+        for edge in ontology.edge_types
+        if _is_primary_bidirectional_edge(edge)
+    }
+
+
+def normalize_authoring_edge_type_dicts(edge_types: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Default bidirectional=true for newly authored primary relationship types."""
+    normalized: list[dict[str, Any]] = []
+    for row in edge_types:
+        payload = dict(row)
+        if (
+            "bidirectional" not in payload
+            and not payload.get("auto_generated")
+            and not payload.get("inverse_of")
+        ):
+            payload["bidirectional"] = True
+        normalized.append(payload)
+    return normalized
+
+
+def expand_twin_edge_creates(
+    operations: list[dict[str, Any]],
+    *,
+    ontology: OntologyConfig,
+    tenant_id: str,
+) -> list[dict[str, Any]]:
+    """Append inverse edge CREATE operations for bidirectional relationship types."""
+    primary_edges = _primary_edge_by_label(ontology)
+    if not primary_edges:
+        return list(operations)
+
+    expanded: list[dict[str, Any]] = []
+    for operation in operations:
+        expanded.append(operation)
+        if operation.get("op") != "CREATE" or operation.get("type") != "edge":
+            continue
+
+        label = str(operation.get("label") or "").strip().lower()
+        primary = primary_edges.get(label)
+        if primary is None:
+            continue
+
+        start_id = str(operation.get("start_id") or "").strip()
+        end_id = str(operation.get("end_id") or "").strip()
+        if not start_id or not end_id:
+            continue
+
+        inverse_label = resolve_inverse_label_for_primary(primary)
+        properties = dict(operation.get("set_properties") or {})
+        twin = {
+            "op": "CREATE",
+            "type": "edge",
+            "id": deterministic_twin_edge_id(
+                relationship_label=inverse_label,
+                start_id=end_id,
+                end_id=start_id,
+                tenant_id=tenant_id,
+            ),
+            "label": inverse_label,
+            "start_id": end_id,
+            "end_id": start_id,
+            "set_properties": properties,
+        }
+        expanded.append(twin)
+
+    return expanded
+
+
+def ontology_config_from_authoring_payload(data: dict[str, Any]) -> OntologyConfig:
+    """Build OntologyConfig from API/workload payload with authoring defaults."""
+    payload = dict(data)
+    payload["edge_types"] = normalize_authoring_edge_type_dicts(
+        list(payload.get("edge_types") or [])
+    )
+    return OntologyConfig.from_dict(payload)
+
+
+def twin_validation_errors(
+    *,
+    ontology: OntologyConfig,
+    relationship_counts: dict[str, int],
+) -> list[str]:
+    """Report primary/inverse relationship instance count mismatches."""
+    errors: list[str] = []
+    for primary in ontology.edge_types:
+        if not _is_primary_bidirectional_edge(primary):
+            continue
+        if not primary.source_labels or not primary.target_labels:
+            continue
+        source = primary.source_labels[0]
+        target = primary.target_labels[0]
+        primary_key = bidirectional_pair_key(
+            source_label=source,
+            relationship_label=primary.label,
+            target_label=target,
+        )
+        inverse_label = resolve_inverse_label_for_primary(primary)
+        inverse_key = bidirectional_pair_key(
+            source_label=target,
+            relationship_label=inverse_label,
+            target_label=source,
+        )
+        primary_count = relationship_counts.get(primary_key, 0)
+        inverse_count = relationship_counts.get(inverse_key, 0)
+        if primary_count != inverse_count:
+            errors.append(
+                f"Bidirectional pair `{primary.label}` / `{inverse_label}` is unbalanced: "
+                f"primary={primary_count}, inverse={inverse_count}"
+            )
+    return errors

--- a/src/api/management/domain/value_objects.py
+++ b/src/api/management/domain/value_objects.py
@@ -475,6 +475,11 @@ class EdgeTypeDefinition:
     prepopulated: bool = False
     prepopulated_instance_count: int = 0
     instance_generator: str | None = None
+    bidirectional: bool = False
+    inverse_label: str | None = None
+    inverse_of: str | None = None
+    auto_generated: bool = False
+    bidirectional_pair_key: str | None = None
 
     def __post_init__(self) -> None:
         """Validate that label is non-empty."""
@@ -484,6 +489,10 @@ class EdgeTypeDefinition:
             raise ValueError("prepopulated_instance_count must be >= 0")
         if self.instance_generator is not None and not self.instance_generator.strip():
             raise ValueError("instance_generator must not be empty or whitespace-only")
+        if self.inverse_label is not None and not self.inverse_label.strip():
+            raise ValueError("inverse_label must not be empty or whitespace-only")
+        if self.inverse_of is not None and not self.inverse_of.strip():
+            raise ValueError("inverse_of must not be empty or whitespace-only")
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a plain dict suitable for JSON persistence."""
@@ -495,9 +504,17 @@ class EdgeTypeDefinition:
             "properties": list(self.properties),
             "prepopulated": self.prepopulated,
             "prepopulated_instance_count": self.prepopulated_instance_count,
+            "bidirectional": self.bidirectional,
+            "auto_generated": self.auto_generated,
         }
         if self.instance_generator:
             payload["instance_generator"] = self.instance_generator
+        if self.inverse_label:
+            payload["inverse_label"] = self.inverse_label
+        if self.inverse_of:
+            payload["inverse_of"] = self.inverse_of
+        if self.bidirectional_pair_key:
+            payload["bidirectional_pair_key"] = self.bidirectional_pair_key
         return payload
 
     @classmethod
@@ -505,6 +522,12 @@ class EdgeTypeDefinition:
         """Deserialize from a plain dict."""
         raw_generator = data.get("instance_generator")
         instance_generator = str(raw_generator).strip() if raw_generator else None
+        raw_inverse_label = data.get("inverse_label")
+        inverse_label = str(raw_inverse_label).strip() if raw_inverse_label else None
+        raw_inverse_of = data.get("inverse_of")
+        inverse_of = str(raw_inverse_of).strip() if raw_inverse_of else None
+        raw_pair_key = data.get("bidirectional_pair_key")
+        pair_key = str(raw_pair_key).strip() if raw_pair_key else None
         return cls(
             label=data["label"],
             description=data.get("description", ""),
@@ -514,6 +537,11 @@ class EdgeTypeDefinition:
             prepopulated=bool(data.get("prepopulated", False)),
             prepopulated_instance_count=int(data.get("prepopulated_instance_count", 0)),
             instance_generator=instance_generator or None,
+            bidirectional=bool(data.get("bidirectional", False)),
+            inverse_label=inverse_label or None,
+            inverse_of=inverse_of or None,
+            auto_generated=bool(data.get("auto_generated", False)),
+            bidirectional_pair_key=pair_key or None,
         )
 
 

--- a/src/api/management/presentation/knowledge_graphs/models.py
+++ b/src/api/management/presentation/knowledge_graphs/models.py
@@ -335,6 +335,22 @@ class EdgeTypeDefinitionModel(BaseModel):
         default=None,
         description="Optional workspace-relative script under instance_generators/ for prepopulation",
     )
+    bidirectional: bool = Field(
+        default=True,
+        description="When true, platform auto-generates inverse type and twin edge instances",
+    )
+    inverse_label: str | None = Field(
+        default=None,
+        description="Optional explicit inverse relationship label (primary types only)",
+    )
+    inverse_of: str | None = Field(
+        default=None,
+        description="Primary label this auto-generated inverse type mirrors",
+    )
+    auto_generated: bool = Field(
+        default=False,
+        description="True when this edge type was created by bidirectional pairing",
+    )
 
     def to_domain(self) -> EdgeTypeDefinition:
         """Convert to domain EdgeTypeDefinition value object."""
@@ -347,6 +363,10 @@ class EdgeTypeDefinitionModel(BaseModel):
             prepopulated=self.prepopulated,
             prepopulated_instance_count=self.prepopulated_instance_count,
             instance_generator=self.instance_generator,
+            bidirectional=self.bidirectional,
+            inverse_label=self.inverse_label,
+            inverse_of=self.inverse_of,
+            auto_generated=self.auto_generated,
         )
 
     @classmethod
@@ -361,6 +381,10 @@ class EdgeTypeDefinitionModel(BaseModel):
             prepopulated=et.prepopulated,
             prepopulated_instance_count=et.prepopulated_instance_count,
             instance_generator=et.instance_generator,
+            bidirectional=et.bidirectional,
+            inverse_label=et.inverse_label,
+            inverse_of=et.inverse_of,
+            auto_generated=et.auto_generated,
         )
 
 

--- a/src/api/tests/unit/infrastructure/extraction_workload/test_twin_edge_expansion.py
+++ b/src/api/tests/unit/infrastructure/extraction_workload/test_twin_edge_expansion.py
@@ -1,0 +1,45 @@
+"""Unit tests for bidirectional twin edge expansion in mutation preflight."""
+
+from __future__ import annotations
+
+import pytest
+
+from graph.domain.value_objects import EntityType, MutationOperation, MutationOperationType
+from infrastructure.extraction_workload.mutation_preflight import prepare_mutation_operations
+from management.domain.relationship_pairing import expand_ontology_bidirectional_pairs
+from management.domain.value_objects import EdgeTypeDefinition, OntologyConfig
+
+
+@pytest.mark.asyncio
+async def test_prepare_mutation_operations_expands_twin_edge_creates() -> None:
+    ontology = expand_ontology_bidirectional_pairs(
+        OntologyConfig(
+            edge_types=(
+                EdgeTypeDefinition(
+                    label="contains",
+                    source_labels=("repository",),
+                    target_labels=("test",),
+                    bidirectional=True,
+                ),
+            )
+        )
+    )
+    jsonl = (
+        '{"op":"CREATE","type":"edge","id":"contains:0123456789abcdef",'
+        '"label":"contains","start_id":"repository:aaaaaaaaaaaaaaaa",'
+        '"end_id":"test:bbbbbbbbbbbbbbbb","set_properties":{'
+        '"data_source_id":"ds","source_path":"bootstrap","knowledge_graph_id":"kg"}}'
+    )
+
+    operations, errors = await prepare_mutation_operations(
+        jsonl_content=jsonl,
+        tenant_id="tenant-1",
+        ontology=ontology,
+    )
+
+    assert errors == []
+    assert operations is not None
+    assert len(operations) == 2
+    assert operations[1].label == "contained_in"
+    assert operations[1].start_id == "test:bbbbbbbbbbbbbbbb"
+    assert operations[1].end_id == "repository:aaaaaaaaaaaaaaaa"

--- a/src/api/tests/unit/management/application/test_design_artifacts_pairing.py
+++ b/src/api/tests/unit/management/application/test_design_artifacts_pairing.py
@@ -1,0 +1,34 @@
+"""Unit tests for bidirectional metadata in design artifacts."""
+
+from __future__ import annotations
+
+from management.application.design_artifacts import build_design_artifacts
+from management.domain.relationship_pairing import expand_ontology_bidirectional_pairs
+from management.domain.value_objects import EdgeTypeDefinition, OntologyConfig
+
+
+def test_design_artifacts_exposes_reverse_relationship_type() -> None:
+    ontology = expand_ontology_bidirectional_pairs(
+        OntologyConfig(
+            edge_types=(
+                EdgeTypeDefinition(
+                    label="contains",
+                    source_labels=("repository",),
+                    target_labels=("test",),
+                    bidirectional=True,
+                ),
+            )
+        )
+    )
+
+    artifacts = build_design_artifacts(
+        knowledge_graph_id="kg-1",
+        ontology=ontology,
+        graph_data={"nodes": [], "edges": []},
+        limit=100,
+    )
+
+    contains = next(
+        row for row in artifacts["relationships"] if row["relationship_type"] == "contains"
+    )
+    assert contains["reverse_relationship_type"] == "contained_in"

--- a/src/api/tests/unit/management/domain/test_relationship_pairing.py
+++ b/src/api/tests/unit/management/domain/test_relationship_pairing.py
@@ -1,0 +1,179 @@
+"""Unit tests for bidirectional relationship pairing."""
+
+from __future__ import annotations
+
+import pytest
+
+from management.domain.relationship_pairing import (
+    bidirectional_pair_key,
+    build_inverse_edge_type,
+    derive_inverse_label,
+    expand_ontology_bidirectional_pairs,
+    expand_twin_edge_creates,
+    resolve_inverse_label_for_primary,
+)
+from management.domain.value_objects import EdgeTypeDefinition, OntologyConfig
+
+
+class TestDeriveInverseLabel:
+    def test_contains_maps_to_contained_in(self) -> None:
+        assert derive_inverse_label("contains") == "contained_in"
+
+    def test_defines_maps_to_defined_by(self) -> None:
+        assert derive_inverse_label("defines") == "defined_by"
+
+    def test_unknown_uses_suffix(self) -> None:
+        assert derive_inverse_label("relates_to") == "relates_to_inverse"
+
+
+class TestExpandOntologyBidirectionalPairs:
+    def test_auto_generates_inverse_type(self) -> None:
+        config = OntologyConfig(
+            edge_types=(
+                EdgeTypeDefinition(
+                    label="contains",
+                    description="Repository contains test",
+                    source_labels=("repository",),
+                    target_labels=("test",),
+                    bidirectional=True,
+                ),
+            )
+        )
+
+        expanded = expand_ontology_bidirectional_pairs(config)
+
+        labels = {edge.label for edge in expanded.edge_types}
+        assert labels == {"contains", "contained_in"}
+        inverse = next(edge for edge in expanded.edge_types if edge.label == "contained_in")
+        assert inverse.source_labels == ("test",)
+        assert inverse.target_labels == ("repository",)
+        assert inverse.inverse_of == "contains"
+        assert inverse.auto_generated is True
+
+    def test_skips_when_bidirectional_false(self) -> None:
+        config = OntologyConfig(
+            edge_types=(
+                EdgeTypeDefinition(
+                    label="depends_on",
+                    source_labels=("service",),
+                    target_labels=("service",),
+                    bidirectional=False,
+                ),
+            )
+        )
+
+        expanded = expand_ontology_bidirectional_pairs(config)
+
+        assert len(expanded.edge_types) == 1
+        assert expanded.edge_types[0].label == "depends_on"
+
+    def test_respects_explicit_inverse_label(self) -> None:
+        config = OntologyConfig(
+            edge_types=(
+                EdgeTypeDefinition(
+                    label="contains",
+                    source_labels=("repository",),
+                    target_labels=("test",),
+                    bidirectional=True,
+                    inverse_label="housed_in",
+                ),
+            )
+        )
+
+        expanded = expand_ontology_bidirectional_pairs(config)
+        inverse = next(edge for edge in expanded.edge_types if edge.label == "housed_in")
+
+        assert inverse.inverse_of == "contains"
+
+    def test_legacy_edge_without_bidirectional_flag_is_unchanged(self) -> None:
+        config = OntologyConfig(
+            edge_types=(
+                EdgeTypeDefinition(
+                    label="contains",
+                    source_labels=("repository",),
+                    target_labels=("test",),
+                ),
+            )
+        )
+
+        expanded = expand_ontology_bidirectional_pairs(config)
+
+        assert len(expanded.edge_types) == 1
+
+
+class TestExpandTwinEdgeCreates:
+    def test_primary_create_expands_to_inverse(self) -> None:
+        ontology = expand_ontology_bidirectional_pairs(
+            OntologyConfig(
+                edge_types=(
+                    EdgeTypeDefinition(
+                        label="contains",
+                        source_labels=("repository",),
+                        target_labels=("test",),
+                        bidirectional=True,
+                    ),
+                )
+            )
+        )
+        operations = [
+            {
+                "op": "CREATE",
+                "type": "edge",
+                "id": "contains:0123456789abcdef",
+                "label": "contains",
+                "start_id": "repository:aaaaaaaaaaaaaaaa",
+                "end_id": "test:bbbbbbbbbbbbbbbb",
+                "set_properties": {
+                    "data_source_id": "ds-1",
+                    "source_path": "bootstrap",
+                    "knowledge_graph_id": "kg-1",
+                },
+            }
+        ]
+
+        expanded = expand_twin_edge_creates(
+            operations,
+            ontology=ontology,
+            tenant_id="tenant-1",
+        )
+
+        assert len(expanded) == 2
+        inverse = expanded[1]
+        assert inverse["label"] == "contained_in"
+        assert inverse["start_id"] == "test:bbbbbbbbbbbbbbbb"
+        assert inverse["end_id"] == "repository:aaaaaaaaaaaaaaaa"
+
+    def test_non_bidirectional_edge_is_unchanged(self) -> None:
+        ontology = OntologyConfig(
+            edge_types=(
+                EdgeTypeDefinition(
+                    label="depends_on",
+                    source_labels=("service",),
+                    target_labels=("service",),
+                    bidirectional=False,
+                ),
+            )
+        )
+        operations = [
+            {
+                "op": "CREATE",
+                "type": "edge",
+                "id": "depends_on:0123456789abcdef",
+                "label": "depends_on",
+                "start_id": "service:aaaaaaaaaaaaaaaa",
+                "end_id": "service:bbbbbbbbbbbbbbbb",
+                "set_properties": {
+                    "data_source_id": "ds-1",
+                    "source_path": "bootstrap",
+                    "knowledge_graph_id": "kg-1",
+                },
+            }
+        ]
+
+        expanded = expand_twin_edge_creates(
+            operations,
+            ontology=ontology,
+            tenant_id="tenant-1",
+        )
+
+        assert len(expanded) == 1


### PR DESCRIPTION
## Summary
- Default new relationship types to `bidirectional: true` (opt-out for asymmetric edges)
- Auto-generate inverse edge types on ontology save (`contains` → `contained_in`)
- Expand primary edge CREATE mutations into twin inverse CREATEs in workload validate/apply
- Validate primary/inverse instance parity in workspace readiness
- Populate `reverse_relationship_type` in design artifacts (UI already renders it)
- Spec: `specs/graph/bidirectional-relationships.spec.md`

Closes #763

## Test plan
- [x] `uv run pytest tests/unit/management/domain/test_relationship_pairing.py`
- [x] `uv run pytest tests/unit/infrastructure/extraction_workload/test_twin_edge_expansion.py`
- [x] `uv run pytest tests/unit/management/application/test_design_artifacts_pairing.py`
- [x] `uv run pytest tests/unit/management/test_architecture.py` (management_no_graph)
- [ ] `make down && make dev` — save ontology with `contains`, apply primary edge JSONL, verify twin in graph


Made with [Cursor](https://cursor.com)