### PR TITLE
feat(extraction): complete GMA bootstrap guidance and runtime improvements

### DIFF
--- a/specs/extraction/chat-turns.spec.md
+++ b/specs/extraction/chat-turns.spec.md
@@ -95,6 +95,15 @@ The system SHALL expose schema, mutation, and workspace tooling appropriate for 
 - THEN the system prompt omits the full skill prose block
 - AND still includes live workspace readiness and a short tools summary
 
+### Requirement: Multi-Deliverable Turn Pacing
+The system SHALL instruct the Graph Management Assistant to pace multi-item bootstrap requests across turns.
+
+#### Scenario: One phase per turn by default
+- GIVEN the user sends one message with multiple bootstrap deliverables
+- WHEN the Graph Management Assistant processes the turn
+- THEN schema bootstrap guardrails require completing at most one bootstrap phase
+- AND the assistant asks whether to continue automatically or one phase at a time
+
 ### Requirement: Sticky Turn Timeout
 The system SHALL allow configuring a per-turn execution timeout for graph-management chat in sticky session containers.
 

--- a/specs/graph/schema-authoring.spec.md
+++ b/specs/graph/schema-authoring.spec.md
@@ -68,6 +68,34 @@ The system SHALL enforce `prepopulated=true` as a transition-blocking readiness 
 - WHEN readiness is evaluated
 - THEN validation fails and transition to extraction mode is blocked
 
+### Requirement: Opinionated Bootstrap Workflow
+The system SHALL guide the Graph Management Assistant through a six-phase schema bootstrap workflow.
+
+#### Scenario: Goals before schema
+- GIVEN a new schema bootstrap conversation
+- WHEN the assistant begins intake
+- THEN it asks for questions the graph must answer before proposing entity types
+
+#### Scenario: Phased bootstrap guidance
+- GIVEN schema bootstrap skills are resolved for a graph-management turn
+- WHEN the agent system prompt is assembled
+- THEN it includes the six phases: goals, discovery, schema Q&A, prepopulation planning, confirmed save, bulk implementation
+
+#### Scenario: Confirmed ontology save
+- GIVEN the assistant has drafted a schema but the user has not confirmed it
+- WHEN the assistant considers persisting types
+- THEN guardrails require waiting for explicit user confirmation before `kartograph_save_schema_ontology`
+
+#### Scenario: Property versus entity modeling guidance
+- GIVEN schema bootstrap skills are resolved
+- WHEN the assistant models attributes
+- THEN skills distinguish categorize/distinguish → property from track-which/needs-relationships → entity type
+
+#### Scenario: Workspace discovery before prepopulation
+- GIVEN the assistant enters prepopulation planning
+- WHEN skills are resolved
+- THEN prepopulation guidance requires Glob/Grep discovery on `repository-files/` first
+
 ### Requirement: Workload Bulk Instance Authoring
 The system SHALL support bulk instance authoring for the Graph Management Assistant via workspace files and strict CREATE semantics.
 

--- a/src/agent-runtime/kartograph_agent_runtime/executor.py
+++ b/src/agent-runtime/kartograph_agent_runtime/executor.py
@@ -59,10 +59,12 @@ def _build_workspace_prompt_appendix(settings: AgentRuntimeSettings) -> str:
                 f"Workspace mount: `{settings.workspace_dir}`",
                 (
                     "Prepared repository files live under "
-                    "`repository-files/<data_source_name>/`. "
-                    "Prebuilt instance generator scripts are in `instance_generators/` "
-                    "(run with Bash: `python3 instance_generators/<script>.py repository-files`). "
-                    "Use Read, Grep, Glob, and Bash against the workspace mount only."
+                    "`repository-files/<data_source_name>/` (read-only). "
+                    "`ingestion-context/` is read-only. "
+                    "Writable outputs: `instance_generators/` only (scripts, JSON, JSONL under "
+                    "`instance_generators/out/`). "
+                    "Run generators with Bash: `python3 instance_generators/<script>.py repository-files`. "
+                    "Use Read, Grep, Glob on repository-files; Bash for generators."
                 ),
             ]
             for source in sources[:12]:

--- a/src/agent-runtime/kartograph_agent_runtime/thinking_stream.py
+++ b/src/agent-runtime/kartograph_agent_runtime/thinking_stream.py
@@ -53,11 +53,30 @@ def replace_last_thinking(
     return {"type": "thinking", "recent": list(recent)}
 
 
-def update_composing_line(recent: list[str], preview_tail: str) -> dict[str, Any] | None:
+def _compose_reply_line(preview_tail: str) -> str:
     preview_tail = normalize_activity_line(preview_tail.replace("\n", " "))
-    line = normalize_activity_line(
-        f"Composing reply · {preview_tail}" if preview_tail else "Composing reply…",
+    if not preview_tail:
+        return "Composing reply…"
+    lowered = preview_tail.lower()
+    noisy_prefixes = (
+        "need.",
+        "need ",
+        "let me",
+        "now let me",
+        "i'll ",
+        "i will ",
+        "creating task",
+        "first, let",
     )
+    if any(lowered.startswith(prefix) for prefix in noisy_prefixes):
+        return "Composing reply…"
+    if len(preview_tail) < 12:
+        return "Composing reply…"
+    return f"Composing reply · {preview_tail}"
+
+
+def update_composing_line(recent: list[str], preview_tail: str) -> dict[str, Any] | None:
+    line = _compose_reply_line(preview_tail)
     prefix = "Composing reply"
     if recent and str(recent[-1]).startswith(prefix):
         recent[-1] = line

--- a/src/agent-runtime/tests/test_executor.py
+++ b/src/agent-runtime/tests/test_executor.py
@@ -53,6 +53,8 @@ def test_build_workspace_prompt_appendix_prefers_sources_index(tmp_path: Path) -
     assert "Hyperfleet API" in appendix
     assert "142 file(s)" in appendix
     assert "pkg/api/adapter_status_types_test.go" in appendix
+    assert "read-only" in appendix
+    assert "instance_generators/" in appendix
 
 
 def test_build_workspace_prompt_appendix_includes_extension_counts(tmp_path: Path) -> None:

--- a/src/agent-runtime/tests/test_thinking_stream.py
+++ b/src/agent-runtime/tests/test_thinking_stream.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from kartograph_agent_runtime.thinking_stream import (
+    _compose_reply_line,
     initial_sdk_thinking_lines,
     push_thinking,
     replace_last_thinking,
     thinking_events_from_sdk_message,
+    update_composing_line,
 )
 
 
@@ -51,6 +53,21 @@ def test_initial_sdk_thinking_lines_include_connected_message() -> None:
 
     assert any("Claude Agent SDK query started" in line for line in lines)
     assert any("Schema tools" in line for line in lines)
+
+
+def test_compose_reply_line_sanitizes_noisy_planning_text() -> None:
+    assert _compose_reply_line("need. Let me create tasks") == "Composing reply…"
+    assert _compose_reply_line("Short") == "Composing reply…"
+    assert _compose_reply_line("Summarizing ontology changes for review.") == (
+        "Composing reply · Summarizing ontology changes for review."
+    )
+
+
+def test_update_composing_line_uses_sanitized_preview() -> None:
+    recent: list[str] = []
+    event = update_composing_line(recent, "Now let me start with the ontology schema")
+    assert event is not None
+    assert recent[-1] == "Composing reply…"
 
 
 def test_agent_runtime_settings_default_max_turns() -> None:

--- a/src/api/extraction/application/schema_authoring_guide.py
+++ b/src/api/extraction/application/schema_authoring_guide.py
@@ -5,9 +5,40 @@ SCHEMA_AUTHORING_GUIDE = """
 
 Use the Kartograph schema tools — never probe undocumented HTTP routes.
 Use Read, Grep, Glob, and Bash against the session workspace mount. Prebuilt generator scripts
-live under `instance_generators/` (see README there).
+live under `instance_generators/` (see README there). Write scripts and JSON/JSONL outputs
+only under `instance_generators/` — `repository-files/` and `ingestion-context/` are read-only.
 
-## Workflow
+## Bootstrap workflow (6 phases)
+
+Complete these in order. Do not mix schema design, prepopulation planning, and bulk
+implementation in the same turn when the user gave multiple deliverables.
+
+1. **Understand goals** — Ask what questions the graph must answer; collect 3–5 stakeholder use cases.
+2. **Workspace discovery** — Glob/Grep under `repository-files/`; report file counts, extensions, and code patterns.
+3. **Draft schema + validation Q&A** — Propose entity types, properties, and relationships; cite workspace examples.
+4. **Prepopulation planning** — Decide prepopulated vs manual per type; required properties; generator strategy.
+5. **Save ontology** — `kartograph_save_schema_ontology` only after the user confirms the full schema.
+6. **Implement prepopulation** — Bash generators → `json_*_to_jsonl.py` → validate-from-file → apply-from-file; entities before edges; verify readiness.
+
+## Schema modeling rules
+
+- **Property vs entity:** distinguish/categorize (e.g. tier0/tier1) → property on an existing type;
+  track which/what or needs relationships → entity type + edges.
+- **Bidirectional relationships** default on — author primary direction only; platform creates inverse type
+  and twin edge instances. Set `bidirectional: false` for asymmetric edges (`depends_on`, `created_by`).
+- For asymmetric edges, confirm direction explicitly (X → rel → Y).
+
+## Workspace discovery patterns
+
+| Target | Glob / Grep hints |
+|--------|-------------------|
+| Tests | `**/*_test.go`, `**/test_*.go`, `**/*_test.py`, `**/tests/**` |
+| API endpoints / handlers | `Grep` for route registrations, `@app.`, `HandleFunc`, OpenAPI paths |
+| Source files | `Glob **/*.{go,py,ts,java,yaml,md}` per data source folder |
+
+Cite the session workspace appendix for per-repo file counts and extension summaries before prepopulation Q&A.
+
+## Tool workflow
 
 1. Call `kartograph_get_schema_authoring_guide` (this document).
 2. Call `kartograph_get_workspace_readiness` to see prepopulated gaps and live instance counts.
@@ -94,7 +125,8 @@ Rules:
 - CREATE requires `data_source_id` and `source_path` in `set_properties`.
 - Node CREATE requires `slug` in `set_properties` (kebab-case, unique per type).
 - `knowledge_graph_id` is stamped by the platform — do not set it.
-- For large sets: Bash + custom script under `instance_generators/` → JSONL file → apply-from-file tool.
+- For large sets: Bash + custom script under `instance_generators/` → `json_*_to_jsonl.py` → apply-from-file.
+  Never hand-author bulk CREATE ids in chat — use converter scripts for deterministic ids.
 - CREATE is strict: existing types/instances must be changed with UPDATE, not CREATE again.
 - Dry-run before apply: `kartograph_validate_graph_mutations` or `kartograph_validate_graph_mutations_from_file`.
 - Create all entity nodes before relationship edges.

--- a/src/api/extraction/application/skill_resolution_service.py
+++ b/src/api/extraction/application/skill_resolution_service.py
@@ -24,8 +24,9 @@ _GLOBAL_PROMPT_SETTINGS: dict[ExtractionSessionMode, dict[str, object]] = {
             "You are the Graph Management Assistant for schema bootstrap. "
             "Use Kartograph schema tools to read and write entity/relationship types "
             "and instances — do not discover or call raw HTTP API routes. "
-            "Start by understanding user goals, then model the ontology and apply changes "
-            "with kartograph_get_schema_ontology and kartograph_save_schema_ontology."
+            "Follow the six-phase bootstrap workflow (goals → discovery → schema Q&A → "
+            "prepopulation planning → confirmed ontology save → bulk implementation). "
+            "Do not conflate schema design, prepopulation planning, and implementation."
         ),
         "prompt_hierarchy": (
             "platform_security_constraints",
@@ -39,6 +40,30 @@ _GLOBAL_PROMPT_SETTINGS: dict[ExtractionSessionMode, dict[str, object]] = {
             "Keep recommendations scoped to the active knowledge graph.",
             "Use kartograph_* schema tools for ontology and JSONL mutations; never probe /management or /graph HTTP routes manually.",
             "Format user-facing replies in GitHub-flavored Markdown (headings, lists, fenced code blocks, tables) for readability in the chat UI.",
+            (
+                "When the user gives multiple deliverables in one message (three or more bullets, "
+                "or any mix of ontology edits + bulk prepopulation + relationships), do not execute "
+                "the full list in one turn. Complete one phase only, summarize what finished, then "
+                "ask whether to continue through the rest automatically or one phase at a time. "
+                "Default to one phase per turn unless the user explicitly requests doing everything."
+            ),
+            (
+                "Bootstrap phases (in order): (1) ontology/types/properties, (2) entity instances "
+                "in dependency order, (3) relationship instances, (4) readiness verification via "
+                "kartograph_get_workspace_readiness. Stop after each phase when multiple deliverables "
+                "were requested."
+            ),
+            (
+                "Do not call kartograph_save_schema_ontology until the user confirms the full "
+                "proposed schema (types, properties, relationship directions, prepopulation flags). "
+                "Exception: the user explicitly says to save/apply or continues after reviewing your draft."
+            ),
+            (
+                "For bulk prepopulation never hand-author CREATE ids in chat. Use Bash generators → "
+                "json_*_to_jsonl.py → validate-from-file → apply-from-file. On ontology save errors, "
+                "read kartograph_get_schema_ontology and kartograph_get_schema_authoring_guide, merge "
+                "a fix, then retry once."
+            ),
         ),
     },
     ExtractionSessionMode.EXTRACTION_OPERATIONS: {
@@ -64,18 +89,40 @@ _GLOBAL_PROMPT_SETTINGS: dict[ExtractionSessionMode, dict[str, object]] = {
 _GLOBAL_SKILL_TEMPLATES: dict[ExtractionSessionMode, dict[str, str]] = {
     ExtractionSessionMode.SCHEMA_BOOTSTRAP: {
         "capabilities_intake": (
-            "Ask for goals once, then co-design or propose a first-pass schema."
+            "Phase 1 — Understand goals: ask what questions the graph must answer; collect "
+            "3–5 concrete stakeholder use cases before proposing types."
+        ),
+        "bootstrap_workflow": (
+            "Opinionated schema bootstrap phases (complete in order; one phase per turn when "
+            "the user gave multiple deliverables): "
+            "(1) Understand goals — 3–5 questions the graph must answer. "
+            "(2) Workspace discovery — Glob/Grep on repository-files/, cite file counts and patterns. "
+            "(3) Draft schema + Q&A — propose types/properties/relationships; show workspace examples. "
+            "(4) Prepopulation planning — which types/relationships are prepopulated vs manual. "
+            "(5) Save ontology — kartograph_save_schema_ontology only after user confirms the full schema. "
+            "(6) Implement prepopulation — generators → json_*_to_jsonl → validate-from-file → "
+            "apply-from-file; entities first, then edges; verify with kartograph_get_workspace_readiness."
+        ),
+        "schema_modeling": (
+            "Property vs entity: distinguish/categorize → property on an existing type; "
+            "track which/what or needs relationships → entity type + edges. "
+            "Relationships default bidirectional — author primary direction only; platform creates "
+            "inverse type + twin instances. Set bidirectional=false for asymmetric edges "
+            "(depends_on, created_by). For asymmetric edges, confirm X → rel → Y direction explicitly."
         ),
         "schema_workflow": (
-            "Call kartograph_get_schema_authoring_guide when you need shapes or mutation rules. "
+            "Call kartograph_get_schema_authoring_guide when you need shapes, phases, or mutation rules. "
             "Read/save ontology via kartograph_get_schema_ontology and kartograph_save_schema_ontology."
         ),
         "prepopulation": (
-            "For prepopulated types: set instance_generator on the type when helpful, run script "
-            "under instance_generators/ with Bash, convert with json_*_to_jsonl helpers, validate "
-            "then apply-from-file. CREATE cannot duplicate existing instances — use UPDATE to edit. "
-            "Bidirectional relationships default on: author primary-direction edges only; platform "
-            "creates inverse type + twin instances. Set bidirectional=false for asymmetric edges."
+            "Before prepopulation planning: Glob/Grep repository-files/ and cite counts from the workspace "
+            "appendix. Write scripts/JSON/JSONL only under instance_generators/ (repository-files/ is "
+            "read-only). For prepopulated types: run script with Bash, convert with json_*_to_jsonl, "
+            "validate then apply-from-file. Bidirectional edges: primary direction only in generators."
+        ),
+        "readiness_reporting": (
+            "After schema or prepopulation work, call kartograph_get_workspace_readiness and cite "
+            "blocking_reasons, prepopulated gaps, and transition_eligible in your reply."
         ),
     },
     ExtractionSessionMode.EXTRACTION_OPERATIONS: {
@@ -174,4 +221,3 @@ class ExtractionSkillResolutionService:
             guardrails=base.guardrails,
             skills=merged_skills,
         )
-

--- a/src/api/tests/unit/extraction/application/test_schema_authoring_guide.py
+++ b/src/api/tests/unit/extraction/application/test_schema_authoring_guide.py
@@ -1,0 +1,14 @@
+"""Unit tests for schema authoring guide content."""
+
+from __future__ import annotations
+
+from extraction.application.schema_authoring_guide import SCHEMA_AUTHORING_GUIDE
+
+
+def test_authoring_guide_documents_bootstrap_and_modeling_guidance() -> None:
+    assert "## Bootstrap workflow (6 phases)" in SCHEMA_AUTHORING_GUIDE
+    assert "## Schema modeling rules" in SCHEMA_AUTHORING_GUIDE
+    assert "## Workspace discovery patterns" in SCHEMA_AUTHORING_GUIDE
+    assert "read-only" in SCHEMA_AUTHORING_GUIDE
+    assert "Property vs entity" in SCHEMA_AUTHORING_GUIDE
+    assert "Never hand-author bulk CREATE ids" in SCHEMA_AUTHORING_GUIDE

--- a/src/api/tests/unit/extraction/application/test_skill_resolution_service.py
+++ b/src/api/tests/unit/extraction/application/test_skill_resolution_service.py
@@ -36,15 +36,23 @@ class TestExtractionSkillResolutionService:
 
         assert set(resolved.skills.keys()) >= {
             "capabilities_intake",
+            "bootstrap_workflow",
+            "schema_modeling",
             "schema_workflow",
             "prepopulation",
+            "readiness_reporting",
         }
-        assert "instance_generators" in resolved.skills["prepopulation"]
-        assert "kartograph_get_schema_authoring_guide" in resolved.skills["schema_workflow"]
-        assert "capabilities_intake" in resolved.skills
-        assert "goal" in resolved.system_prompt.lower()
+        assert "3–5" in resolved.skills["capabilities_intake"]
+        assert "Workspace discovery" in resolved.skills["bootstrap_workflow"]
+        assert "Property vs entity" in resolved.skills["schema_modeling"]
+        assert "read-only" in resolved.skills["prepopulation"]
+        assert "blocking_reasons" in resolved.skills["readiness_reporting"]
+        assert "six-phase" in resolved.system_prompt.lower()
+        guardrails_text = " ".join(resolved.guardrails)
+        assert "one phase per turn" in guardrails_text
+        assert "kartograph_save_schema_ontology" in guardrails_text
+        assert "never hand-author CREATE ids" in guardrails_text
         assert len(resolved.prompt_hierarchy) > 0
-        assert len(resolved.guardrails) > 0
 
     async def test_extraction_mode_uses_extraction_defaults(self):
         service = ExtractionSkillResolutionService(


### PR DESCRIPTION
## Summary
Completes remaining GMA bootstrap work (supersedes conflicted PRs #760–#762):

- **#750** One-hour sticky turn timeout (3600s caps + dev compose)
- **#751** Multi-deliverable pacing guardrails (one phase per turn)
- **#752** Six-phase bootstrap workflow skill + authoring guide
- **#753** Property-vs-entity + bidirectional/asymmetric relationship modeling skill
- **#754** Confirm-before-save ontology guardrail
- **#755** Workspace discovery before prepopulation (Glob/Grep patterns)
- **#756** Writable paths: `instance_generators/` only in workspace appendix
- **#757** Bulk JSONL pipeline guardrails (no hand-authored CREATE ids)
- **#758** Readiness reporting skill (`blocking_reasons`, gaps)
- **#759** Sanitize garbled "Composing reply" thinking stream lines

Closes #750 #751 #752 #753 #754 #755 #756 #757 #758 #759

## Test plan
- [x] `uv run pytest tests/unit/extraction/application/test_skill_resolution_service.py`
- [x] `uv run pytest tests/unit/extraction/application/test_schema_authoring_guide.py`
- [x] `uv run pytest tests/unit/extraction/infrastructure/test_workload_runtime_settings.py`
- [x] `uv run pytest tests/test_thinking_stream.py tests/test_executor.py tests/test_agent_prompt.py`


Made with [Cursor](https://cursor.com)