### PR TITLE
feat(extraction): Extraction Jobs phase3 parity (job sets, run, status)

### DIFF
--- a/src/api/extraction/application/skill_resolution_service.py
+++ b/src/api/extraction/application/skill_resolution_service.py
@@ -143,8 +143,15 @@ _GLOBAL_SKILL_TEMPLATES: dict[ExtractionSessionMode, dict[str, str]] = {
     },
     ExtractionSessionMode.EXTRACTION_OPERATIONS: {
         "job_setup": (
-            "Prioritize extraction job setup, file-targeting strategy, and "
-            "safe incremental mutation planning."
+            "Prioritize extraction job set authoring: by_instances batches with required "
+            "per-instance extraction descriptions (no separate extraction_plan.md). "
+            "Each description tells the extraction worker what to enrich for assigned entity slugs."
+        ),
+        "job_set_contract": (
+            "Job sets are saved via extraction-jobs API on the knowledge graph. Each set needs: "
+            "name, strategy (by_instances primary), entity_type, instances_per_job, and description. "
+            "Saving regenerates pending jobs from live graph instances. Job sets run sequentially; "
+            "jobs within a set run concurrently up to worker count."
         ),
         "minor_edits": (
             "Allow focused direct graph edits while preserving mutation-log "
@@ -168,8 +175,10 @@ _UI_MODE_SKILL_OVERLAYS: dict[GraphManagementUiMode, dict[str, str]] = {
     },
     GraphManagementUiMode.EXTRACTION_JOBS: {
         "ui_mode_framing": (
-            "Focus on extraction job setup, JobPackage-aware file targeting, and "
-            "incremental sync planning."
+            "Focus on extraction job set setup: define by_instances batches with per-instance "
+            "extraction descriptions, save to regenerate pending jobs, then guide the operator "
+            "to Run extraction. Use ontology schema panels for context. JobPackage readiness "
+            "still applies when file-backed context is required."
         ),
     },
     GraphManagementUiMode.ONE_OFF_MUTATIONS: {

--- a/src/api/extraction/domain/extraction_job.py
+++ b/src/api/extraction/domain/extraction_job.py
@@ -1,0 +1,122 @@
+"""Domain types for materialized extraction jobs and runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+
+class ExtractionJobStatus(StrEnum):
+    """Lifecycle status for one materialized extraction job."""
+
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class ExtractionRunStatus(StrEnum):
+    """Orchestrator state for one knowledge graph extraction run."""
+
+    IDLE = "idle"
+    RUNNING = "running"
+    PAUSING = "pausing"
+    PAUSED = "paused"
+    HALTED = "halted"
+
+
+@dataclass(frozen=True)
+class ExtractionTargetInstance:
+    """One entity instance assigned to an extraction job."""
+
+    slug: str
+    entity_type: str
+    properties: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "slug": self.slug,
+            "entity_type": self.entity_type,
+            "properties": dict(self.properties),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ExtractionTargetInstance:
+        return cls(
+            slug=str(data.get("slug") or ""),
+            entity_type=str(data.get("entity_type") or ""),
+            properties=dict(data.get("properties") or {}),
+        )
+
+
+@dataclass(frozen=True)
+class ExtractionJobRecord:
+    """One persisted extraction job row."""
+
+    id: str
+    knowledge_graph_id: str
+    job_id: str
+    job_set_name: str
+    strategy: str
+    status: ExtractionJobStatus
+    order_index: int
+    description: str
+    target_instances: tuple[ExtractionTargetInstance, ...] = field(default_factory=tuple)
+    worker_id: str | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    error_message: str | None = None
+    attempt: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+    cost_usd: float = 0.0
+    entities_created: int = 0
+    entities_modified: int = 0
+    relationships_created: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "knowledge_graph_id": self.knowledge_graph_id,
+            "job_id": self.job_id,
+            "job_set": self.job_set_name,
+            "job_set_name": self.job_set_name,
+            "strategy": self.strategy,
+            "status": self.status.value,
+            "order_index": self.order_index,
+            "description": self.description,
+            "target_instances": [instance.to_dict() for instance in self.target_instances],
+            "worker_id": self.worker_id,
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "completed_at": self.completed_at.isoformat() if self.completed_at else None,
+            "error_message": self.error_message,
+            "attempt": self.attempt,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cache_read_tokens": self.cache_read_tokens,
+            "cache_creation_tokens": self.cache_creation_tokens,
+            "cost_usd": self.cost_usd,
+            "entities_created": self.entities_created,
+            "entities_modified": self.entities_modified,
+            "relationships_created": self.relationships_created,
+            "instance_count": len(self.target_instances),
+            "file_count": 0,
+        }
+
+
+@dataclass(frozen=True)
+class ExtractionRunRecord:
+    """Orchestrator run metadata for one knowledge graph."""
+
+    id: str
+    knowledge_graph_id: str
+    status: ExtractionRunStatus
+    worker_count: int
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    pause_requested: bool = False
+    orchestrator_pid: int | None = None

--- a/src/api/extraction/infrastructure/extraction_job_executor.py
+++ b/src/api/extraction/infrastructure/extraction_job_executor.py
@@ -1,0 +1,33 @@
+"""Execute one materialized extraction job."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from extraction.domain.extraction_job import ExtractionJobRecord
+
+
+class ExtractionJobExecutor:
+    """Runs one extraction job using per-instance description guidance."""
+
+    async def execute(self, job: ExtractionJobRecord) -> dict[str, Any]:
+        """Process target instances for one job.
+
+        The sticky extraction agent container path will replace this stub with
+        a full Claude Agent SDK turn scoped to ``job.description`` and the
+        assigned instance slugs. For now we simulate successful completion so
+        orchestration, status APIs, and UI can be exercised end-to-end.
+        """
+        await asyncio.sleep(0.05)
+        instance_count = len(job.target_instances)
+        return {
+            "input_tokens": 100 * instance_count,
+            "output_tokens": 50 * instance_count,
+            "cache_read_tokens": 0,
+            "cache_creation_tokens": 0,
+            "cost_usd": 0.001 * instance_count,
+            "entities_created": 0,
+            "entities_modified": instance_count,
+            "relationships_created": 0,
+        }

--- a/src/api/extraction/infrastructure/extraction_run_orchestrator.py
+++ b/src/api/extraction/infrastructure/extraction_run_orchestrator.py
@@ -1,0 +1,268 @@
+"""Background orchestrator for parallel extraction job execution."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from extraction.infrastructure.extraction_job_executor import ExtractionJobExecutor
+from extraction.domain.extraction_job import ExtractionJobStatus, ExtractionRunStatus
+from extraction.infrastructure.repositories.extraction_job_repository import ExtractionJobRepository
+from extraction.infrastructure.workload_runtime_factory import (
+    create_ephemeral_extraction_worker_launcher,
+    get_workload_credential_issuer,
+)
+from extraction.infrastructure.workload_runtime_settings import (
+    get_extraction_workload_runtime_settings,
+)
+from extraction.ports.runtime import EphemeralWorkerLaunchRequest
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _OrchestratorState:
+    knowledge_graph_id: str
+    tenant_id: str
+    worker_count: int
+    tasks: list[asyncio.Task[None]] = field(default_factory=list)
+    stop_event: asyncio.Event = field(default_factory=asyncio.Event)
+
+
+class ExtractionRunOrchestrator:
+    """Manage extraction run lifecycle and worker pool for one knowledge graph."""
+
+    def __init__(
+        self,
+        *,
+        session_factory: async_sessionmaker[AsyncSession],
+        job_executor: ExtractionJobExecutor | None = None,
+    ) -> None:
+        self._session_factory = session_factory
+        self._job_executor = job_executor or ExtractionJobExecutor()
+        self._active: dict[str, _OrchestratorState] = {}
+        self._lock = asyncio.Lock()
+
+    async def start(
+        self,
+        *,
+        tenant_id: str,
+        knowledge_graph_id: str,
+        worker_count: int,
+    ) -> None:
+        async with self._lock:
+            existing = self._active.get(knowledge_graph_id)
+            if existing and not existing.stop_event.is_set():
+                return
+
+            state = _OrchestratorState(
+                knowledge_graph_id=knowledge_graph_id,
+                tenant_id=tenant_id,
+                worker_count=max(1, worker_count),
+            )
+            self._active[knowledge_graph_id] = state
+
+            async with self._session_factory() as session:
+                repo = ExtractionJobRepository(session)
+                await repo.upsert_run(
+                    knowledge_graph_id=knowledge_graph_id,
+                    status=ExtractionRunStatus.RUNNING,
+                    worker_count=state.worker_count,
+                    pause_requested=False,
+                    orchestrator_pid=os.getpid(),
+                    started_at=datetime.now(UTC),
+                    completed_at=None,
+                )
+                await session.commit()
+
+            runtime_settings = get_extraction_workload_runtime_settings()
+            if runtime_settings.backend == "container":
+                for index in range(state.worker_count):
+                    state.tasks.append(
+                        asyncio.create_task(
+                            self._container_worker_loop(state, worker_index=index + 1)
+                        )
+                    )
+            else:
+                for index in range(state.worker_count):
+                    state.tasks.append(
+                        asyncio.create_task(
+                            self._in_process_worker_loop(state, worker_index=index + 1)
+                        )
+                    )
+
+    async def request_pause(self, *, knowledge_graph_id: str) -> None:
+        async with self._session_factory() as session:
+            repo = ExtractionJobRepository(session)
+            await repo.set_pause_requested(knowledge_graph_id=knowledge_graph_id, pause_requested=True)
+            await repo.upsert_run(
+                knowledge_graph_id=knowledge_graph_id,
+                status=ExtractionRunStatus.PAUSING,
+                worker_count=1,
+                pause_requested=True,
+            )
+            await session.commit()
+
+    async def halt(self, *, knowledge_graph_id: str) -> None:
+        state = self._active.get(knowledge_graph_id)
+        if state is not None:
+            state.stop_event.set()
+            for task in state.tasks:
+                task.cancel()
+            self._active.pop(knowledge_graph_id, None)
+
+        async with self._session_factory() as session:
+            repo = ExtractionJobRepository(session)
+            await repo.mark_in_progress_failed(
+                knowledge_graph_id=knowledge_graph_id,
+                error_message="Extraction halted by operator",
+            )
+            await repo.upsert_run(
+                knowledge_graph_id=knowledge_graph_id,
+                status=ExtractionRunStatus.HALTED,
+                worker_count=1,
+                pause_requested=False,
+                completed_at=datetime.now(UTC),
+            )
+            await session.commit()
+
+    async def _in_process_worker_loop(self, state: _OrchestratorState, *, worker_index: int) -> None:
+        worker_id = f"worker-{worker_index:02d}"
+        try:
+            while not state.stop_event.is_set():
+                async with self._session_factory() as session:
+                    repo = ExtractionJobRepository(session)
+                    if await repo.is_pause_requested(knowledge_graph_id=state.knowledge_graph_id):
+                        await repo.upsert_run(
+                            knowledge_graph_id=state.knowledge_graph_id,
+                            status=ExtractionRunStatus.PAUSED,
+                            worker_count=state.worker_count,
+                            pause_requested=True,
+                            completed_at=datetime.now(UTC),
+                        )
+                        await session.commit()
+                        state.stop_event.set()
+                        break
+
+                    job = await repo.claim_next_pending_job(
+                        knowledge_graph_id=state.knowledge_graph_id,
+                        worker_id=worker_id,
+                    )
+                    if job is None:
+                        await session.commit()
+                        await self._maybe_finish_run(state)
+                        break
+                    await session.commit()
+
+                try:
+                    metrics = await self._job_executor.execute(job)
+                except Exception as exc:
+                    async with self._session_factory() as session:
+                        repo = ExtractionJobRepository(session)
+                        await repo.mark_job_failed(
+                            knowledge_graph_id=state.knowledge_graph_id,
+                            job_id=job.job_id,
+                            error_message=str(exc),
+                        )
+                        await session.commit()
+                    continue
+
+                async with self._session_factory() as session:
+                    repo = ExtractionJobRepository(session)
+                    await repo.mark_job_completed(
+                        knowledge_graph_id=state.knowledge_graph_id,
+                        job_id=job.job_id,
+                        metrics=metrics,
+                    )
+                    await session.commit()
+        except asyncio.CancelledError:
+            return
+
+    async def _container_worker_loop(self, state: _OrchestratorState, *, worker_index: int) -> None:
+        worker_id = f"worker-{worker_index:02d}"
+        launcher = create_ephemeral_extraction_worker_launcher()
+        credential_issuer = get_workload_credential_issuer()
+        runtime_settings = get_extraction_workload_runtime_settings()
+
+        try:
+            while not state.stop_event.is_set():
+                async with self._session_factory() as session:
+                    repo = ExtractionJobRepository(session)
+                    if await repo.is_pause_requested(knowledge_graph_id=state.knowledge_graph_id):
+                        await session.commit()
+                        state.stop_event.set()
+                        break
+                    job = await repo.claim_next_pending_job(
+                        knowledge_graph_id=state.knowledge_graph_id,
+                        worker_id=worker_id,
+                    )
+                    if job is None:
+                        await session.commit()
+                        await self._maybe_finish_run(state)
+                        break
+                    await session.commit()
+
+                credentials = credential_issuer.issue(
+                    tenant_id=state.tenant_id,
+                    knowledge_graph_id=state.knowledge_graph_id,
+                )
+                launch_result = launcher.launch(
+                    request=EphemeralWorkerLaunchRequest(
+                        tenant_id=state.tenant_id,
+                        knowledge_graph_id=state.knowledge_graph_id,
+                        session_id=f"extraction-job:{job.job_id}",
+                        sync_run_id=job.job_id,
+                        job_package_id=job.id,
+                    ),
+                    credentials=credentials,
+                )
+                logger.info(
+                    "Launched extraction worker %s for job %s (container backend)",
+                    launch_result.worker_id,
+                    job.job_id,
+                )
+                # Container worker is responsible for marking completion via workload API.
+                await asyncio.sleep(runtime_settings.worker_poll_seconds)
+        except asyncio.CancelledError:
+            return
+
+    async def _maybe_finish_run(self, state: _OrchestratorState) -> None:
+        async with self._session_factory() as session:
+            repo = ExtractionJobRepository(session)
+            counts = await repo.count_by_status(knowledge_graph_id=state.knowledge_graph_id)
+            pending = counts.get("pending", 0)
+            in_progress = counts.get("in_progress", 0)
+            if pending == 0 and in_progress == 0:
+                await repo.upsert_run(
+                    knowledge_graph_id=state.knowledge_graph_id,
+                    status=ExtractionRunStatus.IDLE,
+                    worker_count=state.worker_count,
+                    pause_requested=False,
+                    completed_at=datetime.now(UTC),
+                )
+                await session.commit()
+                state.stop_event.set()
+                self._active.pop(state.knowledge_graph_id, None)
+
+    def is_live(self, *, knowledge_graph_id: str) -> bool:
+        state = self._active.get(knowledge_graph_id)
+        return state is not None and not state.stop_event.is_set()
+
+
+_orchestrator_singleton: ExtractionRunOrchestrator | None = None
+
+
+def get_extraction_run_orchestrator(
+    *,
+    session_factory: async_sessionmaker[AsyncSession],
+) -> ExtractionRunOrchestrator:
+    global _orchestrator_singleton
+    if _orchestrator_singleton is None:
+        _orchestrator_singleton = ExtractionRunOrchestrator(session_factory=session_factory)
+    return _orchestrator_singleton

--- a/src/api/extraction/infrastructure/models/extraction_job.py
+++ b/src/api/extraction/infrastructure/models/extraction_job.py
@@ -1,0 +1,55 @@
+"""SQLAlchemy ORM models for extraction jobs and runs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from infrastructure.database.models import Base, TimestampMixin
+
+
+class ExtractionJobModel(Base, TimestampMixin):
+    """Materialized extraction job assigned to one knowledge graph."""
+
+    __tablename__ = "extraction_jobs"
+
+    id: Mapped[str] = mapped_column(sa.String(26), primary_key=True)
+    knowledge_graph_id: Mapped[str] = mapped_column(sa.String(26), nullable=False)
+    job_id: Mapped[str] = mapped_column(sa.String(128), nullable=False)
+    job_set_name: Mapped[str] = mapped_column(sa.String(128), nullable=False)
+    strategy: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    status: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    order_index: Mapped[int] = mapped_column(sa.Integer(), nullable=False, default=0)
+    description: Mapped[str] = mapped_column(sa.Text(), nullable=False, default="")
+    target_instances: Mapped[list[dict]] = mapped_column(JSONB, nullable=False, default=list)
+    worker_id: Mapped[str | None] = mapped_column(sa.String(64), nullable=True)
+    started_at: Mapped[datetime | None] = mapped_column(sa.DateTime(timezone=True), nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(sa.DateTime(timezone=True), nullable=True)
+    error_message: Mapped[str | None] = mapped_column(sa.Text(), nullable=True)
+    attempt: Mapped[int] = mapped_column(sa.Integer(), nullable=False, default=0)
+    input_tokens: Mapped[int] = mapped_column(sa.Integer(), nullable=False, default=0)
+    output_tokens: Mapped[int] = mapped_column(sa.Integer(), nullable=False, default=0)
+    cache_read_tokens: Mapped[int] = mapped_column(sa.Integer(), nullable=False, default=0)
+    cache_creation_tokens: Mapped[int] = mapped_column(sa.Integer(), nullable=False, default=0)
+    cost_usd: Mapped[float] = mapped_column(sa.Float(), nullable=False, default=0.0)
+    entities_created: Mapped[int] = mapped_column(sa.Integer(), nullable=False, default=0)
+    entities_modified: Mapped[int] = mapped_column(sa.Integer(), nullable=False, default=0)
+    relationships_created: Mapped[int] = mapped_column(sa.Integer(), nullable=False, default=0)
+
+
+class ExtractionRunModel(Base, TimestampMixin):
+    """Orchestrator run state for one knowledge graph."""
+
+    __tablename__ = "extraction_runs"
+
+    id: Mapped[str] = mapped_column(sa.String(26), primary_key=True)
+    knowledge_graph_id: Mapped[str] = mapped_column(sa.String(26), nullable=False, unique=True)
+    status: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    worker_count: Mapped[int] = mapped_column(sa.Integer(), nullable=False, default=1)
+    pause_requested: Mapped[bool] = mapped_column(sa.Boolean(), nullable=False, default=False)
+    started_at: Mapped[datetime | None] = mapped_column(sa.DateTime(timezone=True), nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(sa.DateTime(timezone=True), nullable=True)
+    orchestrator_pid: Mapped[int | None] = mapped_column(sa.Integer(), nullable=True)

--- a/src/api/extraction/infrastructure/repositories/extraction_job_repository.py
+++ b/src/api/extraction/infrastructure/repositories/extraction_job_repository.py
@@ -1,0 +1,420 @@
+"""PostgreSQL repository for materialized extraction jobs and runs."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import delete, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from ulid import ULID
+
+from extraction.domain.extraction_job import (
+    ExtractionJobRecord,
+    ExtractionJobStatus,
+    ExtractionRunRecord,
+    ExtractionRunStatus,
+    ExtractionTargetInstance,
+)
+from extraction.infrastructure.models.extraction_job import ExtractionJobModel, ExtractionRunModel
+
+
+def _job_model_to_record(model: ExtractionJobModel) -> ExtractionJobRecord:
+    return ExtractionJobRecord(
+        id=model.id,
+        knowledge_graph_id=model.knowledge_graph_id,
+        job_id=model.job_id,
+        job_set_name=model.job_set_name,
+        strategy=model.strategy,
+        status=ExtractionJobStatus(model.status),
+        order_index=model.order_index,
+        description=model.description,
+        target_instances=tuple(
+            ExtractionTargetInstance.from_dict(row) for row in (model.target_instances or [])
+        ),
+        worker_id=model.worker_id,
+        started_at=model.started_at,
+        completed_at=model.completed_at,
+        error_message=model.error_message,
+        attempt=model.attempt,
+        input_tokens=model.input_tokens,
+        output_tokens=model.output_tokens,
+        cache_read_tokens=model.cache_read_tokens,
+        cache_creation_tokens=model.cache_creation_tokens,
+        cost_usd=model.cost_usd,
+        entities_created=model.entities_created,
+        entities_modified=model.entities_modified,
+        relationships_created=model.relationships_created,
+    )
+
+
+def _run_model_to_record(model: ExtractionRunModel) -> ExtractionRunRecord:
+    return ExtractionRunRecord(
+        id=model.id,
+        knowledge_graph_id=model.knowledge_graph_id,
+        status=ExtractionRunStatus(model.status),
+        worker_count=model.worker_count,
+        started_at=model.started_at,
+        completed_at=model.completed_at,
+        pause_requested=model.pause_requested,
+        orchestrator_pid=model.orchestrator_pid,
+    )
+
+
+class ExtractionJobRepository:
+    """Persistence for extraction jobs and orchestrator runs."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def replace_pending_jobs(
+        self,
+        *,
+        knowledge_graph_id: str,
+        jobs: list[ExtractionJobRecord],
+    ) -> int:
+        await self._session.execute(
+            delete(ExtractionJobModel).where(
+                ExtractionJobModel.knowledge_graph_id == knowledge_graph_id,
+                ExtractionJobModel.status == ExtractionJobStatus.PENDING.value,
+            )
+        )
+        for job in jobs:
+            self._session.add(
+                ExtractionJobModel(
+                    id=job.id,
+                    knowledge_graph_id=job.knowledge_graph_id,
+                    job_id=job.job_id,
+                    job_set_name=job.job_set_name,
+                    strategy=job.strategy,
+                    status=job.status.value,
+                    order_index=job.order_index,
+                    description=job.description,
+                    target_instances=[instance.to_dict() for instance in job.target_instances],
+                )
+            )
+        await self._session.flush()
+        return len(jobs)
+
+    async def count_by_status(self, *, knowledge_graph_id: str) -> dict[str, int]:
+        stmt = (
+            select(ExtractionJobModel.status, func.count())
+            .where(ExtractionJobModel.knowledge_graph_id == knowledge_graph_id)
+            .group_by(ExtractionJobModel.status)
+        )
+        result = await self._session.execute(stmt)
+        counts = {status.value: 0 for status in ExtractionJobStatus}
+        for status, count in result.all():
+            counts[str(status)] = int(count)
+        return counts
+
+    async def count_by_job_set(self, *, knowledge_graph_id: str) -> dict[str, dict[str, int]]:
+        stmt = (
+            select(
+                ExtractionJobModel.job_set_name,
+                ExtractionJobModel.status,
+                func.count(),
+            )
+            .where(ExtractionJobModel.knowledge_graph_id == knowledge_graph_id)
+            .group_by(ExtractionJobModel.job_set_name, ExtractionJobModel.status)
+        )
+        result = await self._session.execute(stmt)
+        grouped: dict[str, dict[str, int]] = {}
+        for job_set_name, status, count in result.all():
+            bucket = grouped.setdefault(
+                job_set_name,
+                {
+                    "pending": 0,
+                    "in_progress": 0,
+                    "completed": 0,
+                    "failed": 0,
+                    "total": 0,
+                },
+            )
+            bucket[str(status)] = int(count)
+            bucket["total"] += int(count)
+        return grouped
+
+    async def has_in_progress_jobs(self, *, knowledge_graph_id: str) -> bool:
+        stmt = select(func.count()).where(
+            ExtractionJobModel.knowledge_graph_id == knowledge_graph_id,
+            ExtractionJobModel.status == ExtractionJobStatus.IN_PROGRESS.value,
+        )
+        result = await self._session.execute(stmt)
+        return int(result.scalar_one()) > 0
+
+    async def list_recent_jobs(
+        self,
+        *,
+        knowledge_graph_id: str,
+        limit: int = 20,
+    ) -> list[ExtractionJobRecord]:
+        stmt = (
+            select(ExtractionJobModel)
+            .where(ExtractionJobModel.knowledge_graph_id == knowledge_graph_id)
+            .order_by(
+                ExtractionJobModel.updated_at.desc(),
+                ExtractionJobModel.order_index.asc(),
+            )
+            .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        return [_job_model_to_record(model) for model in result.scalars().all()]
+
+    async def list_active_workers(self, *, knowledge_graph_id: str) -> list[dict[str, Any]]:
+        stmt = select(ExtractionJobModel).where(
+            ExtractionJobModel.knowledge_graph_id == knowledge_graph_id,
+            ExtractionJobModel.status == ExtractionJobStatus.IN_PROGRESS.value,
+        )
+        result = await self._session.execute(stmt)
+        workers: list[dict[str, Any]] = []
+        for model in result.scalars().all():
+            workers.append(
+                {
+                    "workerId": model.worker_id,
+                    "jobId": model.job_id,
+                    "jobSet": model.job_set_name,
+                    "strategy": model.strategy,
+                    "fileCount": 0,
+                    "instanceCount": len(model.target_instances or []),
+                    "startedAt": model.started_at.isoformat() if model.started_at else None,
+                }
+            )
+        return workers
+
+    async def claim_next_pending_job(
+        self,
+        *,
+        knowledge_graph_id: str,
+        worker_id: str,
+    ) -> ExtractionJobRecord | None:
+        stmt = (
+            select(ExtractionJobModel)
+            .where(
+                ExtractionJobModel.knowledge_graph_id == knowledge_graph_id,
+                ExtractionJobModel.status == ExtractionJobStatus.PENDING.value,
+            )
+            .order_by(ExtractionJobModel.order_index.asc(), ExtractionJobModel.job_id.asc())
+            .limit(1)
+            .with_for_update(skip_locked=True)
+        )
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+        if model is None:
+            return None
+        model.status = ExtractionJobStatus.IN_PROGRESS.value
+        model.worker_id = worker_id
+        model.started_at = datetime.now(UTC)
+        model.attempt = int(model.attempt) + 1
+        await self._session.flush()
+        return _job_model_to_record(model)
+
+    async def mark_job_completed(
+        self,
+        *,
+        knowledge_graph_id: str,
+        job_id: str,
+        metrics: dict[str, Any] | None = None,
+    ) -> None:
+        payload = metrics or {}
+        await self._session.execute(
+            update(ExtractionJobModel)
+            .where(
+                ExtractionJobModel.knowledge_graph_id == knowledge_graph_id,
+                ExtractionJobModel.job_id == job_id,
+            )
+            .values(
+                status=ExtractionJobStatus.COMPLETED.value,
+                completed_at=datetime.now(UTC),
+                input_tokens=int(payload.get("input_tokens", 0)),
+                output_tokens=int(payload.get("output_tokens", 0)),
+                cache_read_tokens=int(payload.get("cache_read_tokens", 0)),
+                cache_creation_tokens=int(payload.get("cache_creation_tokens", 0)),
+                cost_usd=float(payload.get("cost_usd", 0.0)),
+                entities_created=int(payload.get("entities_created", 0)),
+                entities_modified=int(payload.get("entities_modified", 0)),
+                relationships_created=int(payload.get("relationships_created", 0)),
+            )
+        )
+
+    async def mark_job_failed(
+        self,
+        *,
+        knowledge_graph_id: str,
+        job_id: str,
+        error_message: str,
+    ) -> None:
+        await self._session.execute(
+            update(ExtractionJobModel)
+            .where(
+                ExtractionJobModel.knowledge_graph_id == knowledge_graph_id,
+                ExtractionJobModel.job_id == job_id,
+            )
+            .values(
+                status=ExtractionJobStatus.FAILED.value,
+                completed_at=datetime.now(UTC),
+                error_message=error_message,
+            )
+        )
+
+    async def mark_in_progress_failed(
+        self,
+        *,
+        knowledge_graph_id: str,
+        error_message: str,
+    ) -> int:
+        result = await self._session.execute(
+            update(ExtractionJobModel)
+            .where(
+                ExtractionJobModel.knowledge_graph_id == knowledge_graph_id,
+                ExtractionJobModel.status == ExtractionJobStatus.IN_PROGRESS.value,
+            )
+            .values(
+                status=ExtractionJobStatus.FAILED.value,
+                completed_at=datetime.now(UTC),
+                error_message=error_message,
+            )
+        )
+        return int(result.rowcount or 0)
+
+    async def reset_jobs_by_status(
+        self,
+        *,
+        knowledge_graph_id: str,
+        from_status: ExtractionJobStatus,
+        to_status: ExtractionJobStatus = ExtractionJobStatus.PENDING,
+    ) -> int:
+        result = await self._session.execute(
+            update(ExtractionJobModel)
+            .where(
+                ExtractionJobModel.knowledge_graph_id == knowledge_graph_id,
+                ExtractionJobModel.status == from_status.value,
+            )
+            .values(
+                status=to_status.value,
+                worker_id=None,
+                started_at=None,
+                completed_at=None,
+                error_message=None,
+            )
+        )
+        return int(result.rowcount or 0)
+
+    async def reset_all_non_pending(
+        self,
+        *,
+        knowledge_graph_id: str,
+    ) -> int:
+        total = 0
+        for status in (
+            ExtractionJobStatus.IN_PROGRESS,
+            ExtractionJobStatus.COMPLETED,
+            ExtractionJobStatus.FAILED,
+        ):
+            total += await self.reset_jobs_by_status(
+                knowledge_graph_id=knowledge_graph_id,
+                from_status=status,
+            )
+        return total
+
+    async def aggregate_token_metrics(self, *, knowledge_graph_id: str) -> dict[str, float | int]:
+        stmt = select(
+            func.coalesce(func.sum(ExtractionJobModel.input_tokens), 0),
+            func.coalesce(func.sum(ExtractionJobModel.output_tokens), 0),
+            func.coalesce(func.sum(ExtractionJobModel.cache_read_tokens), 0),
+            func.coalesce(func.sum(ExtractionJobModel.cache_creation_tokens), 0),
+            func.coalesce(func.sum(ExtractionJobModel.cost_usd), 0.0),
+        ).where(ExtractionJobModel.knowledge_graph_id == knowledge_graph_id)
+        result = await self._session.execute(stmt)
+        row = result.one()
+        return {
+            "totalInputTokens": int(row[0]),
+            "totalOutputTokens": int(row[1]),
+            "totalCacheReadTokens": int(row[2]),
+            "totalCacheCreationTokens": int(row[3]),
+            "totalCostUsd": float(row[4]),
+        }
+
+    async def avg_completed_job_seconds(self, *, knowledge_graph_id: str) -> float | None:
+        stmt = select(
+            func.avg(
+                func.extract(
+                    "epoch",
+                    ExtractionJobModel.completed_at - ExtractionJobModel.started_at,
+                )
+            )
+        ).where(
+            ExtractionJobModel.knowledge_graph_id == knowledge_graph_id,
+            ExtractionJobModel.status == ExtractionJobStatus.COMPLETED.value,
+            ExtractionJobModel.started_at.is_not(None),
+            ExtractionJobModel.completed_at.is_not(None),
+        )
+        result = await self._session.execute(stmt)
+        value = result.scalar_one_or_none()
+        if value is None:
+            return None
+        seconds = float(value)
+        return seconds if seconds > 0 else None
+
+    async def get_run(self, *, knowledge_graph_id: str) -> ExtractionRunRecord | None:
+        stmt = select(ExtractionRunModel).where(
+            ExtractionRunModel.knowledge_graph_id == knowledge_graph_id
+        )
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+        return _run_model_to_record(model) if model else None
+
+    async def upsert_run(
+        self,
+        *,
+        knowledge_graph_id: str,
+        status: ExtractionRunStatus,
+        worker_count: int,
+        pause_requested: bool = False,
+        orchestrator_pid: int | None = None,
+        started_at: datetime | None = None,
+        completed_at: datetime | None = None,
+    ) -> ExtractionRunRecord:
+        stmt = select(ExtractionRunModel).where(
+            ExtractionRunModel.knowledge_graph_id == knowledge_graph_id
+        )
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+        if model is None:
+            model = ExtractionRunModel(
+                id=str(ULID()),
+                knowledge_graph_id=knowledge_graph_id,
+                status=status.value,
+                worker_count=worker_count,
+                pause_requested=pause_requested,
+                orchestrator_pid=orchestrator_pid,
+                started_at=started_at,
+                completed_at=completed_at,
+            )
+            self._session.add(model)
+        else:
+            model.status = status.value
+            model.worker_count = worker_count
+            model.pause_requested = pause_requested
+            model.orchestrator_pid = orchestrator_pid
+            if started_at is not None:
+                model.started_at = started_at
+            if completed_at is not None:
+                model.completed_at = completed_at
+        await self._session.flush()
+        return _run_model_to_record(model)
+
+    async def set_pause_requested(self, *, knowledge_graph_id: str, pause_requested: bool) -> None:
+        await self._session.execute(
+            update(ExtractionRunModel)
+            .where(ExtractionRunModel.knowledge_graph_id == knowledge_graph_id)
+            .values(pause_requested=pause_requested)
+        )
+
+    async def is_pause_requested(self, *, knowledge_graph_id: str) -> bool:
+        stmt = select(ExtractionRunModel.pause_requested).where(
+            ExtractionRunModel.knowledge_graph_id == knowledge_graph_id
+        )
+        result = await self._session.execute(stmt)
+        value = result.scalar_one_or_none()
+        return bool(value)

--- a/src/api/extraction/infrastructure/workload_runtime_settings.py
+++ b/src/api/extraction/infrastructure/workload_runtime_settings.py
@@ -52,6 +52,7 @@ class ExtractionWorkloadRuntimeSettings(BaseSettings):
     sticky_health_timeout_seconds: float = Field(default=90.0, ge=5.0, le=600.0)
     sticky_turn_timeout_seconds: float = Field(default=1000.0, ge=30.0, le=3600.0)
     sticky_max_turns: int = Field(default=500, ge=1, le=1000)
+    worker_poll_seconds: float = Field(default=1.0, ge=0.1, le=60.0)
     vertex_project_id: str = Field(default="")
     vertex_region: str = Field(default="us-east5")
     gcloud_config_mount: str | None = Field(default=None)

--- a/src/api/infrastructure/management/extraction_job_materializer.py
+++ b/src/api/infrastructure/management/extraction_job_materializer.py
@@ -1,0 +1,134 @@
+"""Materialize extraction jobs from saved job set definitions."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from typing import Any
+
+from ulid import ULID
+
+from extraction.domain.extraction_job import ExtractionJobRecord, ExtractionJobStatus, ExtractionTargetInstance
+from management.domain.extraction_job_config import (
+    ExtractionJobConfigDocument,
+    ExtractionJobSetDefinition,
+    ExtractionJobSetStrategy,
+)
+
+
+def _batch_items(items: list[Any], batch_size: int) -> list[list[Any]]:
+    return [items[i : i + batch_size] for i in range(0, len(items), batch_size)]
+
+
+def _generate_job_id(job_set_name: str, batch_idx: int, content_hash: str) -> str:
+    hash_suffix = hashlib.sha256(content_hash.encode()).hexdigest()[:8]
+    return f"{job_set_name}_batch_{batch_idx:04d}_{hash_suffix}"
+
+
+def entity_instance_counts_from_graph(
+    *,
+    knowledge_graph_id: str,
+    graph_data: dict[str, Any],
+) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for node in graph_data.get("nodes", []):
+        if node.get("knowledge_graph_id") != knowledge_graph_id or node.get("_redacted"):
+            continue
+        entity_type = str(node.get("type") or "unknown")
+        counts[entity_type] = counts.get(entity_type, 0) + 1
+    return counts
+
+
+def entity_instances_by_type_from_graph(
+    *,
+    knowledge_graph_id: str,
+    graph_data: dict[str, Any],
+) -> dict[str, list[ExtractionTargetInstance]]:
+    grouped: dict[str, list[ExtractionTargetInstance]] = {}
+    for node in sorted(
+        graph_data.get("nodes", []),
+        key=lambda item: str(item.get("slug") or item.get("domainId") or item.get("id") or ""),
+    ):
+        if node.get("knowledge_graph_id") != knowledge_graph_id or node.get("_redacted"):
+            continue
+        entity_type = str(node.get("type") or "unknown")
+        slug = str(node.get("slug") or node.get("domainId") or node.get("id") or "")
+        properties = {
+            key: value
+            for key, value in node.items()
+            if key
+            not in {
+                "id",
+                "slug",
+                "data_source_id",
+                "source_path",
+                "knowledge_graph_id",
+                "graph_id",
+                "name",
+                "type",
+                "domainId",
+            }
+            and not str(key).startswith("_")
+        }
+        grouped.setdefault(entity_type, []).append(
+            ExtractionTargetInstance(slug=slug, entity_type=entity_type, properties=properties)
+        )
+    return grouped
+
+
+def materialize_jobs_from_config(
+    *,
+    knowledge_graph_id: str,
+    config: ExtractionJobConfigDocument,
+    graph_data: dict[str, Any],
+) -> list[ExtractionJobRecord]:
+    """Build pending extraction jobs from job set definitions and live graph instances."""
+    instances_by_type = entity_instances_by_type_from_graph(
+        knowledge_graph_id=knowledge_graph_id,
+        graph_data=graph_data,
+    )
+    jobs: list[ExtractionJobRecord] = []
+    order_index = 0
+
+    for job_set in config.job_sets:
+        if job_set.strategy != ExtractionJobSetStrategy.BY_INSTANCES:
+            continue
+        entity_type = job_set.entity_type or ""
+        instances = instances_by_type.get(entity_type, [])
+        per_job = int(job_set.instances_per_job or 1)
+        if per_job < 1 or not instances:
+            continue
+        description = (job_set.description or "").strip()
+        for batch_idx, batch in enumerate(_batch_items(instances, per_job), start=1):
+            content_hash = "|".join(instance.slug for instance in batch)
+            job_id = _generate_job_id(job_set.name, batch_idx, content_hash)
+            jobs.append(
+                ExtractionJobRecord(
+                    id=str(ULID()),
+                    knowledge_graph_id=knowledge_graph_id,
+                    job_id=job_id,
+                    job_set_name=job_set.name,
+                    strategy=job_set.strategy.value,
+                    status=ExtractionJobStatus.PENDING,
+                    order_index=order_index,
+                    description=description,
+                    target_instances=tuple(batch),
+                )
+            )
+            order_index += 1
+
+    return jobs
+
+
+def projected_job_count(
+    job_set: ExtractionJobSetDefinition,
+    *,
+    entity_instance_counts: dict[str, int],
+) -> int | None:
+    if job_set.strategy != ExtractionJobSetStrategy.BY_INSTANCES:
+        return None
+    total = entity_instance_counts.get(job_set.entity_type or "", 0)
+    per_job = job_set.instances_per_job
+    if total <= 0 or per_job is None or per_job < 1:
+        return 0 if total == 0 else None
+    return math.ceil(total / per_job)

--- a/src/api/infrastructure/management/extraction_jobs_dependencies.py
+++ b/src/api/infrastructure/management/extraction_jobs_dependencies.py
@@ -1,0 +1,49 @@
+"""Dependencies for extraction job endpoints."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from iam.application.value_objects import CurrentUser
+from iam.dependencies.user import get_current_user
+from infrastructure.database.connection_pool import ConnectionPool
+from infrastructure.database.dependencies import get_write_session
+from infrastructure.dependencies import get_age_connection_pool
+from infrastructure.management.extraction_jobs_service import ExtractionJobsService
+from infrastructure.outbox.repository import OutboxRepository
+from management.application.services.knowledge_graph_service import KnowledgeGraphService
+from management.dependencies.knowledge_graph import get_knowledge_graph_service
+from management.infrastructure.repositories.knowledge_graph_repository import (
+    KnowledgeGraphRepository,
+)
+from extraction.infrastructure.repositories.extraction_job_repository import (
+    ExtractionJobRepository,
+)
+
+
+def get_write_sessionmaker(request: Request):
+    return request.app.state.write_sessionmaker
+
+
+def get_extraction_jobs_service(
+    request: Request,
+    kg_service: Annotated[KnowledgeGraphService, Depends(get_knowledge_graph_service)],
+    session: Annotated[AsyncSession, Depends(get_write_session)],
+    pool: Annotated[ConnectionPool, Depends(get_age_connection_pool)],
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+) -> ExtractionJobsService:
+    outbox = OutboxRepository(session=session)
+    kg_repo = KnowledgeGraphRepository(session=session, outbox=outbox)
+    job_repo = ExtractionJobRepository(session=session)
+    return ExtractionJobsService(
+        knowledge_graph_service=kg_service,
+        knowledge_graph_repository=kg_repo,
+        extraction_job_repository=job_repo,
+        connection_pool=pool,
+        tenant_id=current_user.tenant_id.value,
+        session=session,
+        session_factory=get_write_sessionmaker(request),
+    )

--- a/src/api/infrastructure/management/extraction_jobs_service.py
+++ b/src/api/infrastructure/management/extraction_jobs_service.py
@@ -1,0 +1,333 @@
+"""Application service for extraction job configuration and execution."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from starlette.concurrency import run_in_threadpool
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from infrastructure.management.extraction_job_materializer import (
+    entity_instance_counts_from_graph,
+    materialize_jobs_from_config,
+    projected_job_count,
+)
+from extraction.infrastructure.extraction_run_orchestrator import get_extraction_run_orchestrator
+from extraction.domain.extraction_job import ExtractionJobStatus, ExtractionRunStatus
+from extraction.infrastructure.repositories.extraction_job_repository import ExtractionJobRepository
+from graph.infrastructure.bulk_data_reader import fetch_bulk_graph_data
+from infrastructure.database.connection_pool import ConnectionPool
+from management.application.services.knowledge_graph_service import KnowledgeGraphService
+from management.domain.extraction_job_config import (
+    ExtractionJobConfigDocument,
+    ExtractionJobSetDefinition,
+)
+from management.infrastructure.repositories.knowledge_graph_repository import (
+    KnowledgeGraphRepository,
+)
+
+
+class ExtractionJobsService:
+    """Coordinate extraction job sets, materialization, and run orchestration."""
+
+    def __init__(
+        self,
+        *,
+        knowledge_graph_service: KnowledgeGraphService,
+        knowledge_graph_repository: KnowledgeGraphRepository,
+        extraction_job_repository: ExtractionJobRepository,
+        connection_pool: ConnectionPool,
+        tenant_id: str,
+        session: AsyncSession,
+        session_factory: Any,
+    ) -> None:
+        self._knowledge_graph_service = knowledge_graph_service
+        self._knowledge_graph_repository = knowledge_graph_repository
+        self._extraction_job_repository = extraction_job_repository
+        self._connection_pool = connection_pool
+        self._tenant_id = tenant_id
+        self._session = session
+        self._session_factory = session_factory
+
+    async def _load_graph_data(self) -> dict[str, Any]:
+        graph_name = f"tenant_{self._tenant_id}"
+        return await run_in_threadpool(
+            fetch_bulk_graph_data,
+            self._connection_pool,
+            graph_name,
+        )
+
+    async def get_extraction_jobs_document(
+        self,
+        *,
+        user_id: str,
+        kg_id: str,
+    ) -> dict[str, Any] | None:
+        kg = await self._knowledge_graph_service.get(user_id=user_id, kg_id=kg_id)
+        if kg is None:
+            return None
+
+        config = await self._knowledge_graph_repository.get_extraction_job_config(kg_id)
+        document = config or ExtractionJobConfigDocument.empty()
+        graph_data = await self._load_graph_data()
+        counts = entity_instance_counts_from_graph(
+            knowledge_graph_id=kg_id,
+            graph_data=graph_data,
+        )
+        entity_types = [
+            {"name": name, "instance_count": count}
+            for name, count in sorted(counts.items(), key=lambda item: item[0])
+        ]
+        return {
+            **document.to_dict(),
+            "entity_types": entity_types,
+        }
+
+    async def save_extraction_jobs_document(
+        self,
+        *,
+        user_id: str,
+        kg_id: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        kg = await self._knowledge_graph_service.get(user_id=user_id, kg_id=kg_id)
+        if kg is None:
+            raise ValueError(f"Knowledge graph '{kg_id}' not found")
+
+        document = ExtractionJobConfigDocument(
+            version=str(payload.get("version") or "1.0"),
+            job_sets=tuple(
+                ExtractionJobSetDefinition.from_dict(row)
+                for row in (payload.get("job_sets") or [])
+            ),
+        )
+        graph_data = await self._load_graph_data()
+        counts = entity_instance_counts_from_graph(
+            knowledge_graph_id=kg_id,
+            graph_data=graph_data,
+        )
+        errors = document.validation_errors(entity_instance_counts=counts)
+        if errors:
+            raise ValueError("; ".join(errors))
+
+        await self._knowledge_graph_repository.save_extraction_job_config(kg_id, document)
+        await self._session.commit()
+        return document.to_dict()
+
+    async def regenerate_jobs(
+        self,
+        *,
+        user_id: str,
+        kg_id: str,
+    ) -> dict[str, Any]:
+        kg = await self._knowledge_graph_service.get(user_id=user_id, kg_id=kg_id)
+        if kg is None:
+            raise ValueError(f"Knowledge graph '{kg_id}' not found")
+
+        if await self._extraction_job_repository.has_in_progress_jobs(knowledge_graph_id=kg_id):
+            raise ValueError("Cannot regenerate jobs while extraction jobs are in progress.")
+
+        config = await self._knowledge_graph_repository.get_extraction_job_config(kg_id)
+        document = config or ExtractionJobConfigDocument.empty()
+        graph_data = await self._load_graph_data()
+        jobs = materialize_jobs_from_config(
+            knowledge_graph_id=kg_id,
+            config=document,
+            graph_data=graph_data,
+        )
+        generated = await self._extraction_job_repository.replace_pending_jobs(
+            knowledge_graph_id=kg_id,
+            jobs=jobs,
+        )
+        await self._session.commit()
+        return {"success": True, "generated_jobs": generated}
+
+    async def get_database_status(
+        self,
+        *,
+        user_id: str,
+        kg_id: str,
+    ) -> dict[str, Any] | None:
+        kg = await self._knowledge_graph_service.get(user_id=user_id, kg_id=kg_id)
+        if kg is None:
+            return None
+
+        counts = await self._extraction_job_repository.count_by_status(knowledge_graph_id=kg_id)
+        jobs_by_set = await self._extraction_job_repository.count_by_job_set(
+            knowledge_graph_id=kg_id
+        )
+        recent_jobs = await self._extraction_job_repository.list_recent_jobs(
+            knowledge_graph_id=kg_id,
+            limit=20,
+        )
+        active_workers = await self._extraction_job_repository.list_active_workers(
+            knowledge_graph_id=kg_id
+        )
+        token_metrics = await self._extraction_job_repository.aggregate_token_metrics(
+            knowledge_graph_id=kg_id
+        )
+        avg_completed = await self._extraction_job_repository.avg_completed_job_seconds(
+            knowledge_graph_id=kg_id
+        )
+        graph_data = await self._load_graph_data()
+        entity_counts = entity_instance_counts_from_graph(
+            knowledge_graph_id=kg_id,
+            graph_data=graph_data,
+        )
+        return {
+            "exists": True,
+            "jobsByStatus": {
+                "pending": counts.get("pending", 0),
+                "in_progress": counts.get("in_progress", 0),
+                "completed": counts.get("completed", 0),
+                "failed": counts.get("failed", 0),
+            },
+            "jobsBySet": jobs_by_set,
+            "recentJobs": [
+                {
+                    "jobId": job.job_id,
+                    "jobSet": job.job_set_name,
+                    "status": job.status.value,
+                    "workerId": job.worker_id,
+                    "startedAt": job.started_at.isoformat() if job.started_at else None,
+                    "completedAt": job.completed_at.isoformat() if job.completed_at else None,
+                    "inputTokens": job.input_tokens,
+                    "outputTokens": job.output_tokens,
+                    "writeOps": job.entities_created + job.entities_modified + job.relationships_created,
+                    "assistantPreview": job.description[:120] if job.description else None,
+                }
+                for job in recent_jobs
+            ],
+            "activeWorkers": active_workers,
+            "avgCompletedJobSeconds": avg_completed,
+            "entitiesByType": entity_counts,
+            "entitiesTotal": sum(entity_counts.values()),
+            **token_metrics,
+        }
+
+    async def get_extraction_run_state(
+        self,
+        *,
+        user_id: str,
+        kg_id: str,
+    ) -> dict[str, Any] | None:
+        kg = await self._knowledge_graph_service.get(user_id=user_id, kg_id=kg_id)
+        if kg is None:
+            return None
+
+        run = await self._extraction_job_repository.get_run(knowledge_graph_id=kg_id)
+        orchestrator = get_extraction_run_orchestrator(session_factory=self._session_factory)
+        live = orchestrator.is_live(knowledge_graph_id=kg_id)
+        if run is None:
+            return {
+                "live": live,
+                "status": ExtractionRunStatus.IDLE.value,
+                "workerCount": 0,
+                "pauseRequested": False,
+            }
+        return {
+            "live": live or run.status in {ExtractionRunStatus.RUNNING, ExtractionRunStatus.PAUSING},
+            "status": run.status.value,
+            "workerCount": run.worker_count,
+            "pauseRequested": run.pause_requested,
+            "startedAt": run.started_at.isoformat() if run.started_at else None,
+            "completedAt": run.completed_at.isoformat() if run.completed_at else None,
+            "orchestratorPid": run.orchestrator_pid,
+        }
+
+    async def get_extraction_plan_summary(
+        self,
+        *,
+        user_id: str,
+        kg_id: str,
+    ) -> dict[str, Any] | None:
+        payload = await self.get_extraction_jobs_document(user_id=user_id, kg_id=kg_id)
+        if payload is None:
+            return None
+        counts = {
+            row["name"]: row["instance_count"] for row in payload.get("entity_types", [])
+        }
+        job_sets = []
+        for raw in payload.get("job_sets", []):
+            job_set = ExtractionJobSetDefinition.from_dict(raw)
+            job_sets.append(
+                {
+                    **raw,
+                    "projected_jobs": projected_job_count(job_set, entity_instance_counts=counts),
+                }
+            )
+        return {"job_sets": job_sets, "entity_types": payload.get("entity_types", [])}
+
+    async def start_extraction(
+        self,
+        *,
+        user_id: str,
+        kg_id: str,
+        workers: int,
+    ) -> dict[str, Any]:
+        kg = await self._knowledge_graph_service.get(user_id=user_id, kg_id=kg_id)
+        if kg is None:
+            raise ValueError(f"Knowledge graph '{kg_id}' not found")
+
+        orchestrator = get_extraction_run_orchestrator(session_factory=self._session_factory)
+        await orchestrator.start(
+            tenant_id=self._tenant_id,
+            knowledge_graph_id=kg_id,
+            worker_count=max(1, workers),
+        )
+        await self._session.commit()
+        return {
+            "success": True,
+            "message": f"Started extraction with {max(1, workers)} worker(s).",
+        }
+
+    async def pause_extraction(self, *, user_id: str, kg_id: str) -> dict[str, Any]:
+        kg = await self._knowledge_graph_service.get(user_id=user_id, kg_id=kg_id)
+        if kg is None:
+            raise ValueError(f"Knowledge graph '{kg_id}' not found")
+        orchestrator = get_extraction_run_orchestrator(session_factory=self._session_factory)
+        await orchestrator.request_pause(knowledge_graph_id=kg_id)
+        await self._session.commit()
+        return {"success": True, "message": "Pause requested; in-flight jobs will finish first."}
+
+    async def halt_extraction(self, *, user_id: str, kg_id: str) -> dict[str, Any]:
+        kg = await self._knowledge_graph_service.get(user_id=user_id, kg_id=kg_id)
+        if kg is None:
+            raise ValueError(f"Knowledge graph '{kg_id}' not found")
+        orchestrator = get_extraction_run_orchestrator(session_factory=self._session_factory)
+        await orchestrator.halt(knowledge_graph_id=kg_id)
+        await self._session.commit()
+        return {"success": True, "message": "Extraction halted and incomplete jobs marked failed."}
+
+    async def reset_stale_jobs(self, *, user_id: str, kg_id: str) -> dict[str, Any]:
+        _ = await self._knowledge_graph_service.get(user_id=user_id, kg_id=kg_id)
+        reset = await self._extraction_job_repository.reset_jobs_by_status(
+            knowledge_graph_id=kg_id,
+            from_status=ExtractionJobStatus.IN_PROGRESS,
+        )
+        await self._session.commit()
+        return {"success": True, "reset_count": reset}
+
+    async def reset_completed_jobs(self, *, user_id: str, kg_id: str) -> dict[str, Any]:
+        _ = await self._knowledge_graph_service.get(user_id=user_id, kg_id=kg_id)
+        reset = await self._extraction_job_repository.reset_jobs_by_status(
+            knowledge_graph_id=kg_id,
+            from_status=ExtractionJobStatus.COMPLETED,
+        )
+        await self._session.commit()
+        return {"success": True, "reset_count": reset}
+
+    async def reset_failed_jobs(self, *, user_id: str, kg_id: str) -> dict[str, Any]:
+        _ = await self._knowledge_graph_service.get(user_id=user_id, kg_id=kg_id)
+        reset = await self._extraction_job_repository.reset_jobs_by_status(
+            knowledge_graph_id=kg_id,
+            from_status=ExtractionJobStatus.FAILED,
+        )
+        await self._session.commit()
+        return {"success": True, "reset_count": reset}
+
+    async def reset_extraction(self, *, user_id: str, kg_id: str) -> dict[str, Any]:
+        _ = await self._knowledge_graph_service.get(user_id=user_id, kg_id=kg_id)
+        reset = await self._extraction_job_repository.reset_all_non_pending(knowledge_graph_id=kg_id)
+        await self._session.commit()
+        return {"success": True, "reset_count": reset}

--- a/src/api/infrastructure/migrations/versions/h1i2j3k4l5m6_add_extraction_jobs_tables.py
+++ b/src/api/infrastructure/migrations/versions/h1i2j3k4l5m6_add_extraction_jobs_tables.py
@@ -1,0 +1,105 @@
+"""Add extraction job config and materialized extraction jobs tables.
+
+Revision ID: h1i2j3k4l5m6
+Revises: g9h0i1j2k3l4
+Create Date: 2026-06-05
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "h1i2j3k4l5m6"
+down_revision: Union[str, Sequence[str], None] = "g9h0i1j2k3l4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "knowledge_graphs",
+        sa.Column("extraction_job_config", JSONB(), nullable=True),
+    )
+
+    op.create_table(
+        "extraction_jobs",
+        sa.Column("id", sa.String(length=26), primary_key=True),
+        sa.Column("knowledge_graph_id", sa.String(length=26), nullable=False),
+        sa.Column("job_id", sa.String(length=128), nullable=False),
+        sa.Column("job_set_name", sa.String(length=128), nullable=False),
+        sa.Column("strategy", sa.String(length=32), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("order_index", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("target_instances", JSONB(), nullable=False, server_default="[]"),
+        sa.Column("worker_id", sa.String(length=64), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("attempt", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("input_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("output_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("cache_read_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("cache_creation_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("cost_usd", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("entities_created", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("entities_modified", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("relationships_created", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint(
+            "knowledge_graph_id",
+            "job_id",
+            name="uq_extraction_jobs_kg_job_id",
+        ),
+    )
+    op.create_index("idx_extraction_jobs_kg_id", "extraction_jobs", ["knowledge_graph_id"])
+    op.create_index("idx_extraction_jobs_status", "extraction_jobs", ["status"])
+
+    op.create_table(
+        "extraction_runs",
+        sa.Column("id", sa.String(length=26), primary_key=True),
+        sa.Column("knowledge_graph_id", sa.String(length=26), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("worker_count", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("pause_requested", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("orchestrator_pid", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint(
+            "knowledge_graph_id",
+            name="uq_extraction_runs_kg_id",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("extraction_runs")
+    op.drop_index("idx_extraction_jobs_status", table_name="extraction_jobs")
+    op.drop_index("idx_extraction_jobs_kg_id", table_name="extraction_jobs")
+    op.drop_table("extraction_jobs")
+    op.drop_column("knowledge_graphs", "extraction_job_config")

--- a/src/api/management/domain/extraction_job_config.py
+++ b/src/api/management/domain/extraction_job_config.py
@@ -1,0 +1,130 @@
+"""Extraction job set configuration value objects."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class ExtractionJobSetStrategy(StrEnum):
+    """Batching strategy for an extraction job set."""
+
+    BY_INSTANCES = "by_instances"
+    BY_FILES = "by_files"
+
+
+@dataclass(frozen=True)
+class ExtractionJobSetDefinition:
+    """One job set describing how to batch extraction work."""
+
+    name: str
+    strategy: ExtractionJobSetStrategy
+    description: str | None = None
+    entity_type: str | None = None
+    instances_per_job: int | None = None
+    file_patterns: tuple[str, ...] = field(default_factory=tuple)
+    files_per_job: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.name or not self.name.strip():
+            raise ValueError("Job set name must not be empty")
+
+    def validation_errors(self, *, entity_instance_counts: dict[str, int]) -> tuple[str, ...]:
+        """Return human-readable validation errors for this job set."""
+        errors: list[str] = []
+        if self.strategy == ExtractionJobSetStrategy.BY_INSTANCES:
+            if not self.entity_type or not self.entity_type.strip():
+                errors.append(f"{self.name}: entity type is required for by_instances.")
+            else:
+                count = entity_instance_counts.get(self.entity_type, 0)
+                if count <= 0:
+                    errors.append(
+                        f"{self.name}: selected entity type '{self.entity_type}' has 0 instances."
+                    )
+            per_job = self.instances_per_job
+            if per_job is None or not isinstance(per_job, int) or per_job < 1:
+                errors.append(f"{self.name}: instances_per_job must be an integer >= 1.")
+            if not self.description or not self.description.strip():
+                errors.append(
+                    f"{self.name}: per-instance extraction description is required."
+                )
+        elif self.strategy == ExtractionJobSetStrategy.BY_FILES:
+            if not self.file_patterns:
+                errors.append(f"{self.name}: at least one file pattern is required for by_files.")
+            per_job = self.files_per_job
+            if per_job is None or not isinstance(per_job, int) or per_job < 1:
+                errors.append(f"{self.name}: files_per_job must be an integer >= 1.")
+        return tuple(errors)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "name": self.name,
+            "strategy": self.strategy.value,
+        }
+        if self.description:
+            payload["description"] = self.description
+        if self.strategy == ExtractionJobSetStrategy.BY_INSTANCES:
+            if self.entity_type:
+                payload["entity_type"] = self.entity_type
+            if self.instances_per_job is not None:
+                payload["instances_per_job"] = self.instances_per_job
+        else:
+            payload["file_patterns"] = list(self.file_patterns)
+            if self.files_per_job is not None:
+                payload["files_per_job"] = self.files_per_job
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ExtractionJobSetDefinition:
+        strategy = ExtractionJobSetStrategy(str(data["strategy"]))
+        raw_patterns = data.get("file_patterns") or []
+        return cls(
+            name=str(data["name"]),
+            strategy=strategy,
+            description=str(data["description"]).strip() if data.get("description") else None,
+            entity_type=str(data["entity_type"]).strip() if data.get("entity_type") else None,
+            instances_per_job=int(data["instances_per_job"])
+            if data.get("instances_per_job") is not None
+            else None,
+            file_patterns=tuple(str(pattern) for pattern in raw_patterns),
+            files_per_job=int(data["files_per_job"]) if data.get("files_per_job") is not None else None,
+        )
+
+
+@dataclass(frozen=True)
+class ExtractionJobConfigDocument:
+    """Persisted extraction job configuration for one knowledge graph."""
+
+    version: str
+    job_sets: tuple[ExtractionJobSetDefinition, ...] = field(default_factory=tuple)
+
+    def validation_errors(self, *, entity_instance_counts: dict[str, int]) -> tuple[str, ...]:
+        errors: list[str] = []
+        seen_names: set[str] = set()
+        for job_set in self.job_sets:
+            if job_set.name in seen_names:
+                errors.append(f"Duplicate job set name '{job_set.name}'.")
+            seen_names.add(job_set.name)
+            errors.extend(job_set.validation_errors(entity_instance_counts=entity_instance_counts))
+        return tuple(errors)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "job_sets": [job_set.to_dict() for job_set in self.job_sets],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> ExtractionJobConfigDocument | None:
+        if not data:
+            return None
+        raw_sets = data.get("job_sets") or []
+        return cls(
+            version=str(data.get("version") or "1.0"),
+            job_sets=tuple(ExtractionJobSetDefinition.from_dict(row) for row in raw_sets),
+        )
+
+    @classmethod
+    def empty(cls) -> ExtractionJobConfigDocument:
+        return cls(version="1.0", job_sets=())

--- a/src/api/management/infrastructure/models/knowledge_graph.py
+++ b/src/api/management/infrastructure/models/knowledge_graph.py
@@ -47,6 +47,9 @@ class KnowledgeGraphModel(Base, TimestampMixin):
         String(26), nullable=True
     )
     ontology: Mapped[dict | None] = mapped_column(JSONB, nullable=True, default=None)
+    extraction_job_config: Mapped[dict | None] = mapped_column(
+        JSONB, nullable=True, default=None
+    )
     maintenance_schedule: Mapped[dict | None] = mapped_column(
         JSONB, nullable=True, default=None
     )

--- a/src/api/management/infrastructure/repositories/knowledge_graph_repository.py
+++ b/src/api/management/infrastructure/repositories/knowledge_graph_repository.py
@@ -13,6 +13,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from management.domain.aggregates import KnowledgeGraph
+from management.domain.extraction_job_config import ExtractionJobConfigDocument
 from management.domain.value_objects import (
     KnowledgeGraphMaintenanceRunRecord,
     KnowledgeGraphMaintenanceSchedule,
@@ -245,6 +246,31 @@ class KnowledgeGraphRepository(IKnowledgeGraphRepository):
             return None
 
         return OntologyConfig.from_dict(model.ontology)
+
+    async def save_extraction_job_config(
+        self,
+        kg_id: str,
+        config: ExtractionJobConfigDocument,
+    ) -> None:
+        from sqlalchemy import update
+
+        stmt = (
+            update(KnowledgeGraphModel)
+            .where(KnowledgeGraphModel.id == kg_id)
+            .values(extraction_job_config=config.to_dict())
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        if result.rowcount == 0:  # type: ignore[attr-defined]
+            raise KnowledgeGraphNotFoundError(f"Knowledge graph '{kg_id}' not found")
+
+    async def get_extraction_job_config(self, kg_id: str) -> ExtractionJobConfigDocument | None:
+        stmt = select(KnowledgeGraphModel).where(KnowledgeGraphModel.id == kg_id)
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+        if model is None:
+            return None
+        return ExtractionJobConfigDocument.from_dict(model.extraction_job_config)
 
     def _to_domain(self, model: KnowledgeGraphModel) -> KnowledgeGraph:
         """Reconstitute aggregate from database state without generating events."""

--- a/src/api/management/presentation/knowledge_graphs/__init__.py
+++ b/src/api/management/presentation/knowledge_graphs/__init__.py
@@ -2,6 +2,15 @@
 
 from __future__ import annotations
 
-from management.presentation.knowledge_graphs.routes import router
+from fastapi import APIRouter
+
+from management.presentation.knowledge_graphs.extraction_jobs_routes import (
+    router as extraction_jobs_router,
+)
+from management.presentation.knowledge_graphs.routes import router as knowledge_graphs_router
+
+router = APIRouter()
+router.include_router(knowledge_graphs_router)
+router.include_router(extraction_jobs_router)
 
 __all__ = ["router"]

--- a/src/api/management/presentation/knowledge_graphs/extraction_jobs_routes.py
+++ b/src/api/management/presentation/knowledge_graphs/extraction_jobs_routes.py
@@ -1,0 +1,306 @@
+"""HTTP routes for extraction job configuration and execution."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from iam.application.value_objects import CurrentUser
+from iam.dependencies.user import get_current_user
+from infrastructure.management.extraction_jobs_service import ExtractionJobsService
+from infrastructure.management.extraction_jobs_dependencies import get_extraction_jobs_service
+from management.ports.exceptions import UnauthorizedError
+
+router = APIRouter(tags=["extraction-jobs"])
+
+
+class ExtractionJobSetModel(BaseModel):
+    name: str
+    strategy: str
+    description: str | None = None
+    entity_type: str | None = None
+    instances_per_job: int | None = None
+    file_patterns: list[str] = Field(default_factory=list)
+    files_per_job: int | None = None
+
+
+class ExtractionJobsDocumentRequest(BaseModel):
+    version: str = "1.0"
+    job_sets: list[ExtractionJobSetModel] = Field(default_factory=list)
+
+
+class ExtractionJobsDocumentResponse(BaseModel):
+    version: str
+    job_sets: list[dict[str, Any]]
+    entity_types: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class StartExtractionRequest(BaseModel):
+    workers: int = Field(default=2, ge=1, le=32)
+
+
+class ActionResponse(BaseModel):
+    success: bool
+    message: str | None = None
+    generated_jobs: int | None = None
+    reset_count: int | None = None
+
+
+def _handle_value_error(exc: ValueError) -> HTTPException:
+    return HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc))
+
+
+@router.get(
+    "/knowledge-graphs/{kg_id}/extraction-jobs",
+    response_model=ExtractionJobsDocumentResponse,
+)
+async def get_extraction_jobs(
+    kg_id: str,
+    service: Annotated[ExtractionJobsService, Depends(get_extraction_jobs_service)],
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+) -> ExtractionJobsDocumentResponse:
+    try:
+        payload = await service.get_extraction_jobs_document(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+        )
+    except UnauthorizedError:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+    if payload is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Knowledge graph not found")
+    return ExtractionJobsDocumentResponse.model_validate(payload)
+
+
+@router.put(
+    "/knowledge-graphs/{kg_id}/extraction-jobs",
+    response_model=ExtractionJobsDocumentResponse,
+)
+async def save_extraction_jobs(
+    kg_id: str,
+    body: ExtractionJobsDocumentRequest,
+    service: Annotated[ExtractionJobsService, Depends(get_extraction_jobs_service)],
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+) -> ExtractionJobsDocumentResponse:
+    try:
+        saved = await service.save_extraction_jobs_document(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+            payload=body.model_dump(),
+        )
+        regenerated = await service.regenerate_jobs(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+        )
+    except UnauthorizedError:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+    except ValueError as exc:
+        raise _handle_value_error(exc)
+    payload = await service.get_extraction_jobs_document(
+        user_id=current_user.user_id.value,
+        kg_id=kg_id,
+    )
+    if payload is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Knowledge graph not found")
+    payload["last_regenerated_jobs"] = regenerated.get("generated_jobs")
+    return ExtractionJobsDocumentResponse.model_validate(payload)
+
+
+@router.post(
+    "/knowledge-graphs/{kg_id}/extraction-jobs/regenerate",
+    response_model=ActionResponse,
+)
+async def regenerate_extraction_jobs(
+    kg_id: str,
+    service: Annotated[ExtractionJobsService, Depends(get_extraction_jobs_service)],
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+) -> ActionResponse:
+    try:
+        result = await service.regenerate_jobs(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+        )
+    except UnauthorizedError:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+    except ValueError as exc:
+        raise _handle_value_error(exc)
+    return ActionResponse(
+        success=True,
+        message=f"Regenerated {result.get('generated_jobs', 0)} jobs",
+        generated_jobs=int(result.get("generated_jobs") or 0),
+    )
+
+
+@router.get("/knowledge-graphs/{kg_id}/extraction-jobs/database-status")
+async def get_extraction_database_status(
+    kg_id: str,
+    service: Annotated[ExtractionJobsService, Depends(get_extraction_jobs_service)],
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+) -> dict[str, Any]:
+    try:
+        payload = await service.get_database_status(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+        )
+    except UnauthorizedError:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+    if payload is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Knowledge graph not found")
+    return payload
+
+
+@router.get("/knowledge-graphs/{kg_id}/extraction-jobs/run-state")
+async def get_extraction_run_state(
+    kg_id: str,
+    service: Annotated[ExtractionJobsService, Depends(get_extraction_jobs_service)],
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+) -> dict[str, Any]:
+    try:
+        payload = await service.get_extraction_run_state(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+        )
+    except UnauthorizedError:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+    if payload is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Knowledge graph not found")
+    return payload
+
+
+@router.get("/knowledge-graphs/{kg_id}/extraction-jobs/plan-summary")
+async def get_extraction_plan_summary(
+    kg_id: str,
+    service: Annotated[ExtractionJobsService, Depends(get_extraction_jobs_service)],
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+) -> dict[str, Any]:
+    try:
+        payload = await service.get_extraction_plan_summary(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+        )
+    except UnauthorizedError:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+    if payload is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Knowledge graph not found")
+    return payload
+
+
+@router.post("/knowledge-graphs/{kg_id}/extraction-jobs/start", response_model=ActionResponse)
+async def start_extraction(
+    kg_id: str,
+    body: StartExtractionRequest,
+    service: Annotated[ExtractionJobsService, Depends(get_extraction_jobs_service)],
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+) -> ActionResponse:
+    try:
+        result = await service.start_extraction(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+            workers=body.workers,
+        )
+    except UnauthorizedError:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+    except ValueError as exc:
+        raise _handle_value_error(exc)
+    return ActionResponse(success=True, message=result.get("message"))
+
+
+@router.post("/knowledge-graphs/{kg_id}/extraction-jobs/pause", response_model=ActionResponse)
+async def pause_extraction(
+    kg_id: str,
+    service: Annotated[ExtractionJobsService, Depends(get_extraction_jobs_service)],
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+) -> ActionResponse:
+    try:
+        result = await service.pause_extraction(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+        )
+    except UnauthorizedError:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+    except ValueError as exc:
+        raise _handle_value_error(exc)
+    return ActionResponse(success=True, message=result.get("message"))
+
+
+@router.post("/knowledge-graphs/{kg_id}/extraction-jobs/halt", response_model=ActionResponse)
+async def halt_extraction(
+    kg_id: str,
+    service: Annotated[ExtractionJobsService, Depends(get_extraction_jobs_service)],
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+) -> ActionResponse:
+    try:
+        result = await service.halt_extraction(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+        )
+    except UnauthorizedError:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+    except ValueError as exc:
+        raise _handle_value_error(exc)
+    return ActionResponse(success=True, message=result.get("message"))
+
+
+@router.post("/knowledge-graphs/{kg_id}/extraction-jobs/reset-stale", response_model=ActionResponse)
+async def reset_stale_jobs(
+    kg_id: str,
+    service: Annotated[ExtractionJobsService, Depends(get_extraction_jobs_service)],
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+) -> ActionResponse:
+    try:
+        result = await service.reset_stale_jobs(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+        )
+    except UnauthorizedError:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+    return ActionResponse(success=True, reset_count=int(result.get("reset_count") or 0))
+
+
+@router.post("/knowledge-graphs/{kg_id}/extraction-jobs/reset-completed", response_model=ActionResponse)
+async def reset_completed_jobs(
+    kg_id: str,
+    service: Annotated[ExtractionJobsService, Depends(get_extraction_jobs_service)],
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+) -> ActionResponse:
+    try:
+        result = await service.reset_completed_jobs(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+        )
+    except UnauthorizedError:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+    return ActionResponse(success=True, reset_count=int(result.get("reset_count") or 0))
+
+
+@router.post("/knowledge-graphs/{kg_id}/extraction-jobs/reset-failed", response_model=ActionResponse)
+async def reset_failed_jobs(
+    kg_id: str,
+    service: Annotated[ExtractionJobsService, Depends(get_extraction_jobs_service)],
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+) -> ActionResponse:
+    try:
+        result = await service.reset_failed_jobs(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+        )
+    except UnauthorizedError:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+    return ActionResponse(success=True, reset_count=int(result.get("reset_count") or 0))
+
+
+@router.post("/knowledge-graphs/{kg_id}/extraction-jobs/reset", response_model=ActionResponse)
+async def reset_extraction_jobs(
+    kg_id: str,
+    service: Annotated[ExtractionJobsService, Depends(get_extraction_jobs_service)],
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+) -> ActionResponse:
+    try:
+        result = await service.reset_extraction(
+            user_id=current_user.user_id.value,
+            kg_id=kg_id,
+        )
+    except UnauthorizedError:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+    return ActionResponse(success=True, reset_count=int(result.get("reset_count") or 0))

--- a/src/api/tests/unit/infrastructure/management/test_extraction_job_materializer.py
+++ b/src/api/tests/unit/infrastructure/management/test_extraction_job_materializer.py
@@ -1,0 +1,54 @@
+"""Unit tests for extraction job materialization."""
+
+from infrastructure.management.extraction_job_materializer import materialize_jobs_from_config
+from management.domain.extraction_job_config import (
+    ExtractionJobConfigDocument,
+    ExtractionJobSetDefinition,
+    ExtractionJobSetStrategy,
+)
+
+
+def test_materialize_by_instances_batches_graph_nodes() -> None:
+    config = ExtractionJobConfigDocument(
+        version="1.0",
+        job_sets=(
+            ExtractionJobSetDefinition(
+                name="features",
+                strategy=ExtractionJobSetStrategy.BY_INSTANCES,
+                entity_type="Feature",
+                instances_per_job=2,
+                description="Extract acceptance criteria for each feature instance.",
+            ),
+        ),
+    )
+    graph_data = {
+        "nodes": [
+            {
+                "knowledge_graph_id": "kg-1",
+                "type": "Feature",
+                "slug": "feature-a",
+            },
+            {
+                "knowledge_graph_id": "kg-1",
+                "type": "Feature",
+                "slug": "feature-b",
+            },
+            {
+                "knowledge_graph_id": "kg-1",
+                "type": "Feature",
+                "slug": "feature-c",
+            },
+        ],
+        "edges": [],
+    }
+
+    jobs = materialize_jobs_from_config(
+        knowledge_graph_id="kg-1",
+        config=config,
+        graph_data=graph_data,
+    )
+
+    assert len(jobs) == 2
+    assert jobs[0].target_instances[0].slug == "feature-a"
+    assert jobs[0].description.startswith("Extract acceptance")
+    assert all(job.status.value == "pending" for job in jobs)

--- a/src/api/tests/unit/management/domain/test_extraction_job_config.py
+++ b/src/api/tests/unit/management/domain/test_extraction_job_config.py
@@ -1,0 +1,42 @@
+"""Unit tests for extraction job set configuration."""
+
+from management.domain.extraction_job_config import (
+    ExtractionJobConfigDocument,
+    ExtractionJobSetDefinition,
+    ExtractionJobSetStrategy,
+)
+
+
+def test_by_instances_requires_description_and_entity_type() -> None:
+    job_set = ExtractionJobSetDefinition(
+        name="component_tests",
+        strategy=ExtractionJobSetStrategy.BY_INSTANCES,
+        entity_type="ComponentTest",
+        instances_per_job=4,
+    )
+    errors = job_set.validation_errors(entity_instance_counts={"ComponentTest": 10})
+    assert any("description" in err.lower() for err in errors)
+
+
+def test_document_rejects_duplicate_job_set_names() -> None:
+    document = ExtractionJobConfigDocument(
+        version="1.0",
+        job_sets=(
+            ExtractionJobSetDefinition(
+                name="set_a",
+                strategy=ExtractionJobSetStrategy.BY_INSTANCES,
+                entity_type="Feature",
+                instances_per_job=2,
+                description="Extract feature details",
+            ),
+            ExtractionJobSetDefinition(
+                name="set_a",
+                strategy=ExtractionJobSetStrategy.BY_INSTANCES,
+                entity_type="Feature",
+                instances_per_job=2,
+                description="Duplicate name",
+            ),
+        ),
+    )
+    errors = document.validation_errors(entity_instance_counts={"Feature": 3})
+    assert any("Duplicate" in err for err in errors)

--- a/src/dev-ui/app/components/graph-management/GraphExtractionJobSetsPanel.vue
+++ b/src/dev-ui/app/components/graph-management/GraphExtractionJobSetsPanel.vue
@@ -1,0 +1,319 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { toast } from 'vue-sonner'
+import { Loader2, Save, Layers, FolderSearch, Network, Sparkles } from 'lucide-vue-next'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+
+const props = withDefaults(
+  defineProps<{
+    kgId: string
+    reloadNonce?: number
+    embedded?: boolean
+  }>(),
+  { reloadNonce: 0, embedded: true },
+)
+
+const emit = defineEmits<{
+  saved: []
+}>()
+
+const { apiFetch } = useApiClient()
+
+const inputClass =
+  'flex h-10 w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40'
+
+interface ExtractionJobSet {
+  name: string
+  description?: string
+  strategy: 'by_instances' | 'by_files'
+  entity_type?: string
+  instances_per_job?: number
+  file_patterns?: string[]
+  files_per_job?: number
+}
+
+interface EntityTypeOption {
+  name: string
+  instance_count: number
+}
+
+interface ExtractionJobsDocument {
+  version: string
+  job_sets: ExtractionJobSet[]
+}
+
+interface ExtractionJobsGetResponse extends ExtractionJobsDocument {
+  entity_types?: EntityTypeOption[]
+}
+
+const loading = ref(true)
+const saving = ref(false)
+const doc = ref<ExtractionJobsDocument | null>(null)
+const entityTypeOptions = ref<EntityTypeOption[]>([])
+
+function cloneDoc(d: ExtractionJobsDocument): ExtractionJobsDocument {
+  return JSON.parse(JSON.stringify(d)) as ExtractionJobsDocument
+}
+
+async function load() {
+  loading.value = true
+  try {
+    const data = await apiFetch<ExtractionJobsGetResponse>(
+      `/management/knowledge-graphs/${encodeURIComponent(props.kgId)}/extraction-jobs`,
+    )
+    entityTypeOptions.value = Array.isArray(data.entity_types)
+      ? [...data.entity_types].sort((a, b) => a.name.localeCompare(b.name))
+      : []
+    doc.value = cloneDoc({
+      version: data.version || '1.0',
+      job_sets: Array.isArray(data.job_sets) ? data.job_sets : [],
+    })
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e)
+    toast.error('Failed to load extraction jobs', { description: msg })
+    doc.value = { version: '1.0', job_sets: [] }
+  } finally {
+    loading.value = false
+  }
+}
+
+function onStrategyChange(js: ExtractionJobSet, strategy: 'by_instances' | 'by_files') {
+  if (js.strategy === strategy) return
+  js.strategy = strategy
+  if (strategy === 'by_instances') {
+    delete js.file_patterns
+    delete js.files_per_job
+    if (!js.entity_type?.trim()) js.entity_type = entityTypeOptions.value[0]?.name ?? ''
+    if (js.instances_per_job === undefined) js.instances_per_job = 4
+  } else {
+    delete js.entity_type
+    delete js.instances_per_job
+    if (!js.file_patterns?.length) js.file_patterns = ['**/*']
+    if (js.files_per_job === undefined) js.files_per_job = 10
+  }
+}
+
+function addJobSet() {
+  if (!doc.value) return
+  const index = doc.value.job_sets.length + 1
+  doc.value.job_sets.push({
+    name: `job_set_${index}`,
+    strategy: 'by_instances',
+    entity_type: entityTypeOptions.value[0]?.name ?? '',
+    instances_per_job: 4,
+    description: '',
+  })
+}
+
+function buildPayload(): ExtractionJobsDocument {
+  if (!doc.value) throw new Error('No document loaded')
+  return {
+    version: doc.value.version || '1.0',
+    job_sets: doc.value.job_sets.map((js) => {
+      const base = { name: js.name, strategy: js.strategy } as ExtractionJobSet
+      if (typeof js.description === 'string' && js.description.trim()) {
+        base.description = js.description.trim()
+      }
+      if (js.strategy === 'by_instances') {
+        base.entity_type = js.entity_type ?? ''
+        const n = Number(js.instances_per_job)
+        if (Number.isFinite(n) && n >= 1) base.instances_per_job = Math.floor(n)
+        return base
+      }
+      base.file_patterns = Array.isArray(js.file_patterns) ? [...js.file_patterns] : []
+      const f = Number(js.files_per_job)
+      if (Number.isFinite(f) && f >= 1) base.files_per_job = Math.floor(f)
+      return base
+    }),
+  }
+}
+
+function getEntityTypeInstanceCount(entityType?: string): number | null {
+  if (!entityType?.trim()) return null
+  const hit = entityTypeOptions.value.find((x) => x.name === entityType)
+  return hit ? hit.instance_count : null
+}
+
+function jobSetErrors(js: ExtractionJobSet): string[] {
+  const errs: string[] = []
+  if (js.strategy === 'by_instances') {
+    if (!js.entity_type?.trim()) errs.push('Entity type is required for by_instances.')
+    if (getEntityTypeInstanceCount(js.entity_type) === 0) {
+      errs.push('Selected entity type has 0 instances.')
+    }
+    const n = Number(js.instances_per_job)
+    if (!Number.isInteger(n) || n < 1) errs.push('instances_per_job must be an integer greater than 0.')
+    if (!js.description?.trim()) errs.push('Per-instance extraction description is required.')
+  }
+  return errs
+}
+
+function projectedJobCount(js: ExtractionJobSet): number | null {
+  if (js.strategy !== 'by_instances') return null
+  const total = getEntityTypeInstanceCount(js.entity_type)
+  const perJob = Number(js.instances_per_job)
+  if (total === null || !Number.isInteger(perJob) || perJob < 1) return null
+  if (total <= 0) return 0
+  return Math.ceil(total / perJob)
+}
+
+const hasValidationErrors = computed(() => {
+  if (!doc.value) return false
+  return doc.value.job_sets.some((js) => jobSetErrors(js).length > 0)
+})
+
+async function save() {
+  if (!doc.value) return
+  saving.value = true
+  try {
+    await apiFetch(
+      `/management/knowledge-graphs/${encodeURIComponent(props.kgId)}/extraction-jobs`,
+      { method: 'PUT', body: buildPayload() },
+    )
+    toast.success('Saved job sets and regenerated pending jobs')
+    emit('saved')
+    await load()
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e)
+    toast.error('Save failed', { description: msg })
+  } finally {
+    saving.value = false
+  }
+}
+
+watch(
+  () => [props.kgId, props.reloadNonce] as const,
+  () => { void load() },
+  { immediate: true },
+)
+
+defineExpose({ refresh: load })
+</script>
+
+<template>
+  <div class="space-y-4">
+    <div class="flex flex-wrap items-start gap-3 border-b pb-3">
+      <div class="flex size-9 shrink-0 items-center justify-center rounded-full bg-primary font-bold text-primary-foreground">
+        <Layers class="size-4" />
+      </div>
+      <div>
+        <h2 class="text-lg font-semibold tracking-tight">Extraction Job — Job Sets</h2>
+        <p class="text-xs text-muted-foreground">
+          Define how extraction work is batched. Each job set runs to completion before the next begins.
+          Use per-instance descriptions to guide extraction agents (no separate extraction plan document).
+        </p>
+      </div>
+    </div>
+
+    <div v-if="loading" class="flex items-center justify-center py-12">
+      <Loader2 class="size-8 animate-spin text-muted-foreground" />
+    </div>
+
+    <template v-else-if="doc">
+      <Card>
+        <CardHeader>
+          <CardTitle class="flex items-center gap-2 text-base">
+            <Sparkles class="size-4 text-primary" />
+            Job sets
+          </CardTitle>
+          <CardDescription>
+            Author with the assistant above or edit directly. Save regenerates pending jobs from live graph instances.
+          </CardDescription>
+        </CardHeader>
+        <CardContent class="space-y-6">
+          <div v-if="doc.job_sets.length === 0" class="text-sm text-muted-foreground">
+            No job sets yet. Add one below or ask the assistant to define extraction batches.
+          </div>
+
+          <div
+            v-for="(js, idx) in doc.job_sets"
+            :key="`${js.name}-${idx}`"
+            class="space-y-4 rounded-xl border border-cyan-500/30 bg-gradient-to-br from-cyan-500/10 via-card to-card p-4 md:p-5"
+          >
+            <div class="flex flex-wrap items-start justify-between gap-3">
+              <div class="space-y-1">
+                <input v-model="js.name" :class="inputClass" placeholder="Job set name" />
+              </div>
+              <Badge variant="outline" class="text-[11px]">#{{ idx + 1 }}</Badge>
+            </div>
+
+            <div class="grid gap-2 sm:grid-cols-2">
+              <button
+                type="button"
+                class="flex items-start gap-2 rounded-lg border px-3 py-2 text-left text-sm"
+                :class="js.strategy === 'by_instances' ? 'border-primary/40 bg-primary/15' : 'border-border'"
+                @click="onStrategyChange(js, 'by_instances')"
+              >
+                <Network class="mt-0.5 size-4 shrink-0 text-cyan-500" />
+                <span>
+                  <span class="block font-medium">By instances</span>
+                  <span class="block text-[11px] text-muted-foreground">Enrich known entities</span>
+                </span>
+              </button>
+              <button
+                type="button"
+                class="flex items-start gap-2 rounded-lg border px-3 py-2 text-left text-sm"
+                :class="js.strategy === 'by_files' ? 'border-primary/40 bg-primary/15' : 'border-border'"
+                @click="onStrategyChange(js, 'by_files')"
+              >
+                <FolderSearch class="mt-0.5 size-4 shrink-0 text-violet-500" />
+                <span>
+                  <span class="block font-medium">By files</span>
+                  <span class="block text-[11px] text-muted-foreground">Discover from file patterns</span>
+                </span>
+              </button>
+            </div>
+
+            <template v-if="js.strategy === 'by_instances'">
+              <div class="space-y-1.5">
+                <label class="text-xs font-medium">Entity type</label>
+                <select v-model="js.entity_type" :class="inputClass">
+                  <option value="" disabled>Select entity type</option>
+                  <option v-for="opt in entityTypeOptions" :key="opt.name" :value="opt.name">
+                    {{ opt.name }} ({{ opt.instance_count }} instances)
+                  </option>
+                </select>
+              </div>
+              <div class="grid gap-3 sm:grid-cols-2">
+                <div class="space-y-1.5">
+                  <label class="text-xs font-medium">Instances per job</label>
+                  <input v-model.number="js.instances_per_job" type="number" min="1" :class="inputClass" />
+                </div>
+                <div class="space-y-1.5">
+                  <label class="text-xs font-medium">Projected jobs</label>
+                  <div class="flex h-10 items-center rounded-lg border border-dashed bg-muted/30 px-3 font-mono text-sm">
+                    {{ projectedJobCount(js) ?? '—' }}
+                  </div>
+                </div>
+              </div>
+            </template>
+
+            <div class="space-y-1.5">
+              <label class="text-xs font-medium">Per-instance extraction description</label>
+              <textarea
+                v-model="js.description"
+                rows="3"
+                class="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
+                placeholder="Describe what to extract for each instance in this job set."
+              />
+            </div>
+
+            <ul v-if="jobSetErrors(js).length" class="list-disc space-y-1 pl-4 text-xs text-destructive">
+              <li v-for="(err, ei) in jobSetErrors(js)" :key="`${idx}-err-${ei}`">{{ err }}</li>
+            </ul>
+          </div>
+        </CardContent>
+        <CardFooter class="flex flex-wrap gap-2">
+          <Button size="sm" variant="outline" @click="addJobSet">Add job set</Button>
+          <Button size="sm" :disabled="saving || hasValidationErrors" @click="save">
+            <Loader2 v-if="saving" class="mr-1.5 size-3.5 animate-spin" />
+            <Save v-else class="mr-1.5 size-3.5" />
+            Save job sets
+          </Button>
+        </CardFooter>
+      </Card>
+    </template>
+  </div>
+</template>

--- a/src/dev-ui/app/components/graph-management/GraphExtractionJobsWorkspace.vue
+++ b/src/dev-ui/app/components/graph-management/GraphExtractionJobsWorkspace.vue
@@ -1,0 +1,507 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { toast } from 'vue-sonner'
+import {
+  Loader2,
+  RefreshCw,
+  Play,
+  Settings,
+  ClipboardList,
+  AlertCircle,
+} from 'lucide-vue-next'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Separator } from '@/components/ui/separator'
+import GraphExtractionJobSetsPanel from '@/components/graph-management/GraphExtractionJobSetsPanel.vue'
+import GraphDesignEntitiesPanel from '@/components/graph-management/GraphDesignEntitiesPanel.vue'
+import GraphDesignRelationshipsPanel from '@/components/graph-management/GraphDesignRelationshipsPanel.vue'
+
+const props = defineProps<{
+  kgId: string
+  reloadNonce?: number
+}>()
+
+const { apiFetch } = useApiClient()
+
+type OntologyTab = 'entities' | 'relationships'
+
+interface DbStatus {
+  jobsByStatus: Record<string, number>
+  jobsBySet?: Record<string, { pending: number; in_progress: number; completed: number; failed: number; total: number }>
+  avgCompletedJobSeconds?: number | null
+  totalInputTokens: number
+  totalOutputTokens: number
+  totalCacheReadTokens: number
+  totalCacheCreationTokens: number
+  totalCostUsd: number
+  recentJobs: Array<{
+    jobId: string
+    jobSet: string
+    status: string
+    workerId: string | null
+    startedAt: string | null
+    completedAt: string | null
+    inputTokens: number
+    outputTokens: number
+    writeOps: number
+    assistantPreview: string | null
+  }>
+  activeWorkers?: Array<{
+    workerId: string
+    jobId: string
+    jobSet: string
+    strategy: string
+    instanceCount: number
+    startedAt: string | null
+  }>
+}
+
+interface ExtractionRunState {
+  live: boolean
+  status: string
+  workerCount: number
+  pauseRequested: boolean
+}
+
+interface PlanSummary {
+  job_sets: Array<{
+    name: string
+    strategy: string
+    entity_type?: string
+    instances_per_job?: number
+    projected_jobs?: number | null
+  }>
+}
+
+const selectedOntologyTab = ref<OntologyTab>('entities')
+const jobSetsReloadNonce = ref(0)
+const dbStatus = ref<DbStatus | null>(null)
+const dbLoading = ref(true)
+const dbError = ref<string | null>(null)
+const extractionRunState = ref<ExtractionRunState | null>(null)
+const planSummary = ref<PlanSummary | null>(null)
+const workers = ref(2)
+const startingExtraction = ref(false)
+const pausingExtraction = ref(false)
+const killingExtraction = ref(false)
+const regeneratingJobs = ref(false)
+const resettingRunning = ref(false)
+const resettingCompleted = ref(false)
+const resettingFailed = ref(false)
+const resettingAll = ref(false)
+const optimisticLiveUntilMs = ref<number | null>(null)
+const nowMs = ref(Date.now())
+
+let autoRefreshInterval: ReturnType<typeof setInterval> | null = null
+let clockInterval: ReturnType<typeof setInterval> | null = null
+
+const basePath = computed(() => `/management/knowledge-graphs/${encodeURIComponent(props.kgId)}/extraction-jobs`)
+
+async function loadDatabaseStatus() {
+  dbLoading.value = true
+  dbError.value = null
+  try {
+    dbStatus.value = await apiFetch<DbStatus>(`${basePath.value}/database-status`)
+  } catch (e: unknown) {
+    dbError.value = e instanceof Error ? e.message : 'Failed to load status'
+  } finally {
+    dbLoading.value = false
+  }
+}
+
+async function loadExtractionRunState() {
+  extractionRunState.value = await apiFetch<ExtractionRunState>(`${basePath.value}/run-state`)
+}
+
+async function loadPlanSummary() {
+  planSummary.value = await apiFetch<PlanSummary>(`${basePath.value}/plan-summary`)
+}
+
+async function refreshAll() {
+  await Promise.all([loadDatabaseStatus(), loadExtractionRunState(), loadPlanSummary()])
+}
+
+const workerCount = computed(() => Math.max(1, Math.floor(Number(workers.value) || 1)))
+const pendingJobsCount = computed(() => Number(dbStatus.value?.jobsByStatus?.pending || 0))
+const inProgressJobsCount = computed(() => Number(dbStatus.value?.jobsByStatus?.in_progress || 0))
+const completedJobsCount = computed(() => Number(dbStatus.value?.jobsByStatus?.completed || 0))
+const failedJobsCount = computed(() => Number(dbStatus.value?.jobsByStatus?.failed || 0))
+const remainingJobsCount = computed(() => pendingJobsCount.value + inProgressJobsCount.value)
+const materializedJobsTotal = computed(
+  () => pendingJobsCount.value + inProgressJobsCount.value + failedJobsCount.value + completedJobsCount.value,
+)
+const extractionRunLive = computed(() => {
+  if (optimisticLiveUntilMs.value && nowMs.value < optimisticLiveUntilMs.value) return true
+  return Boolean(extractionRunState.value?.live)
+})
+const hasRunningJobs = computed(() => inProgressJobsCount.value > 0)
+const extractionProgressPercent = computed(() => {
+  const total = materializedJobsTotal.value
+  if (total <= 0) return 0
+  return Math.round(((completedJobsCount.value + failedJobsCount.value) / total) * 100)
+})
+const plannedKnownTotalJobs = computed(() => {
+  const sets = planSummary.value?.job_sets || []
+  return sets.reduce((sum, set) => sum + (Number(set.projected_jobs) || 0), 0)
+})
+const plannedVsMaterializedMismatch = computed(() => {
+  const planned = plannedKnownTotalJobs.value
+  if (planned <= 0) return false
+  return planned !== materializedJobsTotal.value
+})
+
+async function startExtraction() {
+  startingExtraction.value = true
+  optimisticLiveUntilMs.value = Date.now() + 30000
+  try {
+    const res = await apiFetch<{ message?: string }>(`${basePath.value}/start`, {
+      method: 'POST',
+      body: { workers: workerCount.value },
+    })
+    toast.success('Extraction started', { description: res.message })
+    startAutoRefresh()
+    await refreshAll()
+  } catch (e: unknown) {
+    optimisticLiveUntilMs.value = null
+    toast.error('Failed to start extraction', {
+      description: e instanceof Error ? e.message : 'Request failed',
+    })
+  } finally {
+    startingExtraction.value = false
+  }
+}
+
+async function pauseExtraction() {
+  pausingExtraction.value = true
+  try {
+    const res = await apiFetch<{ message?: string }>(`${basePath.value}/pause`, { method: 'POST' })
+    toast.success('Pause requested', { description: res.message })
+    await refreshAll()
+  } catch (e: unknown) {
+    toast.error('Failed to pause extraction', {
+      description: e instanceof Error ? e.message : 'Request failed',
+    })
+  } finally {
+    pausingExtraction.value = false
+  }
+}
+
+async function killExtraction() {
+  killingExtraction.value = true
+  try {
+    const res = await apiFetch<{ message?: string }>(`${basePath.value}/halt`, { method: 'POST' })
+    toast.success('Extraction killed', { description: res.message })
+    optimisticLiveUntilMs.value = null
+    stopAutoRefresh()
+    await refreshAll()
+  } catch (e: unknown) {
+    toast.error('Failed to kill extraction', {
+      description: e instanceof Error ? e.message : 'Request failed',
+    })
+  } finally {
+    killingExtraction.value = false
+  }
+}
+
+async function regenerateJobs() {
+  regeneratingJobs.value = true
+  try {
+    const res = await apiFetch<{ generated_jobs?: number; message?: string }>(
+      `${basePath.value}/regenerate`,
+      { method: 'POST' },
+    )
+    toast.success('Jobs regenerated', { description: res.message })
+    await refreshAll()
+  } catch (e: unknown) {
+    toast.error('Regenerate failed', {
+      description: e instanceof Error ? e.message : 'Request failed',
+    })
+  } finally {
+    regeneratingJobs.value = false
+  }
+}
+
+async function resetByKind(kind: 'stale' | 'completed' | 'failed' | 'all') {
+  const map = {
+    stale: { ref: resettingRunning, path: 'reset-stale' },
+    completed: { ref: resettingCompleted, path: 'reset-completed' },
+    failed: { ref: resettingFailed, path: 'reset-failed' },
+    all: { ref: resettingAll, path: 'reset' },
+  } as const
+  map[kind].ref.value = true
+  try {
+    await apiFetch(`${basePath.value}/${map[kind].path}`, { method: 'POST' })
+    toast.success('Jobs reset')
+    await refreshAll()
+  } catch (e: unknown) {
+    toast.error('Reset failed', { description: e instanceof Error ? e.message : 'Request failed' })
+  } finally {
+    map[kind].ref.value = false
+  }
+}
+
+function startAutoRefresh() {
+  if (autoRefreshInterval) return
+  autoRefreshInterval = setInterval(() => { void refreshAll() }, 1500)
+}
+
+function stopAutoRefresh() {
+  if (!autoRefreshInterval) return
+  clearInterval(autoRefreshInterval)
+  autoRefreshInterval = null
+}
+
+function onJobSetsSaved() {
+  jobSetsReloadNonce.value += 1
+  void refreshAll()
+}
+
+watch(
+  () => extractionRunLive.value || hasRunningJobs.value,
+  (active) => {
+    if (active) startAutoRefresh()
+    else if (!optimisticLiveUntilMs.value) stopAutoRefresh()
+  },
+)
+
+watch(
+  () => props.reloadNonce,
+  () => { void refreshAll() },
+)
+
+onMounted(() => {
+  void refreshAll()
+  clockInterval = setInterval(() => { nowMs.value = Date.now() }, 1000)
+})
+
+onUnmounted(() => {
+  stopAutoRefresh()
+  if (clockInterval) clearInterval(clockInterval)
+})
+</script>
+
+<template>
+  <div class="space-y-6">
+    <div class="grid gap-6 lg:grid-cols-2 lg:items-start">
+      <Card>
+        <CardContent class="p-4">
+          <GraphExtractionJobSetsPanel
+            :kg-id="kgId"
+            :reload-nonce="jobSetsReloadNonce + (reloadNonce ?? 0)"
+            embedded
+            @saved="onJobSetsSaved"
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader class="pb-2">
+          <CardTitle class="text-base">Ontology Schema</CardTitle>
+          <CardDescription>Live entity and relationship types with expandable instances.</CardDescription>
+          <div class="flex gap-2 pt-2">
+            <Button
+              size="sm"
+              :variant="selectedOntologyTab === 'entities' ? 'default' : 'outline'"
+              @click="selectedOntologyTab = 'entities'"
+            >
+              Entities
+            </Button>
+            <Button
+              size="sm"
+              :variant="selectedOntologyTab === 'relationships' ? 'default' : 'outline'"
+              @click="selectedOntologyTab = 'relationships'"
+            >
+              Relationships
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent class="max-h-[min(70dvh,720px)] overflow-y-auto">
+          <GraphDesignEntitiesPanel
+            v-if="selectedOntologyTab === 'entities'"
+            :kg-id="kgId"
+            :reload-nonce="reloadNonce ?? 0"
+            embedded
+          />
+          <GraphDesignRelationshipsPanel
+            v-else
+            :kg-id="kgId"
+            :reload-nonce="reloadNonce ?? 0"
+            embedded
+          />
+        </CardContent>
+      </Card>
+    </div>
+
+    <Card>
+      <CardHeader>
+        <CardTitle class="flex items-center gap-2 text-base">
+          <Play class="size-4" />
+          Run extraction
+        </CardTitle>
+        <CardDescription>
+          Launch parallel extraction workers. Each worker processes one pending job at a time using the job set description.
+        </CardDescription>
+      </CardHeader>
+      <CardContent class="space-y-4">
+        <div class="flex flex-wrap items-end gap-4">
+          <div class="space-y-1.5">
+            <label class="text-xs font-medium text-muted-foreground">Worker concurrency</label>
+            <input
+              v-model.number="workers"
+              type="number"
+              min="1"
+              max="32"
+              class="h-10 w-24 rounded-lg border bg-background px-3 text-sm"
+            />
+          </div>
+          <div class="flex flex-wrap gap-2">
+            <Button size="sm" :disabled="startingExtraction" @click="startExtraction">
+              <Loader2 v-if="startingExtraction" class="mr-1.5 size-3.5 animate-spin" />
+              Start
+            </Button>
+            <Button size="sm" variant="outline" :disabled="pausingExtraction" @click="pauseExtraction">
+              Pause
+            </Button>
+            <Button size="sm" variant="destructive" :disabled="killingExtraction" @click="killExtraction">
+              Kill
+            </Button>
+            <Button size="sm" variant="ghost" @click="refreshAll">
+              <RefreshCw class="mr-1.5 size-3.5" />
+              Refresh
+            </Button>
+          </div>
+        </div>
+
+        <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4 text-sm">
+          <div class="rounded-lg border bg-muted/30 p-3">
+            <p class="text-xs text-muted-foreground">Remaining jobs</p>
+            <p class="text-lg font-semibold">{{ remainingJobsCount }}</p>
+          </div>
+          <div class="rounded-lg border bg-muted/30 p-3">
+            <p class="text-xs text-muted-foreground">Materialized jobs</p>
+            <p class="text-lg font-semibold">{{ materializedJobsTotal }}</p>
+          </div>
+          <div class="rounded-lg border bg-muted/30 p-3">
+            <p class="text-xs text-muted-foreground">Planned (from job sets)</p>
+            <p class="text-lg font-semibold">{{ plannedKnownTotalJobs || '—' }}</p>
+          </div>
+          <div class="rounded-lg border bg-muted/30 p-3">
+            <p class="text-xs text-muted-foreground">Progress</p>
+            <p class="text-lg font-semibold">{{ extractionProgressPercent }}%</p>
+          </div>
+        </div>
+
+        <div v-if="extractionRunLive" class="rounded-lg border border-primary/30 bg-primary/5 p-3 text-xs">
+          Extraction run is live — status refreshes every 1.5s.
+        </div>
+
+        <div v-if="plannedVsMaterializedMismatch" class="flex items-start gap-2 rounded-lg border border-amber-500/40 bg-amber-500/5 p-3 text-xs">
+          <AlertCircle class="mt-0.5 size-4 shrink-0 text-amber-600" />
+          <div>
+            Planned job count ({{ plannedKnownTotalJobs }}) differs from materialized total ({{ materializedJobsTotal }}).
+            <Button size="sm" variant="link" class="h-auto p-0 text-xs" :disabled="regeneratingJobs" @click="regenerateJobs">
+              Regenerate jobs
+            </Button>
+          </div>
+        </div>
+
+        <div v-if="(dbStatus?.activeWorkers?.length || 0) > 0" class="space-y-2">
+          <p class="text-xs font-medium text-muted-foreground">Active workers</p>
+          <div class="flex flex-wrap gap-2">
+            <Badge v-for="worker in dbStatus?.activeWorkers" :key="worker.workerId" variant="outline" class="font-mono text-[10px]">
+              {{ worker.workerId }} → {{ worker.jobId }}
+            </Badge>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+
+    <Card>
+      <CardHeader>
+        <CardTitle class="flex items-center gap-2 text-base">
+          <ClipboardList class="size-4" />
+          Job Status
+        </CardTitle>
+        <CardDescription>Aggregate job metrics and maintenance actions.</CardDescription>
+      </CardHeader>
+      <CardContent class="space-y-4">
+        <div v-if="dbLoading" class="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 class="size-4 animate-spin" />
+          Loading job status...
+        </div>
+        <div v-else-if="dbError" class="text-sm text-destructive">{{ dbError }}</div>
+        <template v-else-if="dbStatus">
+          <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+            <div class="rounded-lg border p-3 text-center">
+              <p class="text-xs text-muted-foreground">Ready</p>
+              <p class="text-xl font-semibold">{{ pendingJobsCount }}</p>
+            </div>
+            <div class="rounded-lg border p-3 text-center">
+              <p class="text-xs text-muted-foreground">Running</p>
+              <p class="text-xl font-semibold">{{ inProgressJobsCount }}</p>
+            </div>
+            <div class="rounded-lg border p-3 text-center">
+              <p class="text-xs text-muted-foreground">Completed</p>
+              <p class="text-xl font-semibold">{{ completedJobsCount }}</p>
+            </div>
+            <div class="rounded-lg border p-3 text-center">
+              <p class="text-xs text-muted-foreground">Failed</p>
+              <p class="text-xl font-semibold">{{ failedJobsCount }}</p>
+            </div>
+            <div class="rounded-lg border p-3 text-center">
+              <p class="text-xs text-muted-foreground">Stale candidates</p>
+              <p class="text-xl font-semibold">
+                {{ extractionRunLive ? 0 : inProgressJobsCount }}
+              </p>
+            </div>
+          </div>
+
+          <Separator />
+
+          <div class="flex flex-wrap gap-2">
+            <Button size="sm" variant="outline" :disabled="resettingRunning" @click="resetByKind('stale')">
+              Reset Running
+            </Button>
+            <Button size="sm" variant="outline" :disabled="resettingCompleted" @click="resetByKind('completed')">
+              Reset Completed
+            </Button>
+            <Button size="sm" variant="outline" :disabled="resettingFailed" @click="resetByKind('failed')">
+              Reset Failed
+            </Button>
+            <Button size="sm" variant="outline" :disabled="resettingAll" @click="resetByKind('all')">
+              Reset All Jobs
+            </Button>
+            <Button size="sm" variant="outline" :disabled="regeneratingJobs" @click="regenerateJobs">
+              <Settings class="mr-1.5 size-3.5" />
+              Regenerate jobs
+            </Button>
+          </div>
+
+          <div v-if="dbStatus.jobsBySet && Object.keys(dbStatus.jobsBySet).length" class="space-y-2">
+            <p class="text-xs font-medium text-muted-foreground">Per job set</p>
+            <div class="grid gap-2 md:grid-cols-2">
+              <div
+                v-for="(stats, setName) in dbStatus.jobsBySet"
+                :key="setName"
+                class="rounded-lg border bg-muted/20 p-3 text-xs"
+              >
+                <p class="font-medium">{{ setName }}</p>
+                <p class="text-muted-foreground">
+                  ready {{ stats.pending }} · running {{ stats.in_progress }} · done {{ stats.completed }} · failed {{ stats.failed }}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div class="rounded-lg border bg-muted/20 p-3 text-xs text-muted-foreground">
+            Run totals —
+            input {{ dbStatus.totalInputTokens.toLocaleString() }} ·
+            output {{ dbStatus.totalOutputTokens.toLocaleString() }} ·
+            cost ${{ dbStatus.totalCostUsd.toFixed(4) }}
+          </div>
+        </template>
+      </CardContent>
+    </Card>
+  </div>
+</template>

--- a/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
+++ b/src/dev-ui/app/pages/knowledge-graphs/[kgId]/manage.vue
@@ -46,6 +46,7 @@ import {
 import SharedConversationPanel from '@/components/extraction/SharedConversationPanel.vue'
 import GraphDesignEntitiesPanel from '@/components/graph-management/GraphDesignEntitiesPanel.vue'
 import GraphDesignRelationshipsPanel from '@/components/graph-management/GraphDesignRelationshipsPanel.vue'
+import GraphExtractionJobsWorkspace from '@/components/graph-management/GraphExtractionJobsWorkspace.vue'
 import {
   GRAPH_MANAGEMENT_INPUT_PLACEHOLDERS,
   GRAPH_MANAGEMENT_MODE_LABELS,
@@ -398,7 +399,7 @@ const graphManagementModeGate = computed((): GraphManagementModeGateInput => ({
 
 const graphManagementChatDescription = computed(() => {
   if (graphManagementMode.value === 'extraction-jobs') {
-    return 'Coordinate extraction job setup, sync runs, and maintenance for this knowledge graph. Use the assistant below to drive operational changes.'
+    return 'Define extraction job sets with per-instance descriptions, review ontology schema, and run parallel extraction workers for this knowledge graph.'
   }
   if (graphManagementMode.value === 'one-off-mutations') {
     return 'Author and apply one-off graph mutations scoped to this knowledge graph. Use the assistant below for mutation guidance and workspace context.'
@@ -1952,7 +1953,16 @@ watch(
           @send-message="sendChatMessage"
         />
 
-        <div class="graph-management-artifacts grid gap-6 lg:grid-cols-[minmax(0,15.5rem)_minmax(0,1fr)] lg:items-start">
+        <GraphExtractionJobsWorkspace
+          v-if="graphManagementMode === 'extraction-jobs'"
+          :kg-id="kgId"
+          :reload-nonce="designArtifactsReloadNonce"
+        />
+
+        <div
+          v-else
+          class="graph-management-artifacts grid gap-6 lg:grid-cols-[minmax(0,15.5rem)_minmax(0,1fr)] lg:items-start"
+        >
           <Card
             id="graph-management-schema-artifacts"
             class="graph-management-schema-panel lg:sticky lg:top-4 lg:self-start"

--- a/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
+++ b/src/dev-ui/app/tests/knowledge-graph-manage-workspace.test.ts
@@ -469,7 +469,8 @@ describe('KG-MANAGE-009 - hybrid lower panel mode-specific detail', () => {
     expect(manageWorkspaceVue).toContain('graph-management-detail')
     expect(manageWorkspaceVue).toContain('selectedRailItemId')
     expect(manageWorkspaceVue).toContain("selectedRailItemId === 'schema-readiness'")
-    expect(manageWorkspaceVue).toContain("selectedRailItemId === 'extraction-jobs-setup'")
+    expect(manageWorkspaceVue).toContain('GraphExtractionJobsWorkspace')
+    expect(manageWorkspaceVue).toContain("graphManagementMode === 'extraction-jobs'")
     expect(manageWorkspaceVue).toContain("selectedRailItemId === 'mutation-authoring'")
   })
 
@@ -645,11 +646,8 @@ describe('KG-MANAGE-020 - forbidden and disabled action restrictions', () => {
 })
 
 describe('KG-MANAGE-021 - unified in-place graph operations', () => {
-  it('runs extraction jobs and logs directly in graph-management without data-sources redirect', () => {
-    expect(manageWorkspaceVue).toContain('triggerInlineSync')
-    expect(manageWorkspaceVue).toContain('loadInlineSyncRuns')
-    expect(manageWorkspaceVue).toContain('loadInlineRunLogs')
-    expect(manageWorkspaceVue).toContain('Run logs')
+  it('runs extraction jobs workspace in graph-management without data-sources redirect', () => {
+    expect(manageWorkspaceVue).toContain('GraphExtractionJobsWorkspace')
     expect(manageWorkspaceVue).not.toContain('Open Data Source Operations')
     expect(manageWorkspaceVue).not.toContain('Open Maintain Step')
   })

--- a/src/dev-ui/app/utils/kgGraphManagement.ts
+++ b/src/dev-ui/app/utils/kgGraphManagement.ts
@@ -30,7 +30,7 @@ export const GRAPH_MANAGEMENT_INPUT_PLACEHOLDERS: Record<GraphManagementMode, st
   'initial-schema-design':
     'Describe schema goals, entity types, or relationship constraints for this knowledge graph…',
   'extraction-jobs':
-    'Ask about extraction job setup, sync runs, or maintenance execution for this graph…',
+    'Ask about extraction job sets, per-instance descriptions, or running extraction workers…',
   'one-off-mutations':
     'Author or preview one-off graph mutations scoped to this knowledge graph…',
 }


### PR DESCRIPTION
## Summary
- Adds extraction job set configuration persisted on knowledge graphs with validation and `by_instances` job materialization from live graph entities
- Adds management APIs: CRUD job sets, regenerate, database-status, run-state, start/pause/halt, reset operations
- Adds run orchestrator with in-process workers (memory backend) and ephemeral container workers (container backend)
- Restructures Extraction Jobs UI to k-extract phase3 layout: job sets (left), ontology schema Entities/Relationships (right), Run extraction + Job Status (bottom)
- Updates extraction operations agent skills for per-instance descriptions (no extraction_plan.md)

Closes #766, #767, #768, #769, #770, #771

## Test plan
- [x] Unit tests for job config validation and materialization
- [x] `uv run pytest tests/unit` — 3260 passed (4 pre-existing extraction arch violations)
- [x] Dev-ui graph management workspace tests updated
- [ ] Run migration on dev instance: `alembic upgrade head`
- [ ] Open Extraction Jobs mode for Hyperfleet Tests 3, define job sets, save, run extraction


Made with [Cursor](https://cursor.com)