### PR TITLE
fix(ci): wire hp-fleet-gitops auth for Konflux deploy-tag

### DIFF
--- a/.tekton/kartograph-agent-runtime-push.yaml
+++ b/.tekton/kartograph-agent-runtime-push.yaml
@@ -615,9 +615,9 @@ spec:
             value: $(params.git-url)
         workspaces:
           - name: basic-auth
-            workspace: git-auth
+            workspace: hp-fleet-gitops-auth
           - name: netrc
-            workspace: netrc
+            workspace: hp-fleet-gitops-auth
         taskSpec:
           params:
             - name: COMMIT_SHA
@@ -657,6 +657,12 @@ spec:
                 export HOME=/tekton/home
                 mkdir -p "$HOME"
 
+                if [ ! -f "${WORKSPACE_BASIC_AUTH_PATH}/.git-credentials" ] && [ ! -f "${WORKSPACE_NETRC_PATH}/.netrc" ]; then
+                  echo "ERROR: Secret kartograph-hp-fleet-gitops-auth is missing or empty."
+                  echo "Apply .tekton/kartograph-hp-fleet-gitops-auth.secret.example.yaml in kartograph-tenant."
+                  exit 1
+                fi
+
                 if [ -f "${WORKSPACE_NETRC_PATH}/.netrc" ]; then
                   cp "${WORKSPACE_NETRC_PATH}/.netrc" "$HOME/.netrc"
                   chmod 600 "$HOME/.netrc"
@@ -672,12 +678,7 @@ spec:
                 SHORT_SHA="${COMMIT_SHA:0:12}"
                 BRANCH="konflux/deploy-tag-${DEPLOY_COMPONENT}-${SHORT_SHA}"
 
-                if ! git clone --depth 1 --branch main "https://github.com/openshift-online/hp-fleet-gitops" /tmp/repo; then
-                  echo "WARNING: Could not clone openshift-online/hp-fleet-gitops (private repo)."
-                  echo "Grant Konflux git/netrc credentials read access to hp-fleet-gitops, or update stage tags manually."
-                  echo "Container image build succeeded; skipping deploy-tag automation."
-                  exit 0
-                fi
+                git clone --depth 1 --branch main "https://github.com/openshift-online/hp-fleet-gitops" /tmp/repo
                 cd /tmp/repo
 
                 FILE="apps/kartograph/overlays/stage/kustomization.yaml"
@@ -707,11 +708,7 @@ spec:
 
                 git checkout -b "$BRANCH"
                 git commit -m "chore(deploy): update ${DEPLOY_COMPONENT} stage image tag to ${SHORT_SHA}"
-                if ! git push origin "$BRANCH"; then
-                  echo "WARNING: Could not push deploy-tag branch to hp-fleet-gitops."
-                  echo "Update apps/kartograph/overlays/stage/kustomization.yaml manually."
-                  exit 0
-                fi
+                git push origin "$BRANCH"
 
                 mkdir -p /tekton/run
                 printf '%s\n' "$BRANCH" > /tekton/run/deploy-branch
@@ -786,4 +783,7 @@ spec:
     - name: git-auth
       secret:
         secretName: "{{ git_auth_secret }}"
+    - name: hp-fleet-gitops-auth
+      secret:
+        secretName: kartograph-hp-fleet-gitops-auth
 status: {}

--- a/.tekton/kartograph-agent-runtime-push.yaml
+++ b/.tekton/kartograph-agent-runtime-push.yaml
@@ -672,7 +672,12 @@ spec:
                 SHORT_SHA="${COMMIT_SHA:0:12}"
                 BRANCH="konflux/deploy-tag-${DEPLOY_COMPONENT}-${SHORT_SHA}"
 
-                git clone --depth 1 --branch main "https://github.com/openshift-online/hp-fleet-gitops" /tmp/repo
+                if ! git clone --depth 1 --branch main "https://github.com/openshift-online/hp-fleet-gitops" /tmp/repo; then
+                  echo "WARNING: Could not clone openshift-online/hp-fleet-gitops (private repo)."
+                  echo "Grant Konflux git/netrc credentials read access to hp-fleet-gitops, or update stage tags manually."
+                  echo "Container image build succeeded; skipping deploy-tag automation."
+                  exit 0
+                fi
                 cd /tmp/repo
 
                 FILE="apps/kartograph/overlays/stage/kustomization.yaml"
@@ -685,7 +690,7 @@ spec:
 
                 PATCH_FILE="apps/kartograph/overlays/stage/configmap-patch.yaml"
                 if [ -f "$PATCH_FILE" ]; then
-                  sed -i 's|\(KARTOGRAPH_EXTRACTION_RUNTIME_STICKY_IMAGE:.*kartograph-agent-runtime:\)[^"]*|\1'"${COMMIT_SHA}"'"|' "$PATCH_FILE"
+                  sed -i 's|\(KARTOGRAPH_EXTRACTION_RUNTIME_STICKY_IMAGE:.*kartograph-agent-runtime:\)[^"]*|\1'"${COMMIT_SHA}"'|' "$PATCH_FILE"
                 fi
 
                 git config user.email "konflux@kartograph.openshift.com"
@@ -702,7 +707,11 @@ spec:
 
                 git checkout -b "$BRANCH"
                 git commit -m "chore(deploy): update ${DEPLOY_COMPONENT} stage image tag to ${SHORT_SHA}"
-                git push origin "$BRANCH"
+                if ! git push origin "$BRANCH"; then
+                  echo "WARNING: Could not push deploy-tag branch to hp-fleet-gitops."
+                  echo "Update apps/kartograph/overlays/stage/kustomization.yaml manually."
+                  exit 0
+                fi
 
                 mkdir -p /tekton/run
                 printf '%s\n' "$BRANCH" > /tekton/run/deploy-branch

--- a/.tekton/kartograph-api-push.yaml
+++ b/.tekton/kartograph-api-push.yaml
@@ -672,7 +672,12 @@ spec:
                 SHORT_SHA="${COMMIT_SHA:0:12}"
                 BRANCH="konflux/deploy-tag-${DEPLOY_COMPONENT}-${SHORT_SHA}"
 
-                git clone --depth 1 --branch main "https://github.com/openshift-online/hp-fleet-gitops" /tmp/repo
+                if ! git clone --depth 1 --branch main "https://github.com/openshift-online/hp-fleet-gitops" /tmp/repo; then
+                  echo "WARNING: Could not clone openshift-online/hp-fleet-gitops (private repo)."
+                  echo "Grant Konflux git/netrc credentials read access to hp-fleet-gitops, or update stage tags manually."
+                  echo "Container image build succeeded; skipping deploy-tag automation."
+                  exit 0
+                fi
                 cd /tmp/repo
 
                 FILE="apps/kartograph/overlays/stage/kustomization.yaml"
@@ -694,7 +699,11 @@ spec:
 
                 git checkout -b "$BRANCH"
                 git commit -m "chore(deploy): update ${DEPLOY_COMPONENT} stage image tag to ${SHORT_SHA}"
-                git push origin "$BRANCH"
+                if ! git push origin "$BRANCH"; then
+                  echo "WARNING: Could not push deploy-tag branch to hp-fleet-gitops."
+                  echo "Update apps/kartograph/overlays/stage/kustomization.yaml manually."
+                  exit 0
+                fi
 
                 mkdir -p /tekton/run
                 printf '%s\n' "$BRANCH" > /tekton/run/deploy-branch

--- a/.tekton/kartograph-api-push.yaml
+++ b/.tekton/kartograph-api-push.yaml
@@ -615,9 +615,9 @@ spec:
             value: $(params.git-url)
         workspaces:
           - name: basic-auth
-            workspace: git-auth
+            workspace: hp-fleet-gitops-auth
           - name: netrc
-            workspace: netrc
+            workspace: hp-fleet-gitops-auth
         taskSpec:
           params:
             - name: COMMIT_SHA
@@ -657,6 +657,12 @@ spec:
                 export HOME=/tekton/home
                 mkdir -p "$HOME"
 
+                if [ ! -f "${WORKSPACE_BASIC_AUTH_PATH}/.git-credentials" ] && [ ! -f "${WORKSPACE_NETRC_PATH}/.netrc" ]; then
+                  echo "ERROR: Secret kartograph-hp-fleet-gitops-auth is missing or empty."
+                  echo "Apply .tekton/kartograph-hp-fleet-gitops-auth.secret.example.yaml in kartograph-tenant."
+                  exit 1
+                fi
+
                 if [ -f "${WORKSPACE_NETRC_PATH}/.netrc" ]; then
                   cp "${WORKSPACE_NETRC_PATH}/.netrc" "$HOME/.netrc"
                   chmod 600 "$HOME/.netrc"
@@ -672,12 +678,7 @@ spec:
                 SHORT_SHA="${COMMIT_SHA:0:12}"
                 BRANCH="konflux/deploy-tag-${DEPLOY_COMPONENT}-${SHORT_SHA}"
 
-                if ! git clone --depth 1 --branch main "https://github.com/openshift-online/hp-fleet-gitops" /tmp/repo; then
-                  echo "WARNING: Could not clone openshift-online/hp-fleet-gitops (private repo)."
-                  echo "Grant Konflux git/netrc credentials read access to hp-fleet-gitops, or update stage tags manually."
-                  echo "Container image build succeeded; skipping deploy-tag automation."
-                  exit 0
-                fi
+                git clone --depth 1 --branch main "https://github.com/openshift-online/hp-fleet-gitops" /tmp/repo
                 cd /tmp/repo
 
                 FILE="apps/kartograph/overlays/stage/kustomization.yaml"
@@ -699,11 +700,7 @@ spec:
 
                 git checkout -b "$BRANCH"
                 git commit -m "chore(deploy): update ${DEPLOY_COMPONENT} stage image tag to ${SHORT_SHA}"
-                if ! git push origin "$BRANCH"; then
-                  echo "WARNING: Could not push deploy-tag branch to hp-fleet-gitops."
-                  echo "Update apps/kartograph/overlays/stage/kustomization.yaml manually."
-                  exit 0
-                fi
+                git push origin "$BRANCH"
 
                 mkdir -p /tekton/run
                 printf '%s\n' "$BRANCH" > /tekton/run/deploy-branch
@@ -778,4 +775,7 @@ spec:
     - name: git-auth
       secret:
         secretName: "{{ git_auth_secret }}"
+    - name: hp-fleet-gitops-auth
+      secret:
+        secretName: kartograph-hp-fleet-gitops-auth
 status: {}

--- a/.tekton/kartograph-dev-ui-push.yaml
+++ b/.tekton/kartograph-dev-ui-push.yaml
@@ -672,7 +672,12 @@ spec:
                 SHORT_SHA="${COMMIT_SHA:0:12}"
                 BRANCH="konflux/deploy-tag-${DEPLOY_COMPONENT}-${SHORT_SHA}"
 
-                git clone --depth 1 --branch main "https://github.com/openshift-online/hp-fleet-gitops" /tmp/repo
+                if ! git clone --depth 1 --branch main "https://github.com/openshift-online/hp-fleet-gitops" /tmp/repo; then
+                  echo "WARNING: Could not clone openshift-online/hp-fleet-gitops (private repo)."
+                  echo "Grant Konflux git/netrc credentials read access to hp-fleet-gitops, or update stage tags manually."
+                  echo "Container image build succeeded; skipping deploy-tag automation."
+                  exit 0
+                fi
                 cd /tmp/repo
 
                 FILE="apps/kartograph/overlays/stage/kustomization.yaml"
@@ -694,7 +699,11 @@ spec:
 
                 git checkout -b "$BRANCH"
                 git commit -m "chore(deploy): update ${DEPLOY_COMPONENT} stage image tag to ${SHORT_SHA}"
-                git push origin "$BRANCH"
+                if ! git push origin "$BRANCH"; then
+                  echo "WARNING: Could not push deploy-tag branch to hp-fleet-gitops."
+                  echo "Update apps/kartograph/overlays/stage/kustomization.yaml manually."
+                  exit 0
+                fi
 
                 mkdir -p /tekton/run
                 printf '%s\n' "$BRANCH" > /tekton/run/deploy-branch

--- a/.tekton/kartograph-dev-ui-push.yaml
+++ b/.tekton/kartograph-dev-ui-push.yaml
@@ -615,9 +615,9 @@ spec:
             value: $(params.git-url)
         workspaces:
           - name: basic-auth
-            workspace: git-auth
+            workspace: hp-fleet-gitops-auth
           - name: netrc
-            workspace: netrc
+            workspace: hp-fleet-gitops-auth
         taskSpec:
           params:
             - name: COMMIT_SHA
@@ -657,6 +657,12 @@ spec:
                 export HOME=/tekton/home
                 mkdir -p "$HOME"
 
+                if [ ! -f "${WORKSPACE_BASIC_AUTH_PATH}/.git-credentials" ] && [ ! -f "${WORKSPACE_NETRC_PATH}/.netrc" ]; then
+                  echo "ERROR: Secret kartograph-hp-fleet-gitops-auth is missing or empty."
+                  echo "Apply .tekton/kartograph-hp-fleet-gitops-auth.secret.example.yaml in kartograph-tenant."
+                  exit 1
+                fi
+
                 if [ -f "${WORKSPACE_NETRC_PATH}/.netrc" ]; then
                   cp "${WORKSPACE_NETRC_PATH}/.netrc" "$HOME/.netrc"
                   chmod 600 "$HOME/.netrc"
@@ -672,12 +678,7 @@ spec:
                 SHORT_SHA="${COMMIT_SHA:0:12}"
                 BRANCH="konflux/deploy-tag-${DEPLOY_COMPONENT}-${SHORT_SHA}"
 
-                if ! git clone --depth 1 --branch main "https://github.com/openshift-online/hp-fleet-gitops" /tmp/repo; then
-                  echo "WARNING: Could not clone openshift-online/hp-fleet-gitops (private repo)."
-                  echo "Grant Konflux git/netrc credentials read access to hp-fleet-gitops, or update stage tags manually."
-                  echo "Container image build succeeded; skipping deploy-tag automation."
-                  exit 0
-                fi
+                git clone --depth 1 --branch main "https://github.com/openshift-online/hp-fleet-gitops" /tmp/repo
                 cd /tmp/repo
 
                 FILE="apps/kartograph/overlays/stage/kustomization.yaml"
@@ -699,11 +700,7 @@ spec:
 
                 git checkout -b "$BRANCH"
                 git commit -m "chore(deploy): update ${DEPLOY_COMPONENT} stage image tag to ${SHORT_SHA}"
-                if ! git push origin "$BRANCH"; then
-                  echo "WARNING: Could not push deploy-tag branch to hp-fleet-gitops."
-                  echo "Update apps/kartograph/overlays/stage/kustomization.yaml manually."
-                  exit 0
-                fi
+                git push origin "$BRANCH"
 
                 mkdir -p /tekton/run
                 printf '%s\n' "$BRANCH" > /tekton/run/deploy-branch
@@ -778,4 +775,7 @@ spec:
     - name: git-auth
       secret:
         secretName: "{{ git_auth_secret }}"
+    - name: hp-fleet-gitops-auth
+      secret:
+        secretName: kartograph-hp-fleet-gitops-auth
 status: {}

--- a/.tekton/kartograph-hp-fleet-gitops-auth.secret.example.yaml
+++ b/.tekton/kartograph-hp-fleet-gitops-auth.secret.example.yaml
@@ -1,0 +1,23 @@
+# Apply in Konflux tenant namespace (kartograph-tenant) after replacing placeholders.
+#
+# PAT needs repo + pull_request scope on openshift-online/hp-fleet-gitops.
+# Do not commit real tokens.
+#
+#   oc project kartograph-tenant
+#   oc create -f kartograph-hp-fleet-gitops-auth.secret.yaml
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kartograph-hp-fleet-gitops-auth
+  namespace: kartograph-tenant
+type: Opaque
+stringData:
+  .gitconfig: |
+    [credential]
+      helper = store
+  .git-credentials: https://x-access-token:REPLACE_WITH_GITHUB_PAT@github.com
+  .netrc: |
+    machine github.com
+    login x-access-token
+    password REPLACE_WITH_GITHUB_PAT

--- a/.tekton/kartograph-openshell-gateway-push.yaml
+++ b/.tekton/kartograph-openshell-gateway-push.yaml
@@ -672,7 +672,12 @@ spec:
                 SHORT_SHA="${COMMIT_SHA:0:12}"
                 BRANCH="konflux/deploy-tag-${DEPLOY_COMPONENT}-${SHORT_SHA}"
 
-                git clone --depth 1 --branch main "https://github.com/openshift-online/hp-fleet-gitops" /tmp/repo
+                if ! git clone --depth 1 --branch main "https://github.com/openshift-online/hp-fleet-gitops" /tmp/repo; then
+                  echo "WARNING: Could not clone openshift-online/hp-fleet-gitops (private repo)."
+                  echo "Grant Konflux git/netrc credentials read access to hp-fleet-gitops, or update stage tags manually."
+                  echo "Container image build succeeded; skipping deploy-tag automation."
+                  exit 0
+                fi
                 cd /tmp/repo
 
                 FILE="apps/kartograph/overlays/stage/kustomization.yaml"
@@ -694,7 +699,11 @@ spec:
 
                 git checkout -b "$BRANCH"
                 git commit -m "chore(deploy): update ${DEPLOY_COMPONENT} stage image tag to ${SHORT_SHA}"
-                git push origin "$BRANCH"
+                if ! git push origin "$BRANCH"; then
+                  echo "WARNING: Could not push deploy-tag branch to hp-fleet-gitops."
+                  echo "Update apps/kartograph/overlays/stage/kustomization.yaml manually."
+                  exit 0
+                fi
 
                 mkdir -p /tekton/run
                 printf '%s\n' "$BRANCH" > /tekton/run/deploy-branch

--- a/.tekton/kartograph-openshell-gateway-push.yaml
+++ b/.tekton/kartograph-openshell-gateway-push.yaml
@@ -615,9 +615,9 @@ spec:
             value: $(params.git-url)
         workspaces:
           - name: basic-auth
-            workspace: git-auth
+            workspace: hp-fleet-gitops-auth
           - name: netrc
-            workspace: netrc
+            workspace: hp-fleet-gitops-auth
         taskSpec:
           params:
             - name: COMMIT_SHA
@@ -657,6 +657,12 @@ spec:
                 export HOME=/tekton/home
                 mkdir -p "$HOME"
 
+                if [ ! -f "${WORKSPACE_BASIC_AUTH_PATH}/.git-credentials" ] && [ ! -f "${WORKSPACE_NETRC_PATH}/.netrc" ]; then
+                  echo "ERROR: Secret kartograph-hp-fleet-gitops-auth is missing or empty."
+                  echo "Apply .tekton/kartograph-hp-fleet-gitops-auth.secret.example.yaml in kartograph-tenant."
+                  exit 1
+                fi
+
                 if [ -f "${WORKSPACE_NETRC_PATH}/.netrc" ]; then
                   cp "${WORKSPACE_NETRC_PATH}/.netrc" "$HOME/.netrc"
                   chmod 600 "$HOME/.netrc"
@@ -672,12 +678,7 @@ spec:
                 SHORT_SHA="${COMMIT_SHA:0:12}"
                 BRANCH="konflux/deploy-tag-${DEPLOY_COMPONENT}-${SHORT_SHA}"
 
-                if ! git clone --depth 1 --branch main "https://github.com/openshift-online/hp-fleet-gitops" /tmp/repo; then
-                  echo "WARNING: Could not clone openshift-online/hp-fleet-gitops (private repo)."
-                  echo "Grant Konflux git/netrc credentials read access to hp-fleet-gitops, or update stage tags manually."
-                  echo "Container image build succeeded; skipping deploy-tag automation."
-                  exit 0
-                fi
+                git clone --depth 1 --branch main "https://github.com/openshift-online/hp-fleet-gitops" /tmp/repo
                 cd /tmp/repo
 
                 FILE="apps/kartograph/overlays/stage/kustomization.yaml"
@@ -699,11 +700,7 @@ spec:
 
                 git checkout -b "$BRANCH"
                 git commit -m "chore(deploy): update ${DEPLOY_COMPONENT} stage image tag to ${SHORT_SHA}"
-                if ! git push origin "$BRANCH"; then
-                  echo "WARNING: Could not push deploy-tag branch to hp-fleet-gitops."
-                  echo "Update apps/kartograph/overlays/stage/kustomization.yaml manually."
-                  exit 0
-                fi
+                git push origin "$BRANCH"
 
                 mkdir -p /tekton/run
                 printf '%s\n' "$BRANCH" > /tekton/run/deploy-branch
@@ -778,4 +775,7 @@ spec:
     - name: git-auth
       secret:
         secretName: "{{ git_auth_secret }}"
+    - name: hp-fleet-gitops-auth
+      secret:
+        secretName: kartograph-hp-fleet-gitops-auth
 status: {}


### PR DESCRIPTION
## Summary
PAC `git_auth_secret` only covers `openshift-hyperfleet/kartograph`. The `update-deploy-tag` finally task clones private `openshift-online/hp-fleet-gitops`, which caused `Repository not found`.

This PR wires a **dedicated secret** for that repo and reverts the soft-fail workaround.

Also fixes agent-runtime `configmap-patch.yaml` sed double-quote bug.

## Setup (required before merge)

1. Create a GitHub PAT (classic or fine-grained) with **Contents: Read/Write** and **Pull requests: Write** on `openshift-online/hp-fleet-gitops`.

2. In Konflux tenant namespace, apply the secret (replace PAT placeholders):

```bash
oc project kartograph-tenant
cp .tekton/kartograph-hp-fleet-gitops-auth.secret.example.yaml /tmp/kartograph-hp-fleet-gitops-auth.secret.yaml
# edit /tmp/...yaml — replace REPLACE_WITH_GITHUB_PAT (both places)
oc apply -f /tmp/kartograph-hp-fleet-gitops-auth.secret.yaml
rm /tmp/kartograph-hp-fleet-gitops-auth.secret.yaml
```

3. Merge this PR, then rerun Konflux **on-push** for all four components.

Successful runs should open deploy-tag PRs in hp-fleet-gitops automatically.

## Test plan
- [ ] Secret `kartograph-hp-fleet-gitops-auth` exists in `kartograph-tenant`
- [ ] Konflux on-push green for api, dev-ui, agent-runtime, openshell-gateway
- [ ] Deploy-tag PRs appear in hp-fleet-gitops