### PR TITLE
feat(extraction): log sticky runtime start failures via domain probe

### DIFF
--- a/src/api/extraction/application/observability/__init__.py
+++ b/src/api/extraction/application/observability/__init__.py
@@ -1,0 +1,14 @@
+"""Domain-Oriented Observability for Extraction application layer.
+
+Probes for application service operations following Domain-Oriented Observability patterns.
+"""
+
+from extraction.application.observability.sticky_session_runtime_probe import (
+    DefaultStickySessionRuntimeProbe,
+    StickySessionRuntimeProbe,
+)
+
+__all__ = [
+    "StickySessionRuntimeProbe",
+    "DefaultStickySessionRuntimeProbe",
+]

--- a/src/api/extraction/application/observability/sticky_session_runtime_probe.py
+++ b/src/api/extraction/application/observability/sticky_session_runtime_probe.py
@@ -1,0 +1,113 @@
+"""Domain probe for sticky session runtime lifecycle.
+
+Following Domain-Oriented Observability patterns, this probe captures
+sticky-runtime start failures (container/OpenShell sandbox start, Vertex
+provider bootstrap, health checks) so the raw failure detail is visible in
+structured logs instead of only ever reaching the end user's browser.
+
+See: https://martinfowler.com/articles/domain-oriented-observability.html
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+import structlog
+
+if TYPE_CHECKING:
+    from shared_kernel.observability_context import ObservationContext
+
+
+class StickySessionRuntimeProbe(Protocol):
+    """Domain probe for sticky session runtime start/health operations."""
+
+    def runtime_start_failed(
+        self,
+        *,
+        session_id: str,
+        knowledge_graph_id: str,
+        mode: str,
+        error: str,
+    ) -> None:
+        """Record that starting the sticky runtime (container/sandbox) failed."""
+        ...
+
+    def runtime_unhealthy(
+        self,
+        *,
+        session_id: str,
+        knowledge_graph_id: str,
+        mode: str,
+        error: str,
+    ) -> None:
+        """Record that the sticky runtime never became healthy in time."""
+        ...
+
+    def with_context(self, context: ObservationContext) -> StickySessionRuntimeProbe:
+        """Return a new probe with additional context."""
+        ...
+
+
+class DefaultStickySessionRuntimeProbe:
+    """Default implementation of StickySessionRuntimeProbe using structlog."""
+
+    def __init__(
+        self,
+        logger: structlog.stdlib.BoundLogger | None = None,
+        context: ObservationContext | None = None,
+    ):
+        self._logger = logger or structlog.get_logger()
+        self._context = context
+
+    def _get_context_kwargs(self, exclude: set[str] | None = None) -> dict[str, str]:
+        if self._context is None:
+            return {}
+        context_dict = self._context.as_dict()
+        if exclude:
+            return {k: v for k, v in context_dict.items() if k not in exclude}
+        return context_dict
+
+    def with_context(
+        self, context: ObservationContext
+    ) -> DefaultStickySessionRuntimeProbe:
+        return DefaultStickySessionRuntimeProbe(logger=self._logger, context=context)
+
+    def runtime_start_failed(
+        self,
+        *,
+        session_id: str,
+        knowledge_graph_id: str,
+        mode: str,
+        error: str,
+    ) -> None:
+        context_kwargs = self._get_context_kwargs(
+            exclude={"session_id", "knowledge_graph_id", "mode", "error"}
+        )
+        self._logger.error(
+            "sticky_runtime_start_failed",
+            session_id=session_id,
+            knowledge_graph_id=knowledge_graph_id,
+            mode=mode,
+            error=error,
+            **context_kwargs,
+        )
+
+    def runtime_unhealthy(
+        self,
+        *,
+        session_id: str,
+        knowledge_graph_id: str,
+        mode: str,
+        error: str,
+    ) -> None:
+        context_kwargs = self._get_context_kwargs(
+            exclude={"session_id", "knowledge_graph_id", "mode", "error"}
+        )
+        self._logger.error(
+            "sticky_runtime_unhealthy",
+            session_id=session_id,
+            knowledge_graph_id=knowledge_graph_id,
+            mode=mode,
+            error=error,
+            **context_kwargs,
+        )

--- a/src/api/extraction/application/sticky_session_runtime_service.py
+++ b/src/api/extraction/application/sticky_session_runtime_service.py
@@ -9,6 +9,10 @@ from typing import Any
 
 from extraction.application.agent_session_service import ExtractionAgentSessionService
 from extraction.application.job_package_gate import resolve_job_package_gate
+from extraction.application.observability import (
+    DefaultStickySessionRuntimeProbe,
+    StickySessionRuntimeProbe,
+)
 from extraction.application.sticky_session_materialization import (
     should_materialize_job_packages,
 )
@@ -53,6 +57,7 @@ class StickySessionRuntimeService:
         health_checker: IStickyRuntimeHealthChecker,
         runtime_backend: str,
         sticky_health_timeout_seconds: float,
+        probe: StickySessionRuntimeProbe | None = None,
     ) -> None:
         self._session_service = session_service
         self._skill_resolution_service = skill_resolution_service
@@ -62,6 +67,7 @@ class StickySessionRuntimeService:
         self._health_checker = health_checker
         self._runtime_backend = runtime_backend
         self._sticky_health_timeout_seconds = sticky_health_timeout_seconds
+        self._probe = probe or DefaultStickySessionRuntimeProbe()
 
     async def stream_runtime_warmup(
         self,
@@ -295,6 +301,12 @@ class StickySessionRuntimeService:
                 bootstrap=bootstrap,
             )
         except (ContainerRuntimeError, RuntimeError) as exc:
+            self._probe.runtime_start_failed(
+                session_id=session.id,
+                knowledge_graph_id=knowledge_graph_id,
+                mode=mode.value,
+                error=str(exc),
+            )
             session.runtime_context["sticky_runtime"] = {
                 "phase": "failed",
                 "status": "failed",
@@ -330,6 +342,12 @@ class StickySessionRuntimeService:
                 recent, event = thinking_event(recent, line)
                 yield event
         except TimeoutError as exc:
+            self._probe.runtime_unhealthy(
+                session_id=session.id,
+                knowledge_graph_id=knowledge_graph_id,
+                mode=mode.value,
+                error=str(exc),
+            )
             session.runtime_context["sticky_runtime"]["phase"] = "unhealthy"
             session.runtime_context["sticky_runtime"]["status"] = "unhealthy"
             if persist_session:

--- a/src/api/tests/unit/extraction/application/observability/test_sticky_session_runtime_probe.py
+++ b/src/api/tests/unit/extraction/application/observability/test_sticky_session_runtime_probe.py
@@ -1,0 +1,61 @@
+"""Unit tests for StickySessionRuntimeProbe.
+
+Following Domain-Oriented Observability patterns, these probes must capture
+the real failure detail (e.g. the raw OpenShell CLI stderr) whenever a
+sticky runtime fails to start, so that production failures are visible in
+structured logs without needing to reproduce them by hand.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import structlog
+
+from extraction.application.observability.sticky_session_runtime_probe import (
+    DefaultStickySessionRuntimeProbe,
+)
+
+
+class TestStickySessionRuntimeProbe:
+    def test_default_probe_creates_with_default_logger(self):
+        probe = DefaultStickySessionRuntimeProbe()
+        assert probe._logger is not None
+
+    def test_runtime_start_failed_logs_error_with_detail(self):
+        mock_logger = MagicMock(spec=structlog.stdlib.BoundLogger)
+        probe = DefaultStickySessionRuntimeProbe(logger=mock_logger)
+
+        probe.runtime_start_failed(
+            session_id="session-1",
+            knowledge_graph_id="kg-1",
+            mode="schema_bootstrap",
+            error="openshell provider create --name kartograph-gma failed: no credentials resolved",
+        )
+
+        mock_logger.error.assert_called_once_with(
+            "sticky_runtime_start_failed",
+            session_id="session-1",
+            knowledge_graph_id="kg-1",
+            mode="schema_bootstrap",
+            error="openshell provider create --name kartograph-gma failed: no credentials resolved",
+        )
+
+    def test_runtime_unhealthy_logs_error_with_detail(self):
+        mock_logger = MagicMock(spec=structlog.stdlib.BoundLogger)
+        probe = DefaultStickySessionRuntimeProbe(logger=mock_logger)
+
+        probe.runtime_unhealthy(
+            session_id="session-1",
+            knowledge_graph_id="kg-1",
+            mode="schema_bootstrap",
+            error="timed out waiting for sticky runtime health",
+        )
+
+        mock_logger.error.assert_called_once_with(
+            "sticky_runtime_unhealthy",
+            session_id="session-1",
+            knowledge_graph_id="kg-1",
+            mode="schema_bootstrap",
+            error="timed out waiting for sticky runtime health",
+        )

--- a/src/api/tests/unit/extraction/application/test_sticky_session_runtime_service.py
+++ b/src/api/tests/unit/extraction/application/test_sticky_session_runtime_service.py
@@ -157,6 +157,36 @@ class _FailingStickyRuntimeManager(InMemoryStickySessionRuntimeManager):
         raise ContainerRuntimeError("docker run failed: image not found")
 
 
+class _RecordingRuntimeProbe:
+    def __init__(self) -> None:
+        self.start_failed_calls: list[dict[str, str]] = []
+        self.unhealthy_calls: list[dict[str, str]] = []
+
+    def runtime_start_failed(
+        self, *, session_id: str, knowledge_graph_id: str, mode: str, error: str
+    ) -> None:
+        self.start_failed_calls.append(
+            {
+                "session_id": session_id,
+                "knowledge_graph_id": knowledge_graph_id,
+                "mode": mode,
+                "error": error,
+            }
+        )
+
+    def runtime_unhealthy(
+        self, *, session_id: str, knowledge_graph_id: str, mode: str, error: str
+    ) -> None:
+        self.unhealthy_calls.append(
+            {
+                "session_id": session_id,
+                "knowledge_graph_id": knowledge_graph_id,
+                "mode": mode,
+                "error": error,
+            }
+        )
+
+
 @pytest.mark.asyncio
 async def test_stream_runtime_warmup_surfaces_container_start_failure() -> None:
     repo = _InMemoryAgentSessionRepository()
@@ -166,6 +196,7 @@ async def test_stream_runtime_warmup_surfaces_container_start_failure() -> None:
         knowledge_graph_id="kg-1",
         ui_mode=GraphManagementUiMode.INITIAL_SCHEMA_DESIGN,
     )
+    probe = _RecordingRuntimeProbe()
     service = StickySessionRuntimeService(
         session_service=session_service,
         skill_resolution_service=_StaticSkillResolutionService(),
@@ -175,6 +206,7 @@ async def test_stream_runtime_warmup_surfaces_container_start_failure() -> None:
         health_checker=_InstantHealthChecker(),
         runtime_backend="container",
         sticky_health_timeout_seconds=5.0,
+        probe=probe,
     )
 
     events = [
@@ -193,6 +225,12 @@ async def test_stream_runtime_warmup_surfaces_container_start_failure() -> None:
     assert done["ok"] is False
     assert done["error"]["code"] == "RUNTIME_START_FAILED"
     assert "image not found" in done["error"]["message"]
+
+    assert len(probe.start_failed_calls) == 1
+    call = probe.start_failed_calls[0]
+    assert call["knowledge_graph_id"] == "kg-1"
+    assert call["mode"] == ExtractionSessionMode.SCHEMA_BOOTSTRAP.value
+    assert "image not found" in call["error"]
 
 
 class _OnceInactiveStickyRuntimeManager(InMemoryStickySessionRuntimeManager):

--- a/src/api/uv.lock
+++ b/src/api/uv.lock
@@ -1302,7 +1302,7 @@ wheels = [
 
 [[package]]
 name = "kartograph-api"
-version = "3.38.2"
+version = "3.38.6"
 source = { virtual = "." }
 dependencies = [
     { name = "agentic-ci" },


### PR DESCRIPTION
## Summary
- The Graph Management Assistant's "no credentials resolved" / `RUNTIME_START_FAILED` error is completely invisible server-side today: it's only ever surfaced to the browser via the `/runtime/warm` NDJSON stream body, with zero corresponding log line in the `api` container (confirmed via 9+ hours of production logs with no matches for "vertex", "provider", "credential", etc).
- Adds a `StickySessionRuntimeProbe` (Domain-Oriented Observability) that logs the raw failure detail (`error=str(exc)`) whenever `get_or_start_runtime` raises or the health wait times out, in both `stream_runtime_warmup` and `ensure_runtime_for_chat` code paths.
- This is a pure observability addition (no behavior change) so the *next* occurrence of this or any other sticky-runtime start failure is immediately visible via `kubectl logs`/ArgoCD without needing to reproduce it live.

## Test plan
- [x] `uv run pytest tests/unit/extraction/application/observability/test_sticky_session_runtime_probe.py -v`
- [x] `uv run pytest tests/unit/extraction/application/test_sticky_session_runtime_service.py -v`
- [x] `uv run pytest tests/unit -q` (full suite, 3512 passed)
- [x] `uv run ruff format` / `ruff check` on changed files

Made with [Cursor](https://cursor.com)