### PR TITLE
fix(extraction): bump pinned OpenShell to v0.0.83 for Sandbox v1beta1 support

### DIFF
--- a/deploy/container/openshell-gateway/Dockerfile
+++ b/deploy/container/openshell-gateway/Dockerfile
@@ -14,11 +14,14 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 ARG OPENSHELL_VERSION=0.0.83
 
 RUN microdnf install -y ca-certificates gzip tar \
-    && curl -fsSL -o /tmp/openshell-gateway.tgz \
+    && curl -fsSL -o /tmp/openshell-gateway-x86_64-unknown-linux-gnu.tar.gz \
       "https://github.com/NVIDIA/OpenShell/releases/download/v${OPENSHELL_VERSION}/openshell-gateway-x86_64-unknown-linux-gnu.tar.gz" \
-    && tar xzf /tmp/openshell-gateway.tgz -C /usr/local/bin \
+    && curl -fsSL -o /tmp/openshell-gateway-checksums-sha256.txt \
+      "https://github.com/NVIDIA/OpenShell/releases/download/v${OPENSHELL_VERSION}/openshell-gateway-checksums-sha256.txt" \
+    && (cd /tmp && grep " openshell-gateway-x86_64-unknown-linux-gnu.tar.gz$" openshell-gateway-checksums-sha256.txt | sha256sum -c -) \
+    && tar xzf /tmp/openshell-gateway-x86_64-unknown-linux-gnu.tar.gz -C /usr/local/bin \
     && chmod 755 /usr/local/bin/openshell-gateway \
-    && rm -f /tmp/openshell-gateway.tgz \
+    && rm -f /tmp/openshell-gateway-x86_64-unknown-linux-gnu.tar.gz /tmp/openshell-gateway-checksums-sha256.txt \
     && microdnf clean all
 
 RUN mkdir -p /var/openshell \

--- a/deploy/container/openshell-gateway/Dockerfile
+++ b/deploy/container/openshell-gateway/Dockerfile
@@ -1,8 +1,17 @@
 # OpenShell gateway sidecar for kartograph-api (Kubernetes compute driver).
-# Uses the official NVIDIA OpenShell gateway release binary (v0.0.62).
+# Uses the official NVIDIA OpenShell gateway release binary (v0.0.83).
+#
+# Must be >= v0.0.72 (NVIDIA/OpenShell#2009): earlier releases hardcode the
+# Kubernetes driver's Sandbox API group/version to agents.x-k8s.io/v1alpha1
+# with no fallback. v0.0.72+ detects the served version at runtime (trying
+# v1beta1 first, then v1alpha1), which is required once the Agent Sandbox
+# CRD on a cluster only serves v1beta1 — the failure mode otherwise is every
+# sandbox list/watch call erroring with a raw "404 page not found" (not a
+# structured NotFound Status), which is what broke Graph Management
+# Assistant session start in kartograph-stage.
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
-ARG OPENSHELL_VERSION=0.0.62
+ARG OPENSHELL_VERSION=0.0.83
 
 RUN microdnf install -y ca-certificates gzip tar \
     && curl -fsSL -o /tmp/openshell-gateway.tgz \

--- a/scripts/verify-fleet-apps-kartograph.sh
+++ b/scripts/verify-fleet-apps-kartograph.sh
@@ -76,8 +76,9 @@ rg -n "openshell" "hp-fleet-gitops/$KARTOGRAPH_PATH/base/kustomization.yaml" || 
   echo "  MISSING openshell entries in base/kustomization.yaml"
   missing=$((missing + 1))
 }
-echo "    (openshell-rbac.yaml is expected to be commented out until the Agent Sandbox"
-echo "     CRD/controller and ArgoCD SA RBAC escalation are both granted by platform)"
+echo "    (openshell-rbac.yaml is expected to be active: Agent Sandbox CRD/controller"
+echo "     confirmed present, and ArgoCD SA RBAC escalation granted via"
+echo "     hybrid-platforms-gitops/infrastructure!76 as of 2026-07-15)"
 
 echo
 echo "==> Validate hp-fleet-gitops stage overlay renders:"

--- a/scripts/verify-fleet-apps-kartograph.sh
+++ b/scripts/verify-fleet-apps-kartograph.sh
@@ -76,9 +76,11 @@ rg -n "openshell" "hp-fleet-gitops/$KARTOGRAPH_PATH/base/kustomization.yaml" || 
   echo "  MISSING openshell entries in base/kustomization.yaml"
   missing=$((missing + 1))
 }
-echo "    (openshell-rbac.yaml is expected to be active: Agent Sandbox CRD/controller"
-echo "     confirmed present, and ArgoCD SA RBAC escalation granted via"
-echo "     hybrid-platforms-gitops/infrastructure!76 as of 2026-07-15)"
+echo "    (openshell-rbac.yaml was re-enabled 2026-07-15 after"
+echo "     hybrid-platforms-gitops/infrastructure!76 granted the ArgoCD SA the RBAC"
+echo "     it needed to sync it; this is a historical note, not a live check — if"
+echo "     ArgoCD sync is failing, verify current RBAC/CRD state directly instead"
+echo "     of trusting this comment)"
 
 echo
 echo "==> Validate hp-fleet-gitops stage overlay renders:"

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -42,11 +42,14 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS openshell
 ARG OPENSHELL_VERSION=0.0.83
 
 RUN microdnf install -y ca-certificates gzip tar \
-    && curl -fsSL -o /tmp/openshell.tgz \
+    && curl -fsSL -o /tmp/openshell-x86_64-unknown-linux-musl.tar.gz \
       "https://github.com/NVIDIA/OpenShell/releases/download/v${OPENSHELL_VERSION}/openshell-x86_64-unknown-linux-musl.tar.gz" \
-    && tar xzf /tmp/openshell.tgz -C /usr/local/bin \
+    && curl -fsSL -o /tmp/openshell-checksums-sha256.txt \
+      "https://github.com/NVIDIA/OpenShell/releases/download/v${OPENSHELL_VERSION}/openshell-checksums-sha256.txt" \
+    && (cd /tmp && grep " openshell-x86_64-unknown-linux-musl.tar.gz$" openshell-checksums-sha256.txt | sha256sum -c -) \
+    && tar xzf /tmp/openshell-x86_64-unknown-linux-musl.tar.gz -C /usr/local/bin \
     && chmod 755 /usr/local/bin/openshell \
-    && rm -f /tmp/openshell.tgz \
+    && rm -f /tmp/openshell-x86_64-unknown-linux-musl.tar.gz /tmp/openshell-checksums-sha256.txt \
     && microdnf clean all
 
 # Production stage - using Red Hat UBI9 Python image

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -39,7 +39,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # OpenShell CLI for extraction workload runtime (static binary from GitHub releases).
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS openshell
 
-ARG OPENSHELL_VERSION=0.0.62
+ARG OPENSHELL_VERSION=0.0.83
 
 RUN microdnf install -y ca-certificates gzip tar \
     && curl -fsSL -o /tmp/openshell.tgz \

--- a/src/api/tests/unit/extraction/infrastructure/test_openshell_version_pin.py
+++ b/src/api/tests/unit/extraction/infrastructure/test_openshell_version_pin.py
@@ -1,0 +1,67 @@
+"""OpenShell binary version pin tests.
+
+Kartograph vendors the OpenShell CLI and gateway as pinned third-party
+binaries from GitHub releases, pulled in two separate Dockerfiles:
+
+- src/api/Dockerfile (the `openshell` CLI, used by kartograph-api to talk
+  to the gateway sidecar)
+- deploy/container/openshell-gateway/Dockerfile (the `openshell-gateway`
+  sidecar itself, which runs the Kubernetes compute driver)
+
+Both must be pinned to the same OPENSHELL_VERSION (CLI/gateway protocol
+compatibility), and that version must be new enough for the Kubernetes
+compute driver to detect the Agent Sandbox CRD's served API version at
+runtime instead of assuming `v1alpha1`. Versions before v0.0.72
+(NVIDIA/OpenShell#2009) hardcode `v1alpha1` with no fallback, so a
+cluster that only serves `v1beta1` sandboxes causes every sandbox
+list/watch call to fail with a raw "404 page not found" — which is
+exactly the failure the Graph Management Assistant's "Start session"
+hit in kartograph-stage.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[6]
+API_DOCKERFILE = REPO_ROOT / "src" / "api" / "Dockerfile"
+GATEWAY_DOCKERFILE = REPO_ROOT / "deploy" / "container" / "openshell-gateway" / "Dockerfile"
+
+# First release with Kubernetes Sandbox API version auto-detection
+# (v1beta1 with fallback to v1alpha1); see NVIDIA/OpenShell#2009.
+MIN_OPENSHELL_VERSION = (0, 0, 72)
+
+
+def _extract_openshell_version(dockerfile: Path) -> tuple[int, int, int]:
+    match = re.search(
+        r"^ARG OPENSHELL_VERSION=(\d+)\.(\d+)\.(\d+)$",
+        dockerfile.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    assert match, f"no ARG OPENSHELL_VERSION=X.Y.Z found in {dockerfile}"
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+class TestOpenShellVersionPin:
+    def test_cli_and_gateway_dockerfiles_pin_the_same_version(self) -> None:
+        cli_version = _extract_openshell_version(API_DOCKERFILE)
+        gateway_version = _extract_openshell_version(GATEWAY_DOCKERFILE)
+
+        assert cli_version == gateway_version, (
+            "src/api/Dockerfile and deploy/container/openshell-gateway/Dockerfile "
+            f"must pin the same OPENSHELL_VERSION, got CLI={cli_version} "
+            f"gateway={gateway_version}"
+        )
+
+    def test_gateway_version_supports_sandbox_api_version_detection(self) -> None:
+        gateway_version = _extract_openshell_version(GATEWAY_DOCKERFILE)
+
+        assert gateway_version >= MIN_OPENSHELL_VERSION, (
+            f"openshell-gateway is pinned to v{'.'.join(map(str, gateway_version))}, "
+            f"which predates v{'.'.join(map(str, MIN_OPENSHELL_VERSION))}'s Kubernetes "
+            "driver Sandbox API version auto-detection. Older versions hardcode "
+            "agents.x-k8s.io/v1alpha1 with no fallback, so a cluster serving only "
+            "v1beta1 Sandboxes makes every sandbox list/watch call fail with a "
+            "raw 404, breaking Graph Management Assistant session start."
+        )

--- a/src/api/tests/unit/extraction/infrastructure/test_openshell_version_pin.py
+++ b/src/api/tests/unit/extraction/infrastructure/test_openshell_version_pin.py
@@ -26,7 +26,9 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[6]
 API_DOCKERFILE = REPO_ROOT / "src" / "api" / "Dockerfile"
-GATEWAY_DOCKERFILE = REPO_ROOT / "deploy" / "container" / "openshell-gateway" / "Dockerfile"
+GATEWAY_DOCKERFILE = (
+    REPO_ROOT / "deploy" / "container" / "openshell-gateway" / "Dockerfile"
+)
 
 # First release with Kubernetes Sandbox API version auto-detection
 # (v1beta1 with fallback to v1alpha1); see NVIDIA/OpenShell#2009.


### PR DESCRIPTION
## Summary

- `openshell-gateway`'s Kubernetes compute driver was erroring on every sandbox list/watch call with a raw (non-JSON) `404 page not found` in `kartograph-stage`, breaking Graph Management Assistant session start.
- Root cause: our pinned OpenShell release (`v0.0.62`) hardcodes the Kubernetes driver's Sandbox custom resource to `agents.x-k8s.io/v1alpha1` with no fallback. The Agent Sandbox CRD installed on the cluster now serves `v1beta1`, not `v1alpha1`. [NVIDIA/OpenShell#2009](https://github.com/NVIDIA/OpenShell/pull/2009) (first released in `v0.0.72`) added runtime detection of the served Sandbox API version (`v1beta1` first, falling back to `v1alpha1`), and explicitly documents the raw-404 signature we observed as the exact failure mode this was written to handle.
- This surfaced only after `hybrid-platforms-gitops/infrastructure!76` fixed a separate, previously-blocking RBAC issue (`openshell-rbac.yaml`'s Role/RoleBinding couldn't sync because ArgoCD's application controller SA didn't hold the verbs it needed to grant). Once that RBAC sync succeeded, the driver's list/watch calls started reaching the API server, exposing this version mismatch underneath.
- Bumps `OPENSHELL_VERSION` in both `src/api/Dockerfile` (the `openshell` CLI) and `deploy/container/openshell-gateway/Dockerfile` (the gateway sidecar) to `v0.0.83`, the latest published release, keeping CLI/gateway protocol versions in lockstep.
- Adds `test_openshell_version_pin.py`: a regression test enforcing both Dockerfiles stay pinned to the same version, and that the version is high enough to include the Sandbox API auto-detection fix.
- Refreshes a stale comment in `scripts/verify-fleet-apps-kartograph.sh` that still described `openshell-rbac.yaml` as expected to be disabled.

## Test plan

- [x] New unit test fails (red) against the old `v0.0.62` pin, passes (green) after the bump.
- [x] Full unit suite passes (`uv run pytest tests/unit`, 3515 passed).
- [ ] After Konflux builds the `kartograph-api` and `kartograph-openshell-gateway` images for this PR/merge, bump the stage image tags in `hp-fleet-gitops` and confirm via ArgoCD/pod logs that the openshell-gateway sidecar in `kartograph-stage` successfully detects `agents.x-k8s.io/v1beta1` and stops erroring on sandbox list/watch.
- [ ] Confirm Graph Management Assistant "Start session" succeeds end-to-end in stage.

Made with [Cursor](https://cursor.com)